### PR TITLE
Clarify Hermes streaming config requirements

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -186,28 +186,31 @@ Check three things:
 2. Feishu is not disabled by a platform override: avoid `display.platforms.feishu.streaming: false`; set it to `true` when you want to force Feishu streaming on.
 3. The current model/provider supports and exposes reasoning/thinking deltas. If the model only returns a final answer, the card can only show the final answer.
 
-In Hermes `config.yaml`, confirm:
+In Hermes `config.yaml`, confirm the following. The common path is `~/.hermes/config.yaml`; if your config lives inside the Hermes installation directory, the installer also checks `<hermes-dir>/config.yaml`, `<hermes-dir>/config.yml`, `<hermes-dir>/configs/config.yaml`, and `<hermes-dir>/configs/config.yml`.
 
 ```yaml
 streaming:
   enabled: true
   transport: edit
-  edit_interval: 1.0
-  buffer_threshold: 40
+  # Optional. Hermes defaults are fine; these are the values used by the
+  # locally verified real acceptance instance.
+  edit_interval: 0.8
+  buffer_threshold: 20
+  cursor: ""
+```
 
+If your Hermes config previously disabled Feishu streaming with a platform override, explicitly enable it:
+
+```yaml
 display:
   platforms:
     feishu:
       streaming: true
-      show_reasoning: true
-
-agent:
-  # Optional and model/provider-dependent. Supported values depend on the Hermes version.
-  # Common levels include none/minimal/low/medium/high/xhigh.
-  reasoning_effort: medium
 ```
 
-You can also send Hermes' native `/reasoning show` command in Feishu to enable reasoning display for that platform. Use `/reasoning <level> --global` when you want to persist a global reasoning effort level.
+Do not treat `display.show_reasoning` or `display.platforms.feishu.show_reasoning` as required for this plugin. In current Hermes source, those settings control Hermes' native final reasoning display and may prepend a `💭 Reasoning` code block to the final text, which can interfere with the card-only streaming experience. Enable them only when you intentionally want Hermes' native reasoning block in the final response.
+
+`agent.reasoning_effort` is also optional and model/provider-dependent. It can affect whether some models produce reasoning, but it is not the Gateway card streaming switch.
 
 How to read symptoms:
 
@@ -276,7 +279,7 @@ Check `FEISHU_APP_ID` and `FEISHU_APP_SECRET`. Without credentials, advanced sid
 
 ### The card has no thinking content or does not stream
 
-Check Hermes `config.yaml` for `streaming.enabled`, `streaming.transport`, `display.platforms.feishu.streaming`, and `display.platforms.feishu.show_reasoning`, and confirm that the current model/provider exposes reasoning/thinking deltas. The plugin config file `~/.hermes_feishu_card/config.yaml` only controls card title, footer, throttling, and rendering options. It does not control whether Hermes Gateway emits `thinking.delta` or `answer.delta`.
+Check Hermes `config.yaml` for `streaming.enabled: true` and `streaming.transport: edit`. If `display.platforms.feishu.streaming: false` is present, remove that override or set it to `true`. Then confirm that the current model/provider actually exposes reasoning/thinking deltas. Do not blindly enable `show_reasoning` for card thinking; it may only append a final reasoning code block to Hermes' native response. The plugin config file `~/.hermes_feishu_card/config.yaml` only controls card title, footer, throttling, and rendering options. It does not control whether Hermes Gateway emits `thinking.delta` or `answer.delta`.
 
 ### Duplicate cards appear
 
@@ -313,7 +316,7 @@ python3 -m pytest tests/integration/test_feishu_client_http.py -q
 
 Current V3.1.0 acceptance status:
 
-- Full automated test suite: `357 passed`
+- Full automated test suite: `360 passed`
 - GitHub Actions: Python 3.9 / 3.12 matrix passed
 - Installer/restore tests cover backups, manifest, duplicate install, modified-file refusal, uninstall, and restore idempotency
 - Real Hermes Gateway E2E verified card creation, streaming updates, tool counts, completion state, and footer metadata

