### PR TITLE
[codex] fix streaming card update ordering

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -42,6 +42,7 @@ class RuntimeConfig:
 
 
 _SEQUENCES: dict[str, int] = {}
+_SEQUENCE_LOCK = threading.Lock()
 _ACTIVE_FALLBACK_MESSAGE_IDS: dict[tuple[str, str, str | None], str] = {}
 _CURRENT_FALLBACK_KEYS: dict[tuple[str, str], tuple[str, str, str | None]] = {}
 _FALLBACK_LIFECYCLE_COUNTS: dict[tuple[str, str], int] = {}
@@ -49,7 +50,8 @@ _AMBIGUOUS_TERMINAL = object()
 
 
 def reset_runtime_state() -> None:
-    _SEQUENCES.clear()
+    with _SEQUENCE_LOCK:
+        _SEQUENCES.clear()
     _ACTIVE_FALLBACK_MESSAGE_IDS.clear()
     _CURRENT_FALLBACK_KEYS.clear()
     _FALLBACK_LIFECYCLE_COUNTS.clear()
@@ -921,10 +923,12 @@ def _hash_fallback_message_id(
 
 
 def _next_sequence(message_id: str) -> int:
-    sequence = _SEQUENCES.get(message_id, -1) + 1
-    _SEQUENCES[message_id] = sequence
-    return sequence
+    with _SEQUENCE_LOCK:
+        sequence = _SEQUENCES.get(message_id, -1) + 1
+        _SEQUENCES[message_id] = sequence
+        return sequence
 
 
 def _peek_next_sequence(message_id: str) -> int:
-    return _SEQUENCES.get(message_id, -1) + 1
+    with _SEQUENCE_LOCK:
+        return _SEQUENCES.get(message_id, -1) + 1

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -21,6 +21,7 @@ FEISHU_MESSAGE_IDS_KEY = web.AppKey("feishu_message_ids", dict)
 CARD_SUMMARIES_KEY = web.AppKey("card_summaries", dict)
 MESSAGE_BOT_IDS_KEY = web.AppKey("message_bot_ids", dict)
 SESSION_CARD_CONFIGS_KEY = web.AppKey("session_card_configs", dict)
+UPDATE_TASKS_KEY = web.AppKey("update_tasks", dict)
 BOT_ROUTER_KEY = web.AppKey("bot_router", Any)
 ROUTING_DIAGNOSTICS_KEY = web.AppKey("routing_diagnostics", dict)
 PROFILE_DIAGNOSTICS_KEY = web.AppKey("profile_diagnostics", dict)
@@ -54,6 +55,7 @@ def create_app(
     app[CARD_SUMMARIES_KEY] = {}
     app[MESSAGE_BOT_IDS_KEY] = {}
     app[SESSION_CARD_CONFIGS_KEY] = {}
+    app[UPDATE_TASKS_KEY] = {}
     app[BOT_ROUTER_KEY] = bot_router
     app[PROCESS_TOKEN_KEY] = process_token
     app[METRICS_KEY] = SidecarMetrics()
@@ -186,6 +188,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
     feishu_message_ids: Dict[str, str] = request.app[FEISHU_MESSAGE_IDS_KEY]
     message_bot_ids: Dict[str, str] = request.app[MESSAGE_BOT_IDS_KEY]
     last_update_at: Dict[str, float] = request.app[LAST_UPDATE_AT_KEY]
+    update_tasks: Dict[str, asyncio.Task] = request.app[UPDATE_TASKS_KEY]
     _record_profile_diagnostics(request.app, event)
     session = sessions.get(_session_key(event))
 
@@ -319,6 +322,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             card = _render_session_card(request, session)
             bot_id = message_bot_ids.get(_session_key(event))
             is_terminal = event.event in TERMINAL_EVENTS
+            session_key = _session_key(event)
 
             async def _do_update():
                 if is_terminal:
@@ -329,7 +333,23 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 if not updated and is_terminal:
                     await _retry_terminal_update(request.app, feishu_message_id, card, bot_id)
 
-            post_lock_task = _do_update()
+            previous_task = update_tasks.get(session_key)
+
+            async def _queued_update():
+                if previous_task is not None:
+                    try:
+                        await previous_task
+                    except Exception:
+                        logger.exception("previous Feishu card update task failed")
+                try:
+                    await _do_update()
+                finally:
+                    if update_tasks.get(session_key) is current_task:
+                        update_tasks.pop(session_key, None)
+
+            current_task = asyncio.create_task(_queued_update())
+            update_tasks[session_key] = current_task
+            post_lock_task = current_task
     if applied:
         metrics.events_applied += 1
     else:

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -32,6 +32,19 @@ class FakeFeishuClient:
         self.updated.append((message_id, card))
 
 
+class ReorderingFeishuClient(FakeFeishuClient):
+    def __init__(self):
+        super().__init__()
+        self.update_calls = 0
+
+    async def update_card_message(self, message_id, card):
+        self.update_calls += 1
+        update_call = self.update_calls
+        if update_call == 1:
+            await asyncio.sleep(0.05)
+        self.updated.append((message_id, card))
+
+
 class FakeBotRegistry:
     def safe_diagnostics(self):
         return {
@@ -616,6 +629,34 @@ async def test_concurrent_streaming_deltas_share_message_update_window(client):
     assert metrics["events_applied"] == 3
     assert metrics["feishu_update_attempts"] == 1
     assert metrics["feishu_update_successes"] == 1
+
+
+async def test_concurrent_card_updates_preserve_newer_content(monkeypatch):
+    feishu_client = ReorderingFeishuClient()
+    app = create_app(feishu_client)
+    server = TestServer(app)
+    test_client = TestClient(server)
+    monkeypatch.setattr(sidecar_server, "UPDATE_MIN_INTERVAL_SECONDS", 0)
+    await test_client.start_server()
+    try:
+        await test_client.post("/events", json=event_payload("message.started", 0))
+        first_delta, second_delta = await asyncio.gather(
+            test_client.post(
+                "/events",
+                json=event_payload("answer.delta", 1, {"text": "第一段"}),
+            ),
+            test_client.post(
+                "/events",
+                json=event_payload("answer.delta", 2, {"text": "第二段"}),
+            ),
+        )
+
+        assert first_delta.status == 200
+        assert second_delta.status == 200
+        assert len(feishu_client.updated) == 2
+        assert "第一段第二段" in str(feishu_client.updated[-1][1])
+    finally:
+        await test_client.close()
 
 
 async def test_terminal_event_waits_for_update_window(client, monkeypatch):

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -1,7 +1,9 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import json
 import math
 import threading
+import time
 from urllib import error
 
 import pytest
@@ -870,6 +872,27 @@ def test_build_event_increments_sequence_per_message():
 
     assert first["sequence"] == 0
     assert second["sequence"] == 1
+
+
+def test_build_event_allocates_unique_sequences_across_threads(monkeypatch):
+    class SlowSequenceStore(dict):
+        def get(self, key, default=None):
+            value = super().get(key, default)
+            time.sleep(0.02)
+            return value
+
+    monkeypatch.setattr(hook_runtime, "_SEQUENCES", SlowSequenceStore())
+    local_vars = {"chat_id": "oc_abc", "message_id": "msg_seq", "text": "hi"}
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        payloads = list(
+            executor.map(
+                lambda _: hook_runtime.build_event("answer.delta", local_vars),
+                range(2),
+            )
+        )
+
+    assert sorted(payload["sequence"] for payload in payloads) == [0, 1]
 
 
 class SenderProbe:


### PR DESCRIPTION
## Summary

- Serialize Feishu card updates per session so older PATCH requests cannot land after newer card snapshots.
- Make runtime sequence allocation thread-safe for concurrent Hermes callbacks.
- Add regression tests for out-of-order PATCH completion and concurrent sequence allocation.

## Validation

- `python3 -m pytest tests/unit/test_hook_runtime.py tests/integration/test_server.py -q`
- `python3 -m pytest -q`

## Notes

This addresses the observed thinking/answer text truncation and card rollback class of issues. It also covers the #31 scenario where concurrent PATCH requests can make card content flash or regress.
