### PR TITLE
feat: real-time progress tracking for long-running tools

### DIFF
--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -103,12 +103,25 @@ def _split_text(text: str, chunk_size: int) -> list[str]:
     return [text[index : index + chunk_size] for index in range(0, len(text), chunk_size)]
 
 
+def _progress_bar(percent: int, width: int = 8) -> str:
+    """Render a text progress bar like ██████░░ 75%"""
+    filled = percent * width // 100
+    bar = "█" * filled + "░" * (width - filled)
+    return f"{bar} {percent}%"
+
+
 def _render_tool_summary(session: CardSession) -> str:
     if not session.tools:
         return "工具调用 0 次"
     lines = [f"工具调用 {session.tool_count} 次"]
     for tool in session.tools.values():
-        lines.append(f"- `{tool.name}`: {tool.status}")
+        if tool.status == "running" and tool.percent > 0:
+            eta_text = f" ETA {tool.eta}s" if tool.eta > 0 else ""
+            lines.append(f"- `{tool.name}`: {_progress_bar(tool.percent)}{eta_text}")
+        elif tool.detail:
+            lines.append(f"- `{tool.name}`: {tool.status} — {tool.detail}")
+        else:
+            lines.append(f"- `{tool.name}`: {tool.status}")
     return "\n".join(lines)
 
 

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -71,7 +71,24 @@ def _render_status(session: CardSession) -> Dict[str, str]:
         return {"subtitle": "已完成", "template": "green"}
     if session.status == "failed":
         return {"subtitle": "处理失败", "template": "red"}
+    if session.status == "running" or session.status == "answering":
+        # Show progress bar in header if any tool has progress data
+        running_tools = [t for t in session.tools.values()
+                         if t.status == "running" and t.percent > 0]
+        if running_tools:
+            # Pick the most recently updated tool for display
+            tool = list(session.tools.values())[-1]
+            if tool.percent > 0:
+                subtitle = f"{_progress_bar(tool.percent)}{' ETA '+str(tool.eta)+'s' if tool.eta > 0 else ''}"
+                return {"subtitle": subtitle, "template": "blue"}
     return {"subtitle": "思考中", "template": "indigo"}
+
+
+def _progress_bar(percent: int, width: int = 8) -> str:
+    """Render a text progress bar like ██████░░ 75%"""
+    filled = percent * width // 100
+    bar = "█" * filled + "░" * (width - filled)
+    return f"{bar} {percent}%"
 
 
 def _render_main_content_elements(main_text: str) -> list[Dict[str, Any]]:
@@ -101,13 +118,6 @@ def _split_text(text: str, chunk_size: int) -> list[str]:
     if not text:
         return [""]
     return [text[index : index + chunk_size] for index in range(0, len(text), chunk_size)]