--- a/README.md
+++ b/README.md
@@ -190,27 +190,30 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 2. Feishu 平台没有被单独关闭流式更新：不要设置 `display.platforms.feishu.streaming: false`；如需强制打开，可设置为 `true`。
 3. 当前模型/provider 支持并公开 reasoning/thinking 增量；若模型只返回最终答案，卡片会直接显示最终答案，不会出现 `thinking.delta`。
 
-在 Hermes 自身的 `config.yaml` 中，推荐确认以下配置：
+在 Hermes 自身的 `config.yaml` 中，推荐确认以下配置。常见路径是 `~/.hermes/config.yaml`；如果你把配置放在 Hermes 安装目录内，安装器也会尝试读取 `<hermes-dir>/config.yaml`、`<hermes-dir>/config.yml`、`<hermes-dir>/configs/config.yaml` 和 `<hermes-dir>/configs/config.yml`。
 
 ```yaml
 streaming:
   enabled: true
   transport: edit
-  edit_interval: 1.0
-  buffer_threshold: 40
+  # 可选：沿用 Hermes 默认值即可；下面是本机真实验收实例使用的配置。
+  edit_interval: 0.8
+  buffer_threshold: 20
+  cursor: ""
+```
 
+如果你的 Hermes 配置里曾经单独关闭过 Feishu 平台流式更新，可以显式覆盖：
+
+```yaml
 display:
   platforms:
     feishu:
       streaming: true
-      show_reasoning: true
-
-agent:
-  # 可选：需要模型/provider 支持。可用值由 Hermes 版本决定，常见为 none/minimal/low/medium/high/xhigh。
-  reasoning_effort: medium
 ```
 
-也可以在飞书会话里使用 Hermes 原生命令 `/reasoning show` 打开当前平台的 reasoning 显示；需要持久化全局推理强度时可用 `/reasoning <level> --global`。
+不要把 `display.show_reasoning` 或 `display.platforms.feishu.show_reasoning` 当成本插件的必需开关。基于当前 Hermes 源码，这两个配置用于 Hermes 原生最终回复里的 reasoning 展示，可能把思考内容作为 `💭 Reasoning` 代码块附加到最终文本中，反而干扰卡片内的流式体验。只有当你明确想保留 Hermes 原生 reasoning 文本块时才打开它。
+
+`agent.reasoning_effort` 也是可选项，并且依赖模型/provider 支持。它可以影响某些模型是否产生推理内容，但不是 Gateway 卡片流式传输的开关。
 
 现象判断：
 
@@ -279,7 +282,7 @@ sidecar 持有完整会话状态，负责飞书 CardKit 边界。这样可以把
 
 ### 卡片没有思考内容或不流式更新
 
-先检查 Hermes `config.yaml` 中的 `streaming.enabled`、`streaming.transport`、`display.platforms.feishu.streaming` 和 `display.platforms.feishu.show_reasoning`，并确认当前模型/provider 公开 reasoning/thinking 增量。插件配置文件 `~/.hermes_feishu_card/config.yaml` 只控制飞书卡片的标题、footer、节流和渲染参数，不控制 Hermes Gateway 是否发出 `thinking.delta` 或 `answer.delta`。
+先检查 Hermes `config.yaml` 中的 `streaming.enabled: true` 和 `streaming.transport: edit`；如果配置过 `display.platforms.feishu.streaming: false`，改为删除该覆盖或设为 `true`。再确认当前模型/provider 是否真的公开 reasoning/thinking 增量。不要为了卡片思考流盲目打开 `show_reasoning`，它可能只是在最终普通回复里追加 reasoning 代码块。插件配置文件 `~/.hermes_feishu_card/config.yaml` 只控制飞书卡片的标题、footer、节流和渲染参数，不控制 Hermes Gateway 是否发出 `thinking.delta` 或 `answer.delta`。
 
 ### 出现重复卡片
 
