### PR TITLE
Document Hermes streaming requirements

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -176,6 +176,33 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 
 This command sends a test card and updates it once. It redacts App Secret, tenant token, and Authorization headers in output.
 
+## Hermes Streaming And Thinking Configuration
+
+This plugin renders events that Hermes already produces. It does not invent model thinking content. To see streaming thinking and progressive answers in the card, Hermes itself and the current model/provider must emit streaming events.
+
+Check three things:
+
+1. Hermes model calls are running in streaming mode. The exact field depends on the Hermes version, but common forms are `streaming: true` or `stream: true` in the Hermes model/provider config.
+2. The current model/provider supports and exposes reasoning/thinking deltas. If the model only returns a final answer, the card can only show the final answer.
+3. Hermes Gateway forwards thinking, answer, and tool events to the hook. The plugin consumes `thinking.delta`, `answer.delta`, `tool.updated`, and `message.completed`.
+
+Example snippet for orientation only; use the exact schema supported by your Hermes version:
+
+```yaml
+model:
+  streaming: true
+  # Enable reasoning/thinking in Hermes or the provider when that option exists.
+```
+
+How to read symptoms:
+
+- The card is created, stays at “thinking”, then completes: the model or Hermes probably did not emit thinking deltas.
+- Answer text streams, but no thinking appears: streaming works, but the model is not exposing thinking.
+- The card updates only once at the end: check whether Hermes/model streaming is disabled.
+- No Feishu card appears: check Feishu credentials, sidecar status, and Hermes hook installation first.
+
+`setup` and `doctor --hermes-dir` provide conservative Hermes config guidance. If common config files contain `streaming: false` or `stream: false`, they print a warning. If streaming config cannot be detected, they print a note. This does not block installation because Hermes config schemas vary across versions.
+
 ## Architecture
 
 ```text
@@ -232,6 +259,10 @@ Confirm the Hermes version is at least `v2026.4.23` and that the target director
 
 Check `FEISHU_APP_ID` and `FEISHU_APP_SECRET`. Without credentials, advanced sidecar starts use a no-op client that accepts events but does not send real Feishu cards.
 
+### The card has no thinking content or does not stream
+
+Check whether Hermes/model streaming is enabled and whether the current model exposes reasoning/thinking deltas. The plugin config file `~/.hermes_feishu_card/config.yaml` only controls card title, footer, throttling, and rendering options. It does not control whether Hermes calls the model in streaming mode.
+
 ### Duplicate cards appear
 
 Check `feishu_send_successes`, `events_received`, and `events_rejected` in `/health`. V3.1.0 uses a per-message lock and message_id mapping, so one Hermes message should create one Feishu card.
@@ -267,7 +298,7 @@ python3 -m pytest tests/integration/test_feishu_client_http.py -q
 
 Current V3.1.0 acceptance status:
 
-- Full automated test suite: `356 passed`
+- Full automated test suite: `357 passed`
 - GitHub Actions: Python 3.9 / 3.12 matrix passed
 - Installer/restore tests cover backups, manifest, duplicate install, modified-file refusal, uninstall, and restore idempotency
 - Real Hermes Gateway E2E verified card creation, streaming updates, tool counts, completion state, and footer metadata

--- a/README.en.md
+++ b/README.en.md
@@ -176,32 +176,47 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 
 This command sends a test card and updates it once. It redacts App Secret, tenant token, and Authorization headers in output.
 
-## Hermes Streaming And Thinking Configuration
+## Hermes Gateway Streaming And Thinking Configuration
 
-This plugin renders events that Hermes already produces. It does not invent model thinking content. To see streaming thinking and progressive answers in the card, Hermes itself and the current model/provider must emit streaming events.
+This plugin renders events that Hermes already produces. It does not invent model thinking content. To see streaming thinking and progressive answers in the card, Hermes Gateway and the current model/provider must emit streaming events.
 
 Check three things:
 
-1. Hermes model calls are running in streaming mode. The exact field depends on the Hermes version, but common forms are `streaming: true` or `stream: true` in the Hermes model/provider config.
-2. The current model/provider supports and exposes reasoning/thinking deltas. If the model only returns a final answer, the card can only show the final answer.
-3. Hermes Gateway forwards thinking, answer, and tool events to the hook. The plugin consumes `thinking.delta`, `answer.delta`, `tool.updated`, and `message.completed`.
+1. Hermes Gateway platform streaming is enabled: `streaming.enabled: true`, with `streaming.transport: edit`.
+2. Feishu is not disabled by a platform override: avoid `display.platforms.feishu.streaming: false`; set it to `true` when you want to force Feishu streaming on.
+3. The current model/provider supports and exposes reasoning/thinking deltas. If the model only returns a final answer, the card can only show the final answer.
 
-Example snippet for orientation only; use the exact schema supported by your Hermes version:
+In Hermes `config.yaml`, confirm:
 
 ```yaml
