### PR TITLE
fix: multi-profile support for Hermes v0.13+

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -193,11 +193,11 @@ def build_event(event_name: str, local_vars: dict[str, Any]) -> dict[str, Any] |
     created_at_lifecycle_token = _created_at_lifecycle_token(created_at_value)
     fallback_key = (conversation_id, chat_id)
     explicit_message_id = _first_string(
-        local_vars, ("message_id", "msg_id")
+        local_vars, ("message_id", "msg_id", "event_message_id")
     ) or _first_attr_string(
-        message_obj, ("message_id", "msg_id")
+        message_obj, ("message_id", "msg_id", "event_message_id")
     ) or _first_attr_string(
-        gateway_event_obj, ("message_id", "msg_id")
+        gateway_event_obj, ("message_id", "msg_id", "event_message_id")
     )
     message_id = explicit_message_id
     is_terminal_event = event_name in {"message.completed", "message.failed"}
@@ -264,29 +264,43 @@ def build_event(event_name: str, local_vars: dict[str, Any]) -> dict[str, Any] |
 def _event_data(
     event_name: str, local_vars: dict[str, Any], message_obj: Any
 ) -> dict[str, Any]:
+    profile_id = _extract_profile_id(local_vars)
+
     if event_name in {"thinking.delta", "answer.delta"}:
         text = _first_string(local_vars, ("text", "delta", "delta_text", "content"))
         if text is None:
             text = _first_attr_string(message_obj, ("text", "content"))
-        return {"text": text or ""}
+        data = {"text": text or ""}
+        if profile_id:
+            data["profile_id"] = profile_id
+        return data
     if event_name == "tool.updated":
         tool_id = _first_string(local_vars, ("tool_id", "tool_call_id", "name")) or "tool"
         name = _first_string(local_vars, ("name", "tool_name")) or tool_id
         status = _first_string(local_vars, ("status", "tool_status")) or "running"
         detail = _first_string(local_vars, ("detail", "tool_detail")) or ""
-        return {"tool_id": tool_id, "name": name, "status": status, "detail": detail}
+        data = {"tool_id": tool_id, "name": name, "status": status, "detail": detail}
+        if profile_id:
+            data["profile_id"] = profile_id
+        return data
     if event_name == "message.completed":
         answer = _first_string(local_vars, ("answer", "final_answer", "text", "content")) or ""
-        return {
+        data = {
             "answer": answer,
             "duration": _completion_duration(local_vars),
             "model": _completion_model(local_vars),
             "tokens": _completion_tokens(local_vars, answer),
             "context": _completion_context(local_vars),
         }
+        if profile_id:
+            data["profile_id"] = profile_id
+        return data
     if event_name == "message.failed":
         error = _first_string(local_vars, ("error", "exception")) or "消息处理失败"
-        return {"error": error}
+        data = {"error": error}
+        if profile_id:
+            data["profile_id"] = profile_id
+        return data
     if event_name == "message.started":
         data: dict[str, Any] = {}
         for source_key, data_key in (
@@ -298,8 +312,25 @@ def _event_data(
             value = _first_string(local_vars, (source_key,)) or _first_attr_string(message_obj, (source_key,))
             if value:
                 data[data_key] = value
+        if "profile_id" not in data:
+            hermes_home = os.environ.get("HERMES_HOME", "")
+            if hermes_home and "/profiles/" in hermes_home:
+                profile_id = hermes_home.rstrip("/").split("/profiles/")[-1]
+                if profile_id:
+                    data["profile_id"] = profile_id
         return data if data else {}
     return {}
+
+
+def _extract_profile_id(local_vars: dict[str, Any]) -> str | None:
+    """Extract profile_id from local_vars or HERMES_HOME env var."""
+    profile_id = _first_string(local_vars, ("profile_id",))
+    if profile_id:
+        return profile_id
+    hermes_home = os.environ.get("HERMES_HOME", "")
+    if hermes_home and "/profiles/" in hermes_home:
+        return hermes_home.rstrip("/").split("/profiles/")[-1]
+    return None
 
 
 def _first_string(source: dict[str, Any], names: tuple[str, ...]) -> str | None:

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -99,7 +99,11 @@ def _render_tool_summary(session: CardSession) -> str:
         return "工具调用 0 次"
     lines = [f"工具调用 {session.tool_count} 次"]
     for tool in session.tools.values():
-        lines.append(f"- `{tool.name}`: {tool.status}")
+        if tool.detail and tool.name == "send_message":
+            lines.append(f"- `{tool.name}`: {tool.status}")
+            lines.append(f"  > {tool.detail}")
+        else:
+            lines.append(f"- `{tool.name}`: {tool.status}")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Problem

Hermes v0.13 introduced the multi-profile architecture (`hermes gateway run --profile <name>`), where each profile runs as an isolated gateway process with `HERMES_HOME=/root/.hermes/profiles/<name>`. The streaming card sidecar was unable to:

1. Route events to the correct Feishu app, since no `profile_id` was included in event payloads
2. Extract message IDs in some hook contexts where the variable is named `event_message_id` instead of `message_id`/`msg_id`

This caused cards to fail or be sent via the wrong bot in multi-profile setups.

## Solution

### `hook_runtime.py`

- **Inject `profile_id` into all event payloads** — `_event_data()` now extracts the profile identity and includes it in `thinking.delta`, `answer.delta`, `tool.updated`, `message.completed`, `message.failed`, and `message.started` data
- **`_extract_profile_id()` helper** — resolves profile identity from hook `local_vars` first, then falls back to parsing `HERMES_HOME` environment variable (e.g. `HERMES_HOME=/root/.hermes/profiles/main` → `main`)
- **`event_message_id` fallback** — message ID extraction now also checks `event_message_id`, matching the variable name used in v0.13 gateway hooks

### `render.py`

- **Show `send_message` tool detail in cards** — when a `send_message` tool is called with detail content, the card now renders it as a quoted line for better visibility

## Testing

Verified on a live server running 8 Hermes profiles (`main`, `sgcc`, `wei_paper`, `wei_fund`, `wei_idea`, `wei_agrs`, `wei_trash`, `william`) with Hermes `v2026.5.7` (post-v0.13). All profiles correctly connect to Feishu, events include proper `profile_id`, and cards are sent via the correct bot per profile.