@@ -316,7 +319,7 @@ python3 -m pytest tests/integration/test_feishu_client_http.py -q
 
 当前 V3.1.0 验收状态：
 
-- 自动化全量测试：`357 passed`
+- 自动化全量测试：`360 passed`
 - GitHub Actions：Python 3.9 / 3.12 测试矩阵通过
 - 安装/恢复专项测试：覆盖备份、manifest、重复安装、用户改动拒绝恢复、卸载和恢复幂等
 - 真实 Hermes Gateway E2E：已验证新卡片创建、流式更新、工具调用计数、完成状态和 footer 元数据

--- a/docs/e2e-verification.en.md
+++ b/docs/e2e-verification.en.md
@@ -47,4 +47,4 @@ The current mainline has completed these checks with a real Hermes Gateway and r
 - A real long-card stress test updated one Feishu card to 16k Chinese characters.
 - Installer validation completed a `restore -> install` loop against a real Hermes `v2026.4.23` directory and left it installed.
 
-Latest full automated regression: `357 passed`.
+Latest full automated regression: `360 passed`.

--- a/docs/e2e-verification.md
+++ b/docs/e2e-verification.md
@@ -47,4 +47,4 @@ python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example
 - 真实长卡压力测试中，同一张飞书卡片更新到 16k 中文字符成功。
 - 安装器在真实 Hermes `v2026.4.23` 目录完成 `restore -> install` 循环验证，最终保持已安装状态。
 
-最近一次全量自动化回归：`357 passed`。
+最近一次全量自动化回归：`360 passed`。

--- a/docs/testing.en.md
+++ b/docs/testing.en.md
@@ -113,4 +113,4 @@ Latest full automated regression:
 python3 -m pytest -q -p no:cacheprovider
 ```
 
-Result: `357 passed`.
+Result: `360 passed`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -113,4 +113,4 @@ python3 -m hermes_feishu_card.cli doctor --config config.yaml.example --hermes-d
 python3 -m pytest -q -p no:cacheprovider
 ```
 
-结果：`357 passed`。
+结果：`360 passed`。

--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -273,17 +273,6 @@ def _print_hermes_streaming_guidance(hermes_root: Path) -> None:
             )
         )
 
-    reasoning_status = _detect_hermes_reasoning_display_status(config)
-    if reasoning_status == "disabled":
-        print(
-            (
-                "note: Hermes reasoning display appears disabled for Feishu. "
-                "If the model supports reasoning and you want thinking content "
-                "in cards, set display.platforms.feishu.show_reasoning: true "
-                "or use /reasoning show in Feishu."
-            )
-        )
-
 
 def _load_hermes_user_config(hermes_root: Path) -> dict[str, object]:
     for config_path in _candidate_hermes_config_paths(hermes_root):
@@ -316,25 +305,14 @@ def _detect_hermes_streaming_status(config: dict[str, object]) -> str:
     return "disabled"
 
 
