### PR TITLE
fix: add Accept-Encoding header to avoid brotli decoding error

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -116,6 +116,30 @@ card:
 
 > **Note**: `feishu.app_id` / `feishu.app_secret` are only used for the fallback bot or single-bot setups. For multi-bot, provide per-bot credentials to avoid cross-bot permission issues.
 
+### How to Get chat_id
+
+**Important**: `bindings.chats` defaults to empty `{}`. All unbound messages will route to `fallback_bot`. When using multiple bots, you must configure chat_id bindings.
+
+Methods to obtain chat_id:
+
+1. **Extract from Gateway logs** (recommended):
+   ```bash
+   # Check Gateway logs for chat_id
+   grep "chat_id=" ~/.hermes/profiles/*/logs/gateway.log | grep "Inbound" | tail -20
+   
+   # Example output:
+   # ... chat_id=oc_xxxxxxxxxxxxxxxx
+   ```
+
+2. **Verify routing via sidecar health check**:
+   ```bash
+   curl -s http://127.0.0.1:8765/health | jq '.routing.last_route'
+   # Output: {"message_id": "...", "chat_id": "oc_xxx", "bot_id": "main", "reason": "bindings.fallback_bot"}
+   ```
+   If `reason` shows `bindings.fallback_bot`, the chat_id is unbound and needs to be added to config.
+
+3. **From Feishu group URL**: Open the Feishu group chat, the `oc_xxx` in the URL is the chat_id.
+
 ### Common Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -98,6 +98,30 @@ card:
 
 > **注意**：`feishu.app_id`/`feishu.app_secret` 仅用于未配置多 bot 或作为 fallback。建议为每个 bot 提供独立凭据，避免权限交叉。
 
+### 如何获取 chat_id
+
+**重要**：`bindings.chats` 默认为空 `{}`，所有未绑定的消息都会路由到 `fallback_bot`。如果使用多 bot，必须配置 chat_id 绑定。
+
+获取 chat_id 的方法：
+
+1. **从 Gateway 日志提取**（推荐）：
+   ```bash
+   # 查看 Gateway 日志中的 chat_id
+   grep "chat_id=" ~/.hermes/profiles/*/logs/gateway.log | grep "Inbound" | tail -20
+   
+   # 输出示例：
+   # ... chat_id=oc_xxxxxxxxxxxxxxxx
+   ```
+
+2. **从 sidecar 健康检查确认路由**：
+   ```bash
+   curl -s http://127.0.0.1:8765/health | jq '.routing.last_route'
+   # 输出: {"message_id": "...", "chat_id": "oc_xxx", "bot_id": "main", "reason": "bindings.fallback_bot"}
+   ```
+   如果 `reason` 显示 `bindings.fallback_bot`，说明该 chat_id 未绑定，需要添加到配置中。
+
+3. **从飞书群聊 URL 获取**：打开飞书群聊，URL 中的 `oc_xxx` 即为 chat_id。
+
 ### 常用命令
 
 ```bash

--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -129,7 +129,7 @@ class FeishuClient:
         json_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         url = f"{self.config.base_url.rstrip('/')}/{path.lstrip('/')}"
-        headers = {"Content-Type": "application/json; charset=utf-8"}
+        headers = {"Content-Type": "application/json; charset=utf-8", "Accept-Encoding": "gzip, deflate"}
         if token:
             headers["Authorization"] = f"Bearer {token}"
 


### PR DESCRIPTION
## Problem

Feishu API returns brotli (br) encoded responses, but aiohttp library cannot decode them properly, causing Feishu card send/update failures with error:

```
aiohttp.client_exceptions.ClientPayloadError: 400, message:
  Can not decode content-encoding: br
```

## Solution

Add `Accept-Encoding: gzip, deflate` header to HTTP requests in `feishu_client.py`, preventing Feishu from returning brotli encoded responses.

## Change

```diff
- headers = {"Content-Type": "application/json; charset=utf-8"}
+ headers = {"Content-Type": "application/json; charset=utf-8", "Accept-Encoding": "gzip, deflate"}
```

## Testing

Verified with 8 different Feishu bots, all successfully send and update cards after this fix.