-model:
-  streaming: true
-  # Enable reasoning/thinking in Hermes or the provider when that option exists.
+streaming:
+  enabled: true
+  transport: edit
+  edit_interval: 1.0
+  buffer_threshold: 40
+
+display:
+  platforms:
+    feishu:
+      streaming: true
+      show_reasoning: true
+
+agent:
+  # Optional and model/provider-dependent. Supported values depend on the Hermes version.
+  # Common levels include none/minimal/low/medium/high/xhigh.
+  reasoning_effort: medium
 ```
+
+You can also send Hermes' native `/reasoning show` command in Feishu to enable reasoning display for that platform. Use `/reasoning <level> --global` when you want to persist a global reasoning effort level.
 
 How to read symptoms:
 
 - The card is created, stays at “thinking”, then completes: the model or Hermes probably did not emit thinking deltas.
 - Answer text streams, but no thinking appears: streaming works, but the model is not exposing thinking.
-- The card updates only once at the end: check whether Hermes/model streaming is disabled.
+- The card updates only once at the end: check `streaming.enabled`, `streaming.transport`, and `display.platforms.feishu.streaming`.
 - No Feishu card appears: check Feishu credentials, sidecar status, and Hermes hook installation first.
 
-`setup` and `doctor --hermes-dir` provide conservative Hermes config guidance. If common config files contain `streaming: false` or `stream: false`, they print a warning. If streaming config cannot be detected, they print a note. This does not block installation because Hermes config schemas vary across versions.
+`setup` and `doctor --hermes-dir` provide conservative Hermes config guidance. If common config files contain `streaming.enabled: false`, `streaming.transport: off`, or `display.platforms.feishu.streaming: false`, they print a warning. If Gateway streaming config cannot be detected, they print a note. This does not block installation because Hermes config schemas vary across versions.
 
 ## Architecture
 
@@ -261,7 +276,7 @@ Check `FEISHU_APP_ID` and `FEISHU_APP_SECRET`. Without credentials, advanced sid
 
 ### The card has no thinking content or does not stream
 
-Check whether Hermes/model streaming is enabled and whether the current model exposes reasoning/thinking deltas. The plugin config file `~/.hermes_feishu_card/config.yaml` only controls card title, footer, throttling, and rendering options. It does not control whether Hermes calls the model in streaming mode.
+Check Hermes `config.yaml` for `streaming.enabled`, `streaming.transport`, `display.platforms.feishu.streaming`, and `display.platforms.feishu.show_reasoning`, and confirm that the current model/provider exposes reasoning/thinking deltas. The plugin config file `~/.hermes_feishu_card/config.yaml` only controls card title, footer, throttling, and rendering options. It does not control whether Hermes Gateway emits `thinking.delta` or `answer.delta`.
 
 ### Duplicate cards appear
 

--- a/README.md
+++ b/README.md
@@ -180,32 +180,46 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 
 该命令会向指定会话发送一张测试卡片并更新一次。输出会隐藏 App Secret、tenant token 和 Authorization header。
 
-## Hermes streaming 与思考流配置
+## Hermes Gateway streaming 与思考流配置
 
-本插件只负责把 Hermes 已经产生的事件渲染成飞书卡片，不会凭空生成模型思考内容。要看到卡片内的思考过程和渐进式答案，Hermes 本身和当前模型/provider 必须输出流式事件。
+本插件只负责把 Hermes 已经产生的事件渲染成飞书卡片，不会凭空生成模型思考内容。要看到卡片内的思考过程和渐进式答案，Hermes Gateway 和当前模型/provider 必须输出流式事件。
 
 需要确认三件事：
 
-1. Hermes 的模型调用已开启 streaming。不同 Hermes 版本的配置字段可能不同，常见形式是 `streaming: true` 或 `stream: true`，通常位于 Hermes 的模型/provider 配置中。
-2. 当前模型/provider 支持并公开 reasoning/thinking 增量。若模型只返回最终答案，卡片会直接显示最终答案，不会出现 `thinking.delta`。
-3. Hermes Gateway 能把 thinking、answer、tool 事件传给 hook。插件接收的事件名是 `thinking.delta`、`answer.delta`、`tool.updated` 和 `message.completed`。
+1. Hermes Gateway 的平台消息流式开关已开启：`streaming.enabled: true`，并保持 `streaming.transport: edit`。
+2. Feishu 平台没有被单独关闭流式更新：不要设置 `display.platforms.feishu.streaming: false`；如需强制打开，可设置为 `true`。
+3. 当前模型/provider 支持并公开 reasoning/thinking 增量；若模型只返回最终答案，卡片会直接显示最终答案，不会出现 `thinking.delta`。
 
-示例配置片段仅供参考，实际以你的 Hermes 版本为准：
+在 Hermes 自身的 `config.yaml` 中，推荐确认以下配置：
 
 ```yaml