-def _detect_hermes_reasoning_display_status(config: dict[str, object]) -> str:
-    feishu_show_reasoning = _nested_get(
-        config, ("display", "platforms", "feishu", "show_reasoning")
-    )
-    if feishu_show_reasoning is not None:
-        return "enabled" if _truthy(feishu_show_reasoning) else "disabled"
-
-    global_show_reasoning = _nested_get(config, ("display", "show_reasoning"))
-    if global_show_reasoning is None:
-        return "disabled"
-    return "enabled" if _truthy(global_show_reasoning) else "disabled"
-
-
 def _candidate_hermes_config_paths(hermes_root: Path) -> tuple[Path, ...]:
     return (
         hermes_root / "config.yaml",
         hermes_root / "config.yml",
         hermes_root / "configs" / "config.yaml",
         hermes_root / "configs" / "config.yml",
+        Path.home() / ".hermes" / "config.yaml",
+        Path.home() / ".hermes" / "config.yml",
     )
 
 

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -232,7 +232,7 @@ def test_setup_warns_when_feishu_streaming_override_is_disabled(
     assert "setup ok" in captured.out
 
 
-def test_setup_notes_when_reasoning_display_is_disabled(
+def test_setup_accepts_minimal_streaming_config_without_reasoning_display_warning(
     tmp_path, monkeypatch, capsys
 ):
     hermes_dir = copy_hermes(tmp_path)
@@ -268,9 +268,35 @@ def test_setup_notes_when_reasoning_display_is_disabled(
 
     captured = capsys.readouterr()
     assert exit_code == 0, captured.err
-    assert "Hermes reasoning display appears disabled for Feishu" in captured.out
-    assert "display.platforms.feishu.show_reasoning: true" in captured.out
-    assert "/reasoning show" in captured.out
+    assert "Hermes Gateway streaming appears disabled for Feishu" not in captured.out
+    assert "Hermes reasoning display appears disabled for Feishu" not in captured.out
+    assert "show_reasoning" not in captured.out
+
+
+def test_doctor_reads_user_level_hermes_config(tmp_path, monkeypatch, capsys):
+    hermes_dir = copy_hermes(tmp_path)
+    home = tmp_path / "home"
+    (home / ".hermes").mkdir(parents=True)
+    (home / ".hermes" / "config.yaml").write_text(
+        "streaming:\n  enabled: true\n  transport: edit\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HOME", str(home))
+
+    exit_code = cli.main(
+        [
+            "doctor",
+            "--config",
+            "config.yaml.example",
+            "--hermes-dir",
+            str(hermes_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert "hermes: supported" in captured.out
+    assert "Hermes Gateway streaming config was not detected" not in captured.out
+    assert "show_reasoning" not in captured.out
 
 
 def test_setup_requires_feishu_credentials_before_installing_hook(

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -19,7 +19,7 @@ def test_readme_documents_sidecar_only_and_supported_hermes_version():
     assert "整合安装器" in readme
     assert "streaming.enabled" in readme
     assert "display.platforms.feishu.streaming" in readme
-    assert "display.platforms.feishu.show_reasoning" in readme
+    assert "不要把 `display.show_reasoning`" in readme
     assert "thinking.delta" in readme
     assert "v2026.4.23" in readme
     assert "Git tag `v2026.4.23+`" in readme
@@ -48,9 +48,9 @@ def test_english_readme_and_docs_are_linked():
     assert "Hermes Gateway Streaming And Thinking" in english_readme
     assert "streaming.enabled" in english_readme
     assert "display.platforms.feishu.streaming" in english_readme
-    assert "display.platforms.feishu.show_reasoning" in english_readme
+    assert "Do not treat `display.show_reasoning`" in english_readme
     assert "thinking.delta" in english_readme
-    assert "357 passed" in english_readme
+    assert "360 passed" in english_readme
 
     for name in expected_docs:
         zh_path = f"docs/{name}.md"


### PR DESCRIPTION
## Summary
- document that Feishu streaming cards require Hermes Gateway streaming enabled with transport edit
- stop treating show_reasoning as a required setup flag because it may add a native final reasoning block instead of card streaming
- teach doctor/setup to also read the common user config at ~/.hermes/config.yaml

## Verification
- python3 -m pytest tests/integration/test_cli_install.py::test_doctor_reads_user_level_hermes_config tests/integration/test_cli_install.py::test_setup_accepts_minimal_streaming_config_without_reasoning_display_warning tests/unit/test_docs.py -q
- python3 -m pytest -q -p no:cacheprovider
- git diff --check
- python3 -m hermes_feishu_card.cli doctor --config config.yaml.example --hermes-dir /Users/huangyemin/Documents/Codex/2026-04-24/superpower-hermes-users-bailey-github-hermes/hermes-upstream-v2026.4.23