### PR TITLE
[codex] fix fallback message id lifecycle

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -310,7 +310,7 @@ def _build_event(
     created_at_lifecycle_token = _created_at_lifecycle_token(created_at_value)
     fallback_key = (conversation_id, chat_id)
     explicit_message_id = _first_string(
-        local_vars, ("message_id", "msg_id")
+        local_vars, ("message_id", "msg_id", "event_message_id")
     ) or _first_attr_string(
         message_obj, ("message_id", "msg_id")
     ) or _first_attr_string(
@@ -830,6 +830,15 @@ def _preview_fallback_message_id(
     chat_id: str,
     created_at_lifecycle_token: str | None,
 ) -> str:
+    if created_at_lifecycle_token is not None:
+        token_key = (key[0], key[1], created_at_lifecycle_token)
+        cached = _ACTIVE_FALLBACK_MESSAGE_IDS.get(token_key)
+        if cached is not None:
+            return cached
+    else:
+        current_key = _CURRENT_FALLBACK_KEYS.get(key)
+        if current_key in _ACTIVE_FALLBACK_MESSAGE_IDS:
+            return _ACTIVE_FALLBACK_MESSAGE_IDS[current_key]
     lifecycle_count = _FALLBACK_LIFECYCLE_COUNTS.get(key, 0)
     lifecycle_token = f"active:{lifecycle_count}"
     if created_at_lifecycle_token is not None:

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -194,6 +194,19 @@ def test_build_event_uses_gateway_event_message_id_for_card_lifecycle():
     assert second_completed["message_id"] == "om_second"
 
 
+def test_build_event_uses_event_message_id_from_hermes_run_agent_started_hook():
+    payload = hook_runtime.build_event(
+        "message.started",
+        {
+            "source": SourceObject(),
+            "event_message_id": "om_hermes_20260507",
+            "session_id": "session_source",
+        },
+    )
+
+    assert payload["message_id"] == "om_hermes_20260507"
+
+
 def test_build_event_explicit_started_keeps_active_fallback_identity():
     local_vars = {"chat_id": "oc_abc", "conversation_id": "conv_abc"}
 
@@ -506,6 +519,20 @@ def test_build_event_preview_does_not_advance_sequence_or_retire_fallback():
     assert completed is not None
     assert completed["message_id"] == started["message_id"]
     assert completed["sequence"] == 1
+
+
+def test_preview_fallback_matches_active_fallback_without_created_at():
+    key = ("conv_abc", "oc_abc")
+    cache_key = hook_runtime._new_fallback_cache_key(key, None)
+
+    active = hook_runtime._create_active_fallback_message_id(
+        key, cache_key, "conv_abc", "oc_abc", None
+    )
+    preview = hook_runtime._preview_fallback_message_id(
+        key, "conv_abc", "oc_abc", None
+    )
+
+    assert preview == active
 
 
 def test_attachment_guard_uses_preview_before_terminal_emit_retires_fallback():


### PR DESCRIPTION
## Summary

- Treat Hermes `event_message_id` as an explicit runtime message id for started hooks.
- Reuse active fallback cache when previewing fallback ids without `created_at`.
- Add regression coverage for Hermes v2026.5.7-style started locals and fallback preview/create lifecycle consistency.

## Root Cause

Hermes v2026.5.7 can expose the inbound message id to the `_run_agent` started hook as `event_message_id`, while the runtime only recognized `message_id`, `msg_id`, or `event.message_id`. That made started events unnecessarily enter fallback id generation. Separately, `_create_active_fallback_message_id()` increments the untokened lifecycle counter while `_preview_fallback_message_id()` read the already-incremented value, so helper-level preview/create calls could produce different fallback ids for the same lifecycle.

## Validation

- `python3 -m pytest tests/unit/test_hook_runtime.py -q`
- `python3 -m pytest tests/unit/test_hook_runtime.py tests/unit/test_patcher.py -q`
- `python3 -m pytest -q`

Closes #25