-model:
-  streaming: true
-  # reasoning/thinking 相关开关如有提供，也需要在 Hermes 或 provider 中启用。
+streaming:
+  enabled: true
+  transport: edit
+  edit_interval: 1.0
+  buffer_threshold: 40
+
+display:
+  platforms:
+    feishu:
+      streaming: true
+      show_reasoning: true
+
+agent:
+  # 可选：需要模型/provider 支持。可用值由 Hermes 版本决定，常见为 none/minimal/low/medium/high/xhigh。
+  reasoning_effort: medium
 ```
+
+也可以在飞书会话里使用 Hermes 原生命令 `/reasoning show` 打开当前平台的 reasoning 显示；需要持久化全局推理强度时可用 `/reasoning <level> --global`。
 
 现象判断：
 
 - 卡片能创建，但一直显示“正在思考...”然后直接完成：通常是模型或 Hermes 没有输出 thinking 增量。
 - 卡片内答案能流式更新，但没有思考过程：说明 streaming 已工作，但当前模型没有公开 thinking。
-- 卡片不流式，只在最后更新一次：优先检查 Hermes/model streaming 是否关闭。
+- 卡片不流式，只在最后更新一次：优先检查 `streaming.enabled`、`streaming.transport` 和 `display.platforms.feishu.streaming`。
 - 飞书没有卡片：优先检查飞书凭据、sidecar 状态和 Hermes hook 是否安装成功。
 
-`setup` 和 `doctor --hermes-dir` 会做保守的 Hermes 配置提示：如果在常见配置文件中发现 `streaming: false` 或 `stream: false`，会输出 warning；如果没有检测到 streaming 配置，会输出 note。该提示不阻止安装，因为不同 Hermes 版本的配置结构可能不同。
+`setup` 和 `doctor --hermes-dir` 会做保守的 Hermes 配置提示：如果在常见配置文件中发现 `streaming.enabled: false`、`streaming.transport: off` 或 `display.platforms.feishu.streaming: false`，会输出 warning；如果没有检测到 Gateway streaming 配置，会输出 note。该提示不阻止安装，因为不同 Hermes 版本的配置结构可能不同。
 
 ## 技术架构
 
@@ -265,7 +279,7 @@ sidecar 持有完整会话状态，负责飞书 CardKit 边界。这样可以把
 
 ### 卡片没有思考内容或不流式更新
 
-先检查 Hermes/model streaming 是否开启，以及当前模型是否公开 reasoning/thinking 增量。插件配置文件 `~/.hermes_feishu_card/config.yaml` 只控制飞书卡片的标题、footer、节流和渲染参数，不控制 Hermes 是否以 streaming 模式调用模型。
+先检查 Hermes `config.yaml` 中的 `streaming.enabled`、`streaming.transport`、`display.platforms.feishu.streaming` 和 `display.platforms.feishu.show_reasoning`，并确认当前模型/provider 公开 reasoning/thinking 增量。插件配置文件 `~/.hermes_feishu_card/config.yaml` 只控制飞书卡片的标题、footer、节流和渲染参数，不控制 Hermes Gateway 是否发出 `thinking.delta` 或 `answer.delta`。
 
 ### 出现重复卡片
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,33 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 
 该命令会向指定会话发送一张测试卡片并更新一次。输出会隐藏 App Secret、tenant token 和 Authorization header。
 
+## Hermes streaming 与思考流配置
+
+本插件只负责把 Hermes 已经产生的事件渲染成飞书卡片，不会凭空生成模型思考内容。要看到卡片内的思考过程和渐进式答案，Hermes 本身和当前模型/provider 必须输出流式事件。
+
+需要确认三件事：
+
+1. Hermes 的模型调用已开启 streaming。不同 Hermes 版本的配置字段可能不同，常见形式是 `streaming: true` 或 `stream: true`，通常位于 Hermes 的模型/provider 配置中。
+2. 当前模型/provider 支持并公开 reasoning/thinking 增量。若模型只返回最终答案，卡片会直接显示最终答案，不会出现 `thinking.delta`。
+3. Hermes Gateway 能把 thinking、answer、tool 事件传给 hook。插件接收的事件名是 `thinking.delta`、`answer.delta`、`tool.updated` 和 `message.completed`。
+
+示例配置片段仅供参考，实际以你的 Hermes 版本为准：
+
+```yaml
+model:
+  streaming: true
+  # reasoning/thinking 相关开关如有提供，也需要在 Hermes 或 provider 中启用。
+```
+
+现象判断：
+
+- 卡片能创建，但一直显示“正在思考...”然后直接完成：通常是模型或 Hermes 没有输出 thinking 增量。
+- 卡片内答案能流式更新，但没有思考过程：说明 streaming 已工作，但当前模型没有公开 thinking。
+- 卡片不流式，只在最后更新一次：优先检查 Hermes/model streaming 是否关闭。
+- 飞书没有卡片：优先检查飞书凭据、sidecar 状态和 Hermes hook 是否安装成功。
+
+`setup` 和 `doctor --hermes-dir` 会做保守的 Hermes 配置提示：如果在常见配置文件中发现 `streaming: false` 或 `stream: false`，会输出 warning；如果没有检测到 streaming 配置，会输出 note。该提示不阻止安装，因为不同 Hermes 版本的配置结构可能不同。
+
 ## 技术架构
 
 ```text