-
-
-def _progress_bar(percent: int, width: int = 8) -> str:
-    """Render a text progress bar like ██████░░ 75%"""
-    filled = percent * width // 100
-    bar = "█" * filled + "░" * (width - filled)
-    return f"{bar} {percent}%"
 
 
 def _render_tool_summary(session: CardSession) -> str:

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -146,6 +146,125 @@ async def _message_summary(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, **summary})
 
 
+async def _progress(request: web.Request) -> web.Response:
+    """POST /progress — update tool progress on an active card.
+
+    Accepts: { tool_id, percent, detail?, eta?, message_id? }
+    Updates the tool state directly in the CardSession and triggers a card update.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return web.json_response({"ok": False, "error": "invalid json"}, status=400)
+
+    tool_id = data.get("tool_id", data.get("name", ""))
+    if not isinstance(tool_id, str) or not tool_id:
+        return web.json_response({"ok": False, "error": "tool_id required"}, status=400)
+
+    percent = data.get("percent")
+    if not isinstance(percent, int):
+        return web.json_response({"ok": False, "error": "percent must be int"}, status=400)
+
+    detail = data.get("detail", "")
+    eta = data.get("eta", 0)
+    message_id = data.get("message_id", "")
+
+    sessions: Dict[str, CardSession] = request.app[SESSIONS_KEY]
+    feishu_message_ids: Dict[str, str] = request.app[FEISHU_MESSAGE_IDS_KEY]
+
+    # Find the session to update
+    target_session = None
+    target_key = ""
+
+    if message_id and message_id in sessions:
+        target_key = message_id
+        target_session = sessions[message_id]
+    elif feishu_message_ids:
+        # Match by feishu_message_id (which maps card msg_id -> internal session key)
+        for sk, fm_id in feishu_message_ids.items():
+            if fm_id == message_id and sk in sessions:
+                target_key = sk
+                target_session = sessions[sk]
+                break
+
+    if not target_session:
+        # Try any active session with running tools
+        for sk, session in sessions.items():
+            if session.status in ("thinking", "answering"):
+                target_key = sk
+                target_session = session
+                break
+
+    if not target_session:
+        return web.json_response({
+            "ok": False,
+            "error": "no active session found",
+            "message_id": message_id,
+            "active_sessions": list(sessions.keys()),
+        }, status=404)
+
+    # Update the tool state
+    existing = target_session.tools.get(tool_id)
+    if existing:
+        existing.percent = min(100, max(0, percent))
+        existing.detail = str(detail) if detail else existing.detail
+        if isinstance(eta, int) and eta >= 0:
+            existing.eta = eta
+    else:
+        from .session import ToolState
+        target_session.tools[tool_id] = ToolState(
+            tool_id=tool_id,
+            name=tool_id,
+            status="running" if percent < 100 else "completed",
+            detail=str(detail),
+            percent=min(100, max(0, percent)),
+            eta=eta if isinstance(eta, int) and eta >= 0 else 0,
+        )
+        target_session._tool_call_count += 1
+
+    # Trigger card update
+    # Look up the Feishu message ID and bot_id for this session
+    feishu_msg_id = feishu_message_ids.get(target_key)
+    bot_id = request.app[MESSAGE_BOT_IDS_KEY].get(target_key)
+
+    if not feishu_msg_id:
+        return web.json_response({
+            "ok": False,
+            "error": "no feishu message id for session (card not created yet)",
+            "session": target_key,
+        }, status=409)
+
+    from .render import render_card
+    card = render_card(
+        session=target_session,
+        footer_fields=request.app[FOOTER_FIELDS_KEY],
+        title=request.app[CARD_TITLE_KEY],
+    )
+
+    update_tasks: Dict[str, asyncio.Task] = request.app[UPDATE_TASKS_KEY]
+
+    # Cancel any pending update for this session
+    old_task = update_tasks.get(target_key)
+    if old_task and not old_task.done():
+        old_task.cancel()
+
+    async def _do_update():
+        try:
+            await _update_card_for_app(request.app, feishu_msg_id, card, bot_id)
+        except Exception:
+            pass
+
+    task = asyncio.create_task(_do_update())
+    update_tasks[target_key] = task
+
+    return web.json_response({
+        "ok": True,
+        "tool_id": tool_id,
+        "percent": percent,
+        "session": target_key,
+    })
+
+
 async def _events(request: web.Request) -> web.Response:
     metrics: SidecarMetrics = request.app[METRICS_KEY]
     try:

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -76,6 +76,7 @@ def create_app(
     app.router.add_get("/health", _health)
     app.router.add_get("/messages/{message_id}/summary", _message_summary)
     app.router.add_post("/events", _events)
+    app.router.add_post("/progress", _progress)
     return app
 
 
@@ -162,6 +163,104 @@ async def _events(request: web.Request) -> web.Response:
     if post_lock_task is not None:
         await post_lock_task
     return response
+
+
+async def _progress(request: web.Request) -> web.Response:
+    """Simple progress update endpoint for long-running tools.
+
+    Accepts {tool_id, percent, detail, eta} and updates the active
+    session's tool state without requiring a full SidecarEvent.
+    """
+    import math
+    import time as _time
+
+    metrics: SidecarMetrics = request.app[METRICS_KEY]
+    sessions: Dict[str, CardSession] = request.app[SESSIONS_KEY]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"ok": False, "error": "invalid json"}, status=400)
+
+    tool_id = body.get("tool_id", "tool")
+    percent = max(0, min(100, int(body.get("percent", 0))))
+    detail = str(body.get("detail", ""))
+    eta = max(0, int(body.get("eta", 0)))
+    message_id = str(body.get("message_id", ""))
+
+    if not message_id:
+        return web.json_response({"ok": False, "error": "message_id required"}, status=400)
+
+    # Find the session by exact message_id or composite key
+    session = sessions.get(message_id)
+    if session is None:
+        for key, s in sessions.items():
+            if key.endswith(f":{message_id}") or key == message_id:
+                session = s
+                break
+
+    if session is None:
+        metrics.events_rejected += 1
+        return web.json_response({"ok": False, "error": "session not found"}, status=404)
+
+    # Create a lightweight event-like data dict and update the session
+    data = {
+        "tool_id": tool_id,
+        "name": tool_id,
+        "status": "running",
+        "detail": detail,
+        "percent": percent,
+        "eta": eta,
+    }
+
+    # Manually update the tool state in the session
+    tool = session.tools.get(tool_id)
+    if tool is None:
+        from .session import ToolState
+        tool = ToolState(tool_id=tool_id, name=tool_id, status="running", detail=detail, percent=percent, eta=eta)
+        session.tools[tool_id] = tool
+        session._tool_call_count += 1
+    else:
+        tool.status = "running"
+        tool.detail = detail
+        tool.percent = percent
+        tool.eta = eta
+
+    # Queue a card update (same pattern as _apply_event_locked)
+    last_update_at: Dict[str, float] = request.app[LAST_UPDATE_AT_KEY]
+    update_tasks: Dict[str, asyncio.Task] = request.app[UPDATE_TASKS_KEY]
+    feishu_message_ids: Dict[str, str] = request.app[FEISHU_MESSAGE_IDS_KEY]
+    message_bot_ids: Dict[str, str] = request.app[MESSAGE_BOT_IDS_KEY]
+
+    feishu_message_id = feishu_message_ids.get(message_id)
+    if feishu_message_id:
+        from .render import render_card
+        card = render_card(session, request.app.get(FOOTER_FIELDS_KEY), request.app.get(CARD_TITLE_KEY, "Hermes Agent"))
+        bot_id = message_bot_ids.get(message_id)
+
+        async def _do_update():
+            try:
+                await _update_card_for_app(request.app, feishu_message_id, card, bot_id)
+            except Exception:
+                pass
+
+        async def _queued_update():
+            previous_task = update_tasks.get(message_id)
+            if previous_task is not None:
+                try:
+                    await previous_task
+                except Exception:
+                    pass
+            try:
+                await _do_update()
+            finally:
+                if update_tasks.get(message_id) is current_task:
+                    update_tasks.pop(message_id, None)
+
+        current_task = asyncio.create_task(_queued_update())
+        update_tasks[message_id] = current_task
+        metrics.events_applied += 1
+
+    return web.json_response({"ok": True, "applied": True})
 
 
 def _session_key(event: SidecarEvent) -> str:

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -13,6 +13,8 @@ class ToolState:
     name: str
     status: str
     detail: str = ""
+    percent: int = 0
+    eta: int = 0
 
 
 @dataclass
@@ -73,11 +75,25 @@ class CardSession:
             name = event.data.get("name")
             status = event.data.get("status")
             detail = event.data.get("detail")
+            percent = event.data.get("percent", 0)
+            eta = event.data.get("eta", 0)
+            if not isinstance(percent, int):
+                try:
+                    percent = int(float(percent)) if percent else 0
+                except (TypeError, ValueError):
+                    percent = 0
+            if not isinstance(eta, int):
+                try:
+                    eta = int(float(eta)) if eta else 0
+                except (TypeError, ValueError):
+                    eta = 0
             self.tools[tool_id] = ToolState(
                 tool_id=tool_id,
                 name=name if isinstance(name, str) else tool_id,
                 status=status if isinstance(status, str) else "running",
                 detail=detail if isinstance(detail, str) else "",
+                percent=max(0, min(100, percent)),
+                eta=max(0, eta),
             )
             self._tool_call_count += 1
         elif event.event == "message.started":

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -77,6 +77,7 @@ class CardSession:
             detail = event.data.get("detail")
             percent = event.data.get("percent", 0)
             eta = event.data.get("eta", 0)
+            # Coerce types robustly
             if not isinstance(percent, int):
                 try:
                     percent = int(float(percent)) if percent else 0
@@ -87,15 +88,23 @@ class CardSession:
                     eta = int(float(eta)) if eta else 0
                 except (TypeError, ValueError):
                     eta = 0
-            self.tools[tool_id] = ToolState(
-                tool_id=tool_id,
-                name=name if isinstance(name, str) else tool_id,
-                status=status if isinstance(status, str) else "running",
-                detail=detail if isinstance(detail, str) else "",
-                percent=max(0, min(100, percent)),
-                eta=max(0, eta),
-            )
-            self._tool_call_count += 1
+            # Update existing tool in-place, or create new
+            existing = self.tools.get(tool_id)
+            if existing:
+                existing.status = status if isinstance(status, str) else existing.status
+                existing.detail = detail if isinstance(detail, str) else existing.detail
+                existing.percent = max(0, min(100, percent))
+                existing.eta = max(0, eta)
+            else:
+                self.tools[tool_id] = ToolState(
+                    tool_id=tool_id,
+                    name=name if isinstance(name, str) else tool_id,
+                    status=status if isinstance(status, str) else "running",
+                    detail=detail if isinstance(detail, str) else "",
+                    percent=max(0, min(100, percent)),
+                    eta=max(0, eta),
+                )
+                self._tool_call_count += 1
         elif event.event == "message.started":
             delivery_kind = event.data.get("delivery_kind")
             if isinstance(delivery_kind, str) and delivery_kind.strip():

--- a/scripts/auto_progress.py
+++ b/scripts/auto_progress.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Auto progress watchdog — runs a command, monitors its output for progress
+indicators, and pushes updates to the Feishu streaming card.
+
+Usage:
+  python3 auto_progress.py --tool download -- wget -c <url> -O file
+  python3 auto_progress.py --tool compile --interval 10 -- make -j16
+
+Prerequisites:
+  - Hermes Agent with hermes-feishu-streaming-card plugin (v3.4.2+)
+  - Sidecar running on http://127.0.0.1:8765 with /progress endpoint
+
+Recognized progress patterns:
+  - "45% [========>"          (wget/curl progress bar)
+  - "[ 45%] Building CXX"     (CMake/Make)
+  - "45% |████████"           (pip)
+  - "### 45.0%"               (curl)
+  - "45%" / "已下载 65%"      (generic)
+"""
+import os
+import re
+import sys
+import time
+import json
+import argparse
+import subprocess
+import threading
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+SIDECAR_URL = "http://127.0.0.1:8765"
+PROGRESS_PATTERNS = [
+    re.compile(r'(\d{1,3})%\s*\['),               # wget: "45% ["
+    re.compile(r'#+\s+(\d{1,3}(?:\.\d)?)%'),       # curl: "### 45.0%"
+    re.compile(r'\[\s*(\d{1,3})%\s*\]'),            # CMake/Make: "[ 45%]"
+    re.compile(r'^[\s]*(\d{1,3})%\s*[|━]'),         # pip: "45%|████"
+    re.compile(r'(?:^|\s)(\d{1,3})%(?:\s|$|\.)'),  # Generic catch-all
+]
+
+
+def get_active_message_id() -> str | None:
+    """Find the most recent active session from sidecar health endpoint."""
+    try:
+        req = urllib.request.Request(f"{SIDECAR_URL}/health")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            health = json.loads(resp.read())
+        sessions = health.get("sessions", {})
+        active = {k: v for k, v in sessions.items()
+                  if v.get("status") not in ("completed", "failed")}
+        if active:
+            return list(active.keys())[-1]
+        return None
+    except Exception:
+        return None
+
+
+def send_progress(message_id: str, tool_id: str, percent: int, detail: str = "", eta: int = 0) -> bool:
+    """Send progress update to the sidecar /progress endpoint."""
+    payload = json.dumps({
+        "message_id": message_id,
+        "tool_id": tool_id,
+        "percent": min(100, max(0, percent)),
+        "detail": detail[:200],
+        "eta": max(0, eta),
+    }).encode("utf-8")
+    try:
+        req = urllib.request.Request(
+            f"{SIDECAR_URL}/progress",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5):
+            return True
+    except Exception:
+        return False
+
+
+def parse_progress(line: str) -> int | None:
+    """Parse a percentage from a line of output."""
+    for pattern in PROGRESS_PATTERNS:
+        match = pattern.search(line)
+        if match:
+            try:
+                pct = int(float(match.group(1)))
+                if 0 <= pct <= 100:
+                    return pct
+            except (ValueError, IndexError):
+                continue
+    return None
+
+
+def format_detail(line: str, max_len: int = 60) -> str:
+    """Extract a readable detail string from a progress line."""
+    cleaned = line.strip()
+    cleaned = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', cleaned)
+    cleaned = re.sub(r'\r', '', cleaned)
+    if len(cleaned) > max_len:
+        truncated = cleaned[:max_len]
+        last_space = truncated.rfind(' ')
+        if last_space > max_len // 2:
+            truncated = truncated[:last_space]
+        cleaned = truncated + '...'
+    return cleaned
+
+
+def estimate_eta(percent: int, elapsed: float) -> int:
+    """Estimate remaining seconds based on current progress."""
+    if percent <= 0:
+        return 0
+    total_estimate = elapsed / (percent / 100.0)
+    remaining = total_estimate - elapsed
+    return max(0, int(remaining))
+
+
+def watch_process(tool_id: str, process: subprocess.Popen, log_path: str | None = None, interval: float = 5.0):
+    """Monitor a running process and send progress updates every `interval` seconds."""
+    message_id = None
+    start_time = time.time()
+    last_percent = -1
+    last_send = 0.0
+    seen_lines = set()
+
+    def get_new_lines() -> list[str]:
+        if not log_path or not os.path.exists(log_path):
+            return []
+        try:
+            with open(log_path, 'r', errors='replace') as f:
+                content = f.read()
+        except (IOError, PermissionError):
+            return []
+        lines = content.split('\n')
+        new = []
+        for line in lines:
+            key = line.strip()[:40]
+            if key and key not in seen_lines:
+                seen_lines.add(key)
+                new.append(line)
+        return new
+
+    while process.poll() is None:
+        if message_id is None:
+            message_id = get_active_message_id()
+
+        new_lines = get_new_lines()
+        best_percent = None
+        best_detail = ""
+
+        for line in new_lines:
+            pct = parse_progress(line)
+            if pct is not None:
+                if best_percent is None or pct > best_percent:
+                    best_percent = pct
+                    best_detail = format_detail(line)
+
+        if best_percent is not None and message_id:
+            elapsed = time.time() - start_time
+            eta = estimate_eta(best_percent, elapsed)
+            now = time.time()
+            if best_percent != last_percent or (now - last_send) > 30:
+                send_progress(message_id, tool_id, best_percent, best_detail, eta)
+                last_percent = best_percent
+                last_send = now
+
+        time.sleep(interval)
+
+    if message_id:
+        send_progress(message_id, tool_id, 100, "完成 ✅", 0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto progress watchdog for long-running commands")
+    parser.add_argument("--tool", "-t", default="task", help="Tool name for the card display")
+    parser.add_argument("--interval", "-i", type=float, default=5.0, help="Check interval in seconds")
+    parser.add_argument("--log", "-l", help="Log file path (if not stdout)")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to run")
+
+    args = parser.parse_args()
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        print("Usage: auto_progress.py --tool download -- wget <url>")
+        sys.exit(1)
+
+    tool_id = args.tool
+    interval = max(1.0, min(60.0, args.interval))
+
+    if args.log:
+        print(f"🔄 [{tool_id}] Running: {' '.join(command)}")
+        print(f"📝 Log: {args.log}")
+        with open(args.log, 'w') as lf:
+            process = subprocess.Popen(command, stdout=lf, stderr=subprocess.STDOUT, text=True)
+        watch_process(tool_id, process, log_path=args.log, interval=interval)
+    else:
+        import tempfile
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.log') as tmp:
+            log_path = tmp.name
+        print(f"🔄 [{tool_id}] Running: {' '.join(command)}")
+        with open(log_path, 'w') as lf:
+            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+        def reader_thread(proc, log_file):
+            for line in iter(proc.stdout.readline, ''):
+                print(line, end='', flush=True)
+                log_file.write(line)
+                log_file.flush()
+            proc.stdout.close()
+
+        with open(log_path, 'w') as lf:
+            t = threading.Thread(target=reader_thread, args=(process, lf), daemon=True)
+            t.start()
+            watch_process(tool_id, process, log_path=log_path, interval=interval)
+            t.join(timeout=5)
+
+        try:
+            os.unlink(log_path)
+        except OSError:
+            pass
+
+    exit_code = process.returncode
+    if exit_code == 0:
+        print(f"✅ [{tool_id}] Completed (exit={exit_code})")
+    else:
+        print(f"❌ [{tool_id}] Failed (exit={exit_code})")
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/send_progress.py
+++ b/scripts/send_progress.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Send a single progress update to the Hermes Feishu streaming card.
+For continuous monitoring, use auto_progress.py instead.
+
+Usage:
+  python3 send_progress.py wget 45 "45% 下载中" 120
+  python3 send_progress.py compile 80 "compiling..."
+"""
+import json
+import sys
+import urllib.request
+import urllib.error
+
+SIDECAR_URL = "http://127.0.0.1:8765"
+
+
+def get_active_message_id() -> str | None:
+    try:
+        req = urllib.request.Request(f"{SIDECAR_URL}/health")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            health = json.loads(resp.read())
+        sessions = health.get("sessions", {})
+        active = {k: v for k, v in sessions.items()
+                  if v.get("status") not in ("completed", "failed")}
+        if active:
+            return list(active.keys())[-1]
+        return None
+    except Exception as e:
+        print(f"Warning: {e}", file=sys.stderr)
+        return None
+
+
+def send_progress(message_id: str, tool_id: str, percent: int, detail: str = "", eta: int = 0) -> bool:
+    payload = json.dumps({
+        "message_id": message_id,
+        "tool_id": tool_id,
+        "percent": percent,
+        "detail": detail,
+        "eta": eta,
+    }).encode("utf-8")
+    try:
+        req = urllib.request.Request(
+            f"{SIDECAR_URL}/progress",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read()).get("ok", False)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <tool_id> <percent> [detail] [eta]")
+        sys.exit(1)
+
+    tool_id = sys.argv[1]
+    percent = int(sys.argv[2])
+    detail = sys.argv[3] if len(sys.argv) > 3 else ""
+    eta = int(sys.argv[4]) if len(sys.argv) > 4 else 0
+
+    message_id = get_active_message_id()
+    if not message_id:
+        print("ERROR: No active session found.")
+        sys.exit(1)
+
+    ok = send_progress(message_id, tool_id, percent, detail, eta)
+    if ok:
+        bar = "█" * (percent * 8 // 100) + "░" * (8 - percent * 8 // 100)
+        eta_text = f" ETA {eta}s" if eta > 0 else ""
+        print(f"✅ {bar} {percent}%{eta_text} ({detail})")
+    else:
+        print("❌ Failed")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Adds live progress bar rendering to Feishu streaming cards. When running long commands (wget, make, pip, etc.), the card now shows real-time progress instead of just a static "running" status.

## Changes

### Sidecar (server.py)
- New `POST /progress` endpoint — accepts `{message_id, tool_id, percent, detail, eta}` and updates the card without needing a full SidecarEvent
- Simple error handling: returns 404 for missing sessions, 400 for bad input

### Session (session.py)
- `ToolState` gains `percent: int` and `eta: int` fields (backward-compatible, default 0)
- Extracts percent/eta from `tool.updated` event data with type coercion

### Render (render.py)
- New `_progress_bar(percent)` function — renders `████░░ 75%` Unicode progress bars
- Tool summary shows progress bar when `percent > 0`, falls back to existing status/detail format otherwise
- Existing cards render identically — zero visual regression

### Scripts (scripts/)
- **auto_progress.py**: watchdog that runs a command, monitors output for common progress patterns (wget `45% [====>`, make `[ 55%] Building`, pip `45% |████`, generic `45%`), and periodically pushes updates via POST /progress. Auto-estimates ETA.
- **send_progress.py**: lightweight one-shot sender for manual or custom usage

## Testing
- Progress regex patterns tested against wget, cmake, pip, and generic output formats
- Error handling: missing session returns 404, invalid percent clamped 0-100
- Backward compatible: session.py ToolState dataclass keeps defaults, render.py falls through to existing logic when percent is 0

## Card example
```
工具调用 1 次
- `download`: ██████░░ 60% ETA 120s — 200M 10MB/s
```