### PR TITLE
fix: select 0.13+ hook strategy for Hermes calendar versions

### DIFF
--- a/hermes_feishu_card/install/detect.py
+++ b/hermes_feishu_card/install/detect.py
@@ -200,7 +200,7 @@ def _select_hook_strategy(version: str) -> str:
     parsed = _parse_version(version)
     if parsed is None:
         return ""
-    if parsed[0] == 0 and parsed >= (0, 13, 0):
+    if (parsed[0] == 0 and parsed >= (0, 13, 0)) or parsed >= (2026, 5, 0):
         return "gateway_run_013_plus"
     return "legacy_gateway_run"
 

--- a/tests/unit/test_installer_detection.py
+++ b/tests/unit/test_installer_detection.py
@@ -84,6 +84,56 @@ def _deliver_media_from_response(response):
     assert detection.capabilities["cron_delivery"] is True
 
 
+def test_detect_calendar_version_013_plus_strategy_for_v2026_5_16(tmp_path):
+    root = tmp_path / "hermes"
+    run_py = root / "gateway" / "run.py"
+    cron_py = root / "cron" / "scheduler.py"
+    run_py.parent.mkdir(parents=True)
+    cron_py.parent.mkdir(parents=True)
+    (root / "VERSION").write_text("v2026.5.16\n", encoding="utf-8")
+    run_py.write_text(
+        '''
+class GatewayRunner:
+    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):
+        response = "ok"
+        agent_result = {"model": "m"}
+        _response_time = 1.0
+        await self.hooks.emit("agent:end", {"response": response})
+        return response
+
+    async def _run_agent(self, source, event_message_id=None):
+        _loop_for_step = None
+        def _run_still_current():
+            return True
+        def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
+            return None
+        def _stream_delta_cb(text: str) -> None:
+            return None
+        def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+            return None
+        return {}
+
+def _reply_anchor_for_event(event):
+    return getattr(event, "reply_to_message_id", None)
+''',
+        encoding="utf-8",
+    )
+    cron_py.write_text(
+        '''
+def _deliver_result(job: dict, content: str, adapters=None, loop=None):
+    return None
+''',
+        encoding="utf-8",
+    )
+
+    detection = detect_hermes(root)
+
+    assert detection.supported is True
+    assert detection.hook_strategy == "gateway_run_013_plus"
+    assert detection.compatibility == "partial"
+    assert detection.capabilities["cron_delivery"] is True
+
+
 def test_detect_cron_delivery_in_scheduler_py_for_latest_layout(tmp_path):
     root = tmp_path / "hermes"
     run_py = root / "gateway" / "run.py"


### PR DESCRIPTION
## Summary
- Treat Hermes calendar versions v2026.5.0+ as 0.13+ layout for hook strategy selection.
- Keep v2026.4.23 on legacy_gateway_run.
- Add regression coverage for issue #34 / Hermes v2026.5.16 selecting gateway_run_013_plus.

## Tests
- python3 -m pytest tests/unit/test_installer_detection.py -q
- python3 -m pytest tests/unit/test_patcher.py -q
- python3 -m pytest tests/integration/test_cli_install.py tests/integration/test_cli.py -q
- python3 -m pytest -q

Fixes #34