@@ -236,6 +263,10 @@ sidecar 持有完整会话状态，负责飞书 CardKit 边界。这样可以把
 
 检查 `FEISHU_APP_ID` 和 `FEISHU_APP_SECRET` 是否存在。未配置凭据时，runner 会使用 no-op client 接收事件，不会发送真实飞书卡片。
 
+### 卡片没有思考内容或不流式更新
+
+先检查 Hermes/model streaming 是否开启，以及当前模型是否公开 reasoning/thinking 增量。插件配置文件 `~/.hermes_feishu_card/config.yaml` 只控制飞书卡片的标题、footer、节流和渲染参数，不控制 Hermes 是否以 streaming 模式调用模型。
+
 ### 出现重复卡片
 
 检查 `/health` 中的 `feishu_send_successes`、`events_received` 和 `events_rejected`。V3.1.0 对同一个 Hermes message 使用 per-message lock 和 message_id 映射，正常情况下同一轮对话只创建一张卡片。
@@ -271,7 +302,7 @@ python3 -m pytest tests/integration/test_feishu_client_http.py -q
 
 当前 V3.1.0 验收状态：
 
-- 自动化全量测试：`356 passed`
+- 自动化全量测试：`357 passed`
 - GitHub Actions：Python 3.9 / 3.12 测试矩阵通过
 - 安装/恢复专项测试：覆盖备份、manifest、重复安装、用户改动拒绝恢复、卸载和恢复幂等
 - 真实 Hermes Gateway E2E：已验证新卡片创建、流式更新、工具调用计数、完成状态和 footer 元数据

--- a/docs/e2e-verification.en.md
+++ b/docs/e2e-verification.en.md
@@ -47,4 +47,4 @@ The current mainline has completed these checks with a real Hermes Gateway and r
 - A real long-card stress test updated one Feishu card to 16k Chinese characters.
 - Installer validation completed a `restore -> install` loop against a real Hermes `v2026.4.23` directory and left it installed.
 
