### PR TITLE
fix(detect): 支持 Hermes 日历版本号的 hook 策略选择

### DIFF
--- a/hermes_feishu_card/install/detect.py
+++ b/hermes_feishu_card/install/detect.py
@@ -90,8 +90,11 @@ def detect_hermes(root: str | Path) -> HermesDetection:
         return result(False, "Hermes VERSION missing, unknown, or invalid")
     hook_strategy = _select_hook_strategy(version)
     minimum_version = _parse_version(MIN_SUPPORTED_VERSION)
-    if hook_strategy == "legacy_gateway_run" and minimum_version is not None and parsed_version < minimum_version:
-        return result(False, f"Hermes version must be at least {MIN_SUPPORTED_VERSION}")
+    if minimum_version is not None and parsed_version < minimum_version:
+        # Calendar versions below MIN_SUPPORTED_VERSION are unsupported.
+        # Semver 0.13.0+ IS supported even though tuple-compared lower.
+        if parsed_version[0] != 0 or parsed_version < (0, 13, 0):
+            return result(False, f"Hermes version must be at least {MIN_SUPPORTED_VERSION}")
 
     contents, run_py_error = _read_text(run_py, "gateway/run.py")
     if run_py_error is not None:
@@ -200,7 +203,7 @@ def _select_hook_strategy(version: str) -> str:
     parsed = _parse_version(version)
     if parsed is None:
         return ""
-    if parsed[0] == 0 and parsed >= (0, 13, 0):
+    if parsed >= (0, 13, 0):
         return "gateway_run_013_plus"
     return "legacy_gateway_run"
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -129,7 +129,7 @@ def test_module_doctor_reports_supported_hermes_detection(tmp_path):
     assert "version_source: VERSION" in result.stdout
     assert "version: v2026.4.23" in result.stdout
     assert "minimum_supported_version: v2026.4.23" in result.stdout
-    assert "hook_strategy: legacy_gateway_run" in result.stdout
+    assert "hook_strategy: gateway_run_013_plus" in result.stdout
     assert "compatibility: partial" in result.stdout
     assert "anchors:" in result.stdout
     assert "  message_handler: found" in result.stdout

--- a/tests/unit/test_installer_detection.py
+++ b/tests/unit/test_installer_detection.py
@@ -32,7 +32,7 @@ def test_detect_legacy_strategy_for_v2026_4_23_fixture():
     detection = detect_hermes(FIXTURE_ROOT)
 
     assert detection.supported is True
-    assert detection.hook_strategy == "legacy_gateway_run"
+    assert detection.hook_strategy == "gateway_run_013_plus"
     assert detection.compatibility == "partial"
     assert detection.capabilities["message_handler"] is True
 
@@ -285,6 +285,16 @@ def test_detect_hermes_rejects_missing_required_anchor(tmp_path):
 
 
 def test_detect_hermes_rejects_versions_below_minimum(tmp_path):
+    _write_hermes_root(tmp_path, version="v2026.4.22")
+
+    result = detect_hermes(tmp_path)
+
+    assert result.supported is False
+    assert "v2026.4.23" in result.reason
+
+
+def test_detect_hermes_rejects_v2026_4_22_even_with_013_strategy(tmp_path):
+    """v2026.4.22 is below MIN_SUPPORTED_VERSION despite strategy resolution."""
     _write_hermes_root(tmp_path, version="v2026.4.22")
 
     result = detect_hermes(tmp_path)


### PR DESCRIPTION
## 问题

`_select_hook_strategy()` 只识别 semver `0.x.y` 版本为 `gateway_run_013_plus` 策略。Hermes 切换到日历版本号（如 `v2026.5.16`）后，被错误归类为 `legacy_gateway_run`。

## 根因

`detect.py:203` 的版本检查要求 `parsed[0] == 0 AND parsed >= (0, 13, 0)`：

```python
if parsed[0] == 0 and parsed >= (0, 13, 0):
    return "gateway_run_013_plus"
return "legacy_gateway_run"
```

对于 `v2026.5.16`，解析后的元组是 `(2026, 5, 16)`。因为 `2026 != 0`，始终走 `legacy_gateway_run` 分支。

## 修复

直接对比 parsed tuple 与 `(0, 13, 0)` — Python 元组对比能正确处理跨版本方案的大小关系：

```python
if parsed >= (0, 13, 0):
    return "gateway_run_013_plus"
```

`(2026, 5, 16) >= (0, 13, 0)` 结果为 `True`，因为 Python 逐元素对比，`2026 >= 0` 成立。

## 额外修复：版本门禁解耦

原先第 93 行的不支持的版本检查依赖 `hook_strategy == "legacy_gateway_run"` 来阻止低于 `MIN_SUPPORTED_VERSION` (`v2026.4.23`) 的版本。策略修复后，`v2026.4.22` 会解析为 `gateway_run_013_plus` 并绕过这个门禁。

现在改为：任何低于 `MIN_SUPPORTED_VERSION` 的版本都被拒绝，同时为 semver `0.13.0+` 保留例外（它虽然元组对比上低于日历最小值，但实际是新版本）。

## 测试

- 86 个测试全部通过（单元 + 集成）
- `test_detect_legacy_strategy_for_v2026_4_23_fixture` 更新为预期 `gateway_run_013_plus`
- 新增 `test_detect_hermes_rejects_v2026_4_22_even_with_013_strategy` 验证版本门禁仍然有效
- `test_module_doctor_reports_supported_hermes_detection` 更新为新策略

## 影响

所有使用日历版本号（v2026.4.23+）的 Hermes 用户现在能正确获得 `gateway_run_013_plus` hook 策略，不再被错误归为 legacy。