-Latest full automated regression: `356 passed`.
+Latest full automated regression: `357 passed`.

--- a/docs/e2e-verification.md
+++ b/docs/e2e-verification.md
@@ -47,4 +47,4 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 - 真实长卡压力测试中，同一张飞书卡片更新到 16k 中文字符成功。
 - 安装器在真实 Hermes `v2026.4.23` 目录完成 `restore -> install` 循环验证，最终保持已安装状态。
 
-最近一次全量自动化回归：`356 passed`。
+最近一次全量自动化回归：`357 passed`。

--- a/docs/testing.en.md
+++ b/docs/testing.en.md
@@ -113,4 +113,4 @@ Latest full automated regression:
 python3 -m pytest -q -p no:cacheprovider
 ```
 
-Result: `356 passed`.
+Result: `357 passed`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -113,4 +113,4 @@ python3 -m hermes_feishu_card.cli doctor --config config.yaml.example --hermes-d
 python3 -m pytest -q -p no:cacheprovider
 ```
 
-结果：`356 passed`。
+结果：`357 passed`。

--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -9,6 +9,8 @@ import time
 from uuid import uuid4
 from pathlib import Path
 
+import yaml
+
 from hermes_feishu_card.config import load_config
 from hermes_feishu_card.events import SidecarEvent
 from hermes_feishu_card.feishu_client import FeishuAPIError, FeishuClient, FeishuClientConfig
@@ -250,41 +252,81 @@ def _format_hermes_detection(detection: HermesDetection) -> str:
 
 
 def _print_hermes_streaming_guidance(hermes_root: Path) -> None:
-    status = _detect_hermes_streaming_status(hermes_root)
+    config = _load_hermes_user_config(hermes_root)
+    status = _detect_hermes_streaming_status(config)
     if status == "disabled":
         print(
             (
-                "warning: Hermes streaming appears disabled. Streaming cards "
-                "need Hermes/model streaming output for thinking.delta and "
-                "answer.delta updates."
+                "warning: Hermes Gateway streaming appears disabled for Feishu. "
+                "Set streaming.enabled: true with streaming.transport: edit, "
+                "or set display.platforms.feishu.streaming: true, so "
+                "thinking.delta and answer.delta updates can reach the card."
             )
         )
-        return
-    if status == "not_detected":
+    elif status == "not_detected":
         print(
             (
-                "note: Hermes streaming config was not detected. If cards do "
-                "not show thinking.delta or answer.delta updates, enable "
-                "streaming/reasoning in the Hermes model/provider config."
+                "note: Hermes Gateway streaming config was not detected. If "
+                "cards do not show answer.delta updates, set "
+                "streaming.enabled: true and streaming.transport: edit in the "
+                "Hermes config.yaml."
+            )
+        )
+
+    reasoning_status = _detect_hermes_reasoning_display_status(config)
+    if reasoning_status == "disabled":
+        print(
+            (
+                "note: Hermes reasoning display appears disabled for Feishu. "
+                "If the model supports reasoning and you want thinking content "
+                "in cards, set display.platforms.feishu.show_reasoning: true "
+                "or use /reasoning show in Feishu."
             )
         )
 
 
-def _detect_hermes_streaming_status(hermes_root: Path) -> str:
-    found_enabled = False
+def _load_hermes_user_config(hermes_root: Path) -> dict[str, object]:
     for config_path in _candidate_hermes_config_paths(hermes_root):
         if not config_path.exists() or not config_path.is_file():
             continue
         try:
-            contents = config_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeError):
+            with config_path.open("r", encoding="utf-8") as file:
+                loaded = yaml.safe_load(file) or {}
+        except (OSError, UnicodeError, yaml.YAMLError):
             continue
-        text = _strip_yaml_comments(contents).lower()
-        if re.search(r"(?m)^\s*(streaming|stream)\s*:\s*false\s*$", text):
-            return "disabled"
-        if re.search(r"(?m)^\s*(streaming|stream)\s*:\s*true\s*$", text):
-            found_enabled = True
-    return "enabled" if found_enabled else "not_detected"
+        if isinstance(loaded, dict):
+            return loaded
+    return {}
+
+
+def _detect_hermes_streaming_status(config: dict[str, object]) -> str:
+    feishu_streaming = _nested_get(
+        config, ("display", "platforms", "feishu", "streaming")
+    )
+    if feishu_streaming is not None:
+        return "enabled" if _truthy(feishu_streaming) else "disabled"
+
+    streaming = config.get("streaming")
+    if not isinstance(streaming, dict):
+        return "not_detected"
+    if _truthy(streaming.get("enabled")) and str(
+        streaming.get("transport", "edit")
+    ).strip().lower() != "off":
+        return "enabled"
+    return "disabled"
+
+
+def _detect_hermes_reasoning_display_status(config: dict[str, object]) -> str:
+    feishu_show_reasoning = _nested_get(
+        config, ("display", "platforms", "feishu", "show_reasoning")
+    )
+    if feishu_show_reasoning is not None:
+        return "enabled" if _truthy(feishu_show_reasoning) else "disabled"
+
+    global_show_reasoning = _nested_get(config, ("display", "show_reasoning"))
+    if global_show_reasoning is None:
+        return "disabled"
+    return "enabled" if _truthy(global_show_reasoning) else "disabled"
 
 
 def _candidate_hermes_config_paths(hermes_root: Path) -> tuple[Path, ...]:
@@ -296,12 +338,19 @@ def _candidate_hermes_config_paths(hermes_root: Path) -> tuple[Path, ...]:
     )
 
 
-def _strip_yaml_comments(contents: str) -> str:
-    lines = []
-    for line in contents.splitlines():
-        head = line.split("#", 1)[0]
-        lines.append(head.rstrip())
-    return "\n".join(lines)
+def _nested_get(config: dict[str, object], path: tuple[str, ...]) -> object:
+    current: object = config
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _truthy(value: object) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def _run_start(args: argparse.Namespace) -> int:

--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -130,6 +130,7 @@ def _run_setup(args: argparse.Namespace) -> int:
         return 1
     print("doctor: ok")
     print(_format_hermes_detection(detection))
+    _print_hermes_streaming_guidance(Path(args.hermes_dir))
 
     install_code = _run_install(
         argparse.Namespace(hermes_dir=args.hermes_dir, yes=True)
@@ -224,6 +225,8 @@ def _run_doctor(args: argparse.Namespace) -> int:
     if args.hermes_dir:
         detection = detect_hermes(args.hermes_dir)
         print(_format_hermes_detection(detection))
+        if detection.supported:
+            _print_hermes_streaming_guidance(Path(args.hermes_dir))
         return 0 if detection.supported else 1
     print("hermes: not checked")
     return 0
@@ -244,6 +247,61 @@ def _format_hermes_detection(detection: HermesDetection) -> str:
             f"reason: {detection.reason}",
         ]
     )
+
+
+def _print_hermes_streaming_guidance(hermes_root: Path) -> None:
+    status = _detect_hermes_streaming_status(hermes_root)
+    if status == "disabled":
+        print(
+            (
+                "warning: Hermes streaming appears disabled. Streaming cards "
+                "need Hermes/model streaming output for thinking.delta and "
+                "answer.delta updates."
+            )
+        )
+        return
+    if status == "not_detected":
+        print(
+            (
+                "note: Hermes streaming config was not detected. If cards do "
+                "not show thinking.delta or answer.delta updates, enable "
+                "streaming/reasoning in the Hermes model/provider config."
+            )
+        )
+
+
+def _detect_hermes_streaming_status(hermes_root: Path) -> str:
+    found_enabled = False
+    for config_path in _candidate_hermes_config_paths(hermes_root):
+        if not config_path.exists() or not config_path.is_file():
+            continue
+        try:
+            contents = config_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        text = _strip_yaml_comments(contents).lower()
+        if re.search(r"(?m)^\s*(streaming|stream)\s*:\s*false\s*$", text):
+            return "disabled"
+        if re.search(r"(?m)^\s*(streaming|stream)\s*:\s*true\s*$", text):
+            found_enabled = True
+    return "enabled" if found_enabled else "not_detected"
+
+
+def _candidate_hermes_config_paths(hermes_root: Path) -> tuple[Path, ...]:
+    return (
+        hermes_root / "config.yaml",
+        hermes_root / "config.yml",
+        hermes_root / "configs" / "config.yaml",
+        hermes_root / "configs" / "config.yml",
+    )
+
+
+def _strip_yaml_comments(contents: str) -> str:
+    lines = []
+    for line in contents.splitlines():
+        head = line.split("#", 1)[0]
+        lines.append(head.rstrip())
+    return "\n".join(lines)
 
 
 def _run_start(args: argparse.Namespace) -> int:

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -146,7 +146,7 @@ def test_setup_warns_when_hermes_streaming_appears_disabled(
 ):
     hermes_dir = copy_hermes(tmp_path)
     (hermes_dir / "config.yaml").write_text(
-        "model:\n  streaming: false\n", encoding="utf-8"
+        "streaming:\n  enabled: false\n  transport: edit\n", encoding="utf-8"
     )
     config_path = tmp_path / "generated" / "feishu-card.yaml"
     monkeypatch.setenv("FEISHU_APP_ID", "cli_setup_test")
@@ -176,10 +176,101 @@ def test_setup_warns_when_hermes_streaming_appears_disabled(
 
     captured = capsys.readouterr()
     assert exit_code == 0, captured.err
-    assert "warning: Hermes streaming appears disabled" in captured.out
+    assert "warning: Hermes Gateway streaming appears disabled for Feishu" in captured.out
+    assert "streaming.enabled: true" in captured.out
+    assert "streaming.transport: edit" in captured.out
     assert "thinking.delta" in captured.out
     assert "answer.delta" in captured.out
     assert "setup ok" in captured.out
+
+
+def test_setup_warns_when_feishu_streaming_override_is_disabled(
+    tmp_path, monkeypatch, capsys
+):
+    hermes_dir = copy_hermes(tmp_path)
+    (hermes_dir / "config.yaml").write_text(
+        (
+            "streaming:\n"
+            "  enabled: true\n"
+            "  transport: edit\n"
+            "display:\n"
+            "  platforms:\n"
+            "    feishu:\n"
+            "      streaming: false\n"
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "generated" / "feishu-card.yaml"
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_setup_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "setup-secret")
+    monkeypatch.setattr(cli, "start_sidecar", lambda *_args: "started")
+    monkeypatch.setattr(
+        cli,
+        "status_sidecar",
+        lambda _config: {
+            "running": True,
+            "pid": 12345,
+            "health": {"active_sessions": 0, "metrics": {}},
+            "pid_running": True,
+        },
+    )
+
+    exit_code = cli.main(
+        [
+            "setup",
+            "--hermes-dir",
+            str(hermes_dir),
+            "--config",
+            str(config_path),
+            "--yes",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert "display.platforms.feishu.streaming: true" in captured.out
+    assert "setup ok" in captured.out
+
+
+def test_setup_notes_when_reasoning_display_is_disabled(
+    tmp_path, monkeypatch, capsys
+):
+    hermes_dir = copy_hermes(tmp_path)
+    (hermes_dir / "config.yaml").write_text(
+        "streaming:\n  enabled: true\n  transport: edit\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "generated" / "feishu-card.yaml"
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_setup_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "setup-secret")
+    monkeypatch.setattr(cli, "start_sidecar", lambda *_args: "started")
+    monkeypatch.setattr(
+        cli,
+        "status_sidecar",
+        lambda _config: {
+            "running": True,
+            "pid": 12345,
+            "health": {"active_sessions": 0, "metrics": {}},
+            "pid_running": True,
+        },
+    )
+
+    exit_code = cli.main(
+        [
+            "setup",
+            "--hermes-dir",
+            str(hermes_dir),
+            "--config",
+            str(config_path),
+            "--yes",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert "Hermes reasoning display appears disabled for Feishu" in captured.out
+    assert "display.platforms.feishu.show_reasoning: true" in captured.out
+    assert "/reasoning show" in captured.out
 
 
 def test_setup_requires_feishu_credentials_before_installing_hook(

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -141,6 +141,47 @@ def test_setup_creates_config_installs_hook_and_starts_sidecar(tmp_path, monkeyp
     )
 
 
+def test_setup_warns_when_hermes_streaming_appears_disabled(
+    tmp_path, monkeypatch, capsys
+):
+    hermes_dir = copy_hermes(tmp_path)
+    (hermes_dir / "config.yaml").write_text(
+        "model:\n  streaming: false\n", encoding="utf-8"
+    )
+    config_path = tmp_path / "generated" / "feishu-card.yaml"
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_setup_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "setup-secret")
+    monkeypatch.setattr(cli, "start_sidecar", lambda *_args: "started")
+    monkeypatch.setattr(
+        cli,
+        "status_sidecar",
+        lambda _config: {
+            "running": True,
+            "pid": 12345,
+            "health": {"active_sessions": 0, "metrics": {}},
+            "pid_running": True,
+        },
+    )
+
+    exit_code = cli.main(
+        [
+            "setup",
+            "--hermes-dir",
+            str(hermes_dir),
+            "--config",
+            str(config_path),
+            "--yes",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert "warning: Hermes streaming appears disabled" in captured.out
+    assert "thinking.delta" in captured.out
+    assert "answer.delta" in captured.out
+    assert "setup ok" in captured.out
+
+
 def test_setup_requires_feishu_credentials_before_installing_hook(
     tmp_path, monkeypatch, capsys
 ):

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -17,7 +17,9 @@ def test_readme_documents_sidecar_only_and_supported_hermes_version():
     assert "sidecar-only" in readme.lower()
     assert "setup --hermes-dir" in readme
     assert "整合安装器" in readme
-    assert "Hermes streaming" in readme
+    assert "streaming.enabled" in readme
+    assert "display.platforms.feishu.streaming" in readme
+    assert "display.platforms.feishu.show_reasoning" in readme
     assert "thinking.delta" in readme
     assert "v2026.4.23" in readme
     assert "Git tag `v2026.4.23+`" in readme
@@ -43,7 +45,10 @@ def test_english_readme_and_docs_are_linked():
     assert "Hermes Feishu Streaming Card Plugin V3.1.0" in english_readme
     assert "docs/assets/readme-cover.png" in english_readme
     assert "setup --hermes-dir" in english_readme
-    assert "Hermes Streaming And Thinking" in english_readme
+    assert "Hermes Gateway Streaming And Thinking" in english_readme
+    assert "streaming.enabled" in english_readme
+    assert "display.platforms.feishu.streaming" in english_readme
+    assert "display.platforms.feishu.show_reasoning" in english_readme
     assert "thinking.delta" in english_readme
     assert "357 passed" in english_readme
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -17,6 +17,8 @@ def test_readme_documents_sidecar_only_and_supported_hermes_version():
     assert "sidecar-only" in readme.lower()
     assert "setup --hermes-dir" in readme
     assert "整合安装器" in readme
+    assert "Hermes streaming" in readme
+    assert "thinking.delta" in readme
     assert "v2026.4.23" in readme
     assert "Git tag `v2026.4.23+`" in readme
     assert "docs/assets/feishu-weather-card.png" in readme
@@ -41,7 +43,9 @@ def test_english_readme_and_docs_are_linked():
     assert "Hermes Feishu Streaming Card Plugin V3.1.0" in english_readme
     assert "docs/assets/readme-cover.png" in english_readme
     assert "setup --hermes-dir" in english_readme
-    assert "356 passed" in english_readme
+    assert "Hermes Streaming And Thinking" in english_readme
+    assert "thinking.delta" in english_readme
+    assert "357 passed" in english_readme
 
     for name in expected_docs:
         zh_path = f"docs/{name}.md"


### PR DESCRIPTION
## Summary
- Explain that the plugin renders Hermes events and requires Hermes/model streaming output for `thinking.delta` and `answer.delta`.
- Add README/English README troubleshooting for missing thinking content or non-streaming cards.
- Add non-blocking `setup`/`doctor --hermes-dir` guidance when common Hermes config files show `streaming: false` / `stream: false`, or when streaming config cannot be detected.

## Test Plan
- [x] `python3 -m pytest tests/integration/test_cli_install.py::test_setup_warns_when_hermes_streaming_appears_disabled tests/unit/test_docs.py::test_readme_documents_sidecar_only_and_supported_hermes_version tests/unit/test_docs.py::test_english_readme_and_docs_are_linked -q -p no:cacheprovider`
- [x] `python3 -m pytest tests/unit/test_docs.py tests/integration/test_cli_install.py -q -p no:cacheprovider`
- [x] `python3 -m pytest -q -p no:cacheprovider`
- [x] `git diff --check`
