### PR TITLE
Fix Feishu DM topic card routing and replies

### DIFF
--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -5,7 +5,7 @@ import math
 import time
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 from urllib.parse import quote, urlparse
 
 import aiohttp
@@ -60,13 +60,16 @@ class FeishuClient:
         chat_id: str,
         card: Dict[str, Any],
         thread_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
     ) -> Dict[str, str]:
         if not isinstance(chat_id, str) or not chat_id.strip():
             raise ValueError("chat_id is required")
         if not isinstance(card, dict):
             raise TypeError("card must be a dict")
 
-        receive_id = thread_id if thread_id else chat_id
+        receive_id = chat_id
+        if thread_id and not reply_to_message_id:
+            receive_id = thread_id
         return {
             "receive_id": receive_id,
             "msg_type": "interactive",
@@ -78,17 +81,35 @@ class FeishuClient:
         chat_id: str,
         card: Dict[str, Any],
         thread_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
     ) -> str:
         token = await self._tenant_token()
-        payload = self.build_message_payload(chat_id, card, thread_id=thread_id)
-        receive_id_type = "thread_id" if thread_id else "chat_id"
-        body = await self._request_json(
-            "POST",
-            "/im/v1/messages",
-            token=token,
-            params={"receive_id_type": receive_id_type},
-            json_body=payload,
+        payload = self.build_message_payload(
+            chat_id,
+            card,
+            thread_id=thread_id,
+            reply_to_message_id=reply_to_message_id,
         )
+        if thread_id and reply_to_message_id:
+            body = await self._request_json(
+                "POST",
+                f"/im/v1/messages/{quote(reply_to_message_id, safe='')}/reply",
+                token=token,
+                json_body={
+                    "msg_type": payload["msg_type"],
+                    "content": payload["content"],
+                    "reply_in_thread": True,
+                },
+            )
+        else:
+            receive_id_type = "thread_id" if thread_id else "chat_id"
+            body = await self._request_json(
+                "POST",
+                "/im/v1/messages",
+                token=token,
+                params={"receive_id_type": receive_id_type},
+                json_body=payload,
+            )
         data = body.get("data")
         if not isinstance(data, dict) or not isinstance(data.get("message_id"), str):
             raise FeishuAPIError("Feishu send message response missing message_id")

--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -55,26 +55,38 @@ class FeishuClient:
         self._tenant_access_token: str | None = None
         self._tenant_access_token_expires_at = 0.0
 
-    def build_message_payload(self, chat_id: str, card: Dict[str, Any]) -> Dict[str, str]:
+    def build_message_payload(
+        self,
+        chat_id: str,
+        card: Dict[str, Any],
+        thread_id: Optional[str] = None,
+    ) -> Dict[str, str]:
         if not isinstance(chat_id, str) or not chat_id.strip():
             raise ValueError("chat_id is required")
         if not isinstance(card, dict):
             raise TypeError("card must be a dict")
 
+        receive_id = thread_id if thread_id else chat_id
         return {
-            "receive_id": chat_id,
+            "receive_id": receive_id,
             "msg_type": "interactive",
             "content": json.dumps(card, ensure_ascii=False),
         }
 
-    async def send_card(self, chat_id: str, card: Dict[str, Any]) -> str:
+    async def send_card(
+        self,
+        chat_id: str,
+        card: Dict[str, Any],
+        thread_id: Optional[str] = None,
+    ) -> str:
         token = await self._tenant_token()
-        payload = self.build_message_payload(chat_id, card)
+        payload = self.build_message_payload(chat_id, card, thread_id=thread_id)
+        receive_id_type = "thread_id" if thread_id else "chat_id"
         body = await self._request_json(
             "POST",
             "/im/v1/messages",
             token=token,
-            params={"receive_id_type": "chat_id"},
+            params={"receive_id_type": receive_id_type},
             json_body=payload,
         )
         data = body.get("data")

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -602,11 +602,11 @@ def _build_event(
     if chat_id is None:
         return None
 
-    conversation_id = (
-        _first_string(local_vars, ("conversation_id", "thread_id", "session_id"))
-        or _first_attr_string(message_obj, ("conversation_id", "thread_id", "session_id"))
-        or _first_attr_string(source_obj, ("conversation_id", "thread_id", "session_id"))
-        or chat_id
+    conversation_id = _conversation_id_for_event(
+        local_vars=local_vars,
+        message_obj=message_obj,
+        source_obj=source_obj,
+        chat_id=chat_id,
     )
     created_at_value = local_vars.get("created_at")
     created_at = _created_at(created_at_value)
@@ -981,6 +981,40 @@ def _first_string(source: dict[str, Any], names: tuple[str, ...]) -> str | None:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+def _is_feishu_thread_id(value: str | None) -> bool:
+    return bool(value and value.startswith(("omt_", "om_")))
+
+
+def _is_hermes_session_key(value: str | None) -> bool:
+    return bool(value and value.startswith("agent:main:"))
+
+
+def _conversation_id_for_event(
+    *,
+    local_vars: dict[str, Any],
+    message_obj: Any,
+    source_obj: Any,
+    chat_id: str,
+) -> str:
+    explicit = (
+        _first_string(local_vars, ("conversation_id",))
+        or _first_attr_string(message_obj, ("conversation_id",))
+        or _first_attr_string(source_obj, ("conversation_id",))
+    )
+    if explicit and not _is_hermes_session_key(explicit):
+        return explicit
+
+    thread_id = (
+        _first_string(local_vars, ("thread_id",))
+        or _first_attr_string(message_obj, ("thread_id",))
+        or _first_attr_string(source_obj, ("thread_id",))
+    )
+    if _is_feishu_thread_id(thread_id):
+        return thread_id
+
+    return chat_id
 
 
 def _first_raw_string(source: dict[str, Any], names: tuple[str, ...]) -> str | None:

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -323,6 +323,8 @@ def request_approval_choice_from_hermes_locals(
     if isinstance(result, dict) and result.get("status") == "completed":
         choice = str(result.get("choice") or "").strip()
         return choice or None
+    if isinstance(result, dict) and result.get("status") in {"timeout", "failed"}:
+        return "deny"
     return None
 
 

--- a/hermes_feishu_card/runner.py
+++ b/hermes_feishu_card/runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from aiohttp import web
 
@@ -17,7 +17,12 @@ class NoopFeishuClient:
     def __init__(self) -> None:
         self._sent_count = 0
 
-    async def send_card(self, chat_id: str, card: dict[str, Any]) -> str:
+    async def send_card(
+        self,
+        chat_id: str,
+        card: dict[str, Any],
+        thread_id: Optional[str] = None,
+    ) -> str:
         self._sent_count += 1
         return f"noop-feishu-message-{self._sent_count}"
 

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -5,7 +5,8 @@ import time
 import asyncio
 import logging
 import re
-from typing import Any, Dict
+from collections import deque
+from typing import Any, Deque, Dict
 
 from aiohttp import web
 
@@ -37,7 +38,15 @@ BASE_CARD_CONFIG_KEY = web.AppKey("base_card_config", dict)
 UPDATE_MAX_ATTEMPTS = 3
 UPDATE_MIN_INTERVAL_SECONDS = 0.2
 TERMINAL_EVENTS = {"message.completed", "message.failed"}
+SESSION_START_EVENTS = {
+    "message.started",
+    "thinking.delta",
+    "answer.delta",
+    "tool.updated",
+    "interaction.requested",
+}
 DIAGNOSTICS_KEY = web.AppKey("diagnostics", dict)
+RECENT_EVENTS_KEY = web.AppKey("recent_events", Deque)
 PROFILE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
 logger = logging.getLogger(__name__)
 
@@ -70,6 +79,7 @@ def create_app(
         "last_route_error": "",
         "last_terminal_event": {},
     }
+    app[RECENT_EVENTS_KEY] = deque(maxlen=25)
     app[ROUTING_DIAGNOSTICS_KEY] = _initial_routing_diagnostics(feishu_client)
     app[PROFILE_DIAGNOSTICS_KEY] = {}
     app[BASE_CARD_CONFIG_KEY] = dict(card_config)
@@ -113,6 +123,7 @@ async def _health(request: web.Request) -> web.Response:
             for message_id, session in sessions.items()
         },
         "diagnostics": diagnostics,
+        "recent_events": list(request.app[RECENT_EVENTS_KEY]),
         "routing": request.app[ROUTING_DIAGNOSTICS_KEY],
         "profile_diagnostics": request.app[PROFILE_DIAGNOSTICS_KEY],
     }
@@ -256,6 +267,23 @@ def _thread_id_for_event(event: SidecarEvent) -> str | None:
     return None
 
 
+def _reply_to_message_id_for_event(event: SidecarEvent) -> str | None:
+    data = event.data if isinstance(event.data, dict) else {}
+    reply_to = data.get("reply_to_message_id")
+    if isinstance(reply_to, str) and reply_to.startswith("om_"):
+        return reply_to
+    # When in a thread, reply to the user's message so the response stays in the thread.
+    # Feishu API does not support receive_id_type=thread_id; we must use the reply API.
+    if _thread_id_for_event(event) and isinstance(event.message_id, str) and event.message_id.startswith("om_"):
+        return event.message_id
+    return None
+
+
+def _last_send_error(app: web.Application) -> str:
+    error = str(app[DIAGNOSTICS_KEY].get("last_send_error") or "").strip()
+    return error or "feishu_send_failed"
+
+
 async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tuple[web.Response, Any]:
     """Process event state inside the lock. Returns (response, post_lock_task).
 
@@ -271,10 +299,19 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
     pending_update_requests: Dict[str, bool] = request.app[PENDING_UPDATE_REQUESTS_KEY]
     _record_profile_diagnostics(request.app, event)
     _record_attachment_diagnostics(request.app, event)
-    session = sessions.get(_session_key(event))
+    session_key = _session_key(event)
+    session = sessions.get(session_key)
 
     if event.event == "message.started":
         if session is not None:
+            _record_recent_event(
+                request.app,
+                event,
+                session_key=session_key,
+                applied=False,
+                action="ignored",
+                reason="duplicate_started",
+            )
             metrics.events_ignored += 1
             return web.json_response({"ok": True, "applied": False}), None
         session = CardSession(
@@ -282,18 +319,26 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             message_id=event.message_id,
             chat_id=event.chat_id,
         )
-        sessions[_session_key(event)] = session
+        sessions[session_key] = session
         applied = session.apply(event)
-        if applied and _session_key(event) not in feishu_message_ids:
+        if applied and session_key not in feishu_message_ids:
             route = _resolve_route(request, event)
             if route is None:
-                sessions.pop(_session_key(event), None)
+                sessions.pop(session_key, None)
+                _record_recent_event(
+                    request.app,
+                    event,
+                    session_key=session_key,
+                    applied=False,
+                    action="rejected",
+                    reason="bot_route_failed",
+                )
                 metrics.events_rejected += 1
                 return web.json_response(
                     {"ok": False, "error": "bot route failed"},
                     status=502,
                 ), None
-            request.app[SESSION_CARD_CONFIGS_KEY][_session_key(event)] = (
+            request.app[SESSION_CARD_CONFIGS_KEY][session_key] = (
                 _resolve_session_card_config(request.app, route.bot_id, event)
             )
             message_id = await _send_card(
@@ -302,42 +347,67 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 _render_session_card(request, session),
                 route.bot_id,
                 thread_id=_thread_id_for_event(event),
+                reply_to_message_id=_reply_to_message_id_for_event(event),
             )
             if message_id is None:
-                sessions.pop(_session_key(event), None)
-                request.app[SESSION_CARD_CONFIGS_KEY].pop(_session_key(event), None)
+                sessions.pop(session_key, None)
+                request.app[SESSION_CARD_CONFIGS_KEY].pop(session_key, None)
+                _record_recent_event(
+                    request.app,
+                    event,
+                    session_key=session_key,
+                    applied=False,
+                    action="rejected",
+                    reason=_last_send_error(request.app),
+                )
                 metrics.events_rejected += 1
                 return web.json_response(
                     {"ok": False, "error": "feishu send failed"},
                     status=502,
                 ), None
-            feishu_message_ids[_session_key(event)] = message_id
-            message_bot_ids[_session_key(event)] = route.bot_id
+            feishu_message_ids[session_key] = message_id
+            message_bot_ids[session_key] = route.bot_id
         if applied:
             metrics.events_applied += 1
         else:
             metrics.events_ignored += 1
+        _record_recent_event(
+            request.app,
+            event,
+            session_key=session_key,
+            applied=applied,
+            action="started",
+            reason="" if applied else "session_apply_rejected",
+        )
         return web.json_response({"ok": True, "applied": applied}), None
 
     if session is None:
-        if event.event == "interaction.requested":
+        if event.event in SESSION_START_EVENTS:
             session = CardSession(
                 conversation_id=event.conversation_id,
                 message_id=event.message_id,
                 chat_id=event.chat_id,
             )
-            sessions[_session_key(event)] = session
+            sessions[session_key] = session
             applied = session.apply(event)
             if applied:
                 route = _resolve_route(request, event)
                 if route is None:
-                    sessions.pop(_session_key(event), None)
+                    sessions.pop(session_key, None)
+                    _record_recent_event(
+                        request.app,
+                        event,
+                        session_key=session_key,
+                        applied=False,
+                        action="rejected",
+                        reason="bot_route_failed",
+                    )
                     metrics.events_rejected += 1
                     return web.json_response(
                         {"ok": False, "error": "bot route failed"},
                         status=502,
                     ), None
-                request.app[SESSION_CARD_CONFIGS_KEY][_session_key(event)] = (
+                request.app[SESSION_CARD_CONFIGS_KEY][session_key] = (
                     _resolve_session_card_config(request.app, route.bot_id, event)
                 )
                 message_id = await _send_card(
@@ -346,21 +416,39 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                     _render_session_card(request, session),
                     route.bot_id,
                     thread_id=_thread_id_for_event(event),
+                    reply_to_message_id=_reply_to_message_id_for_event(event),
                 )
                 if message_id is None:
-                    sessions.pop(_session_key(event), None)
-                    request.app[SESSION_CARD_CONFIGS_KEY].pop(_session_key(event), None)
+                    sessions.pop(session_key, None)
+                    request.app[SESSION_CARD_CONFIGS_KEY].pop(session_key, None)
+                    _record_recent_event(
+                        request.app,
+                        event,
+                        session_key=session_key,
+                        applied=False,
+                        action="rejected",
+                        reason=_last_send_error(request.app),
+                    )
                     metrics.events_rejected += 1
                     return web.json_response(
                         {"ok": False, "error": "feishu send failed"},
                         status=502,
                     ), None
-                feishu_message_ids[_session_key(event)] = message_id
-                message_bot_ids[_session_key(event)] = route.bot_id
-                _store_interaction_result(request.app, session)
+                feishu_message_ids[session_key] = message_id
+                message_bot_ids[session_key] = route.bot_id
+                if event.event == "interaction.requested":
+                    _store_interaction_result(request.app, session)
                 metrics.events_applied += 1
             else:
                 metrics.events_ignored += 1
+            _record_recent_event(
+                request.app,
+                event,
+                session_key=session_key,
+                applied=applied,
+                action="auto_started",
+                reason="" if applied else "session_apply_rejected",
+            )
             return web.json_response({"ok": True, "applied": applied}), None
         if event.event == "message.completed" and _delivery_kind(event) == "cron":
             session = CardSession(
@@ -368,19 +456,27 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 message_id=event.message_id,
                 chat_id=event.chat_id,
             )
-            sessions[_session_key(event)] = session
+            sessions[session_key] = session
             applied = session.apply(event)
             if applied:
                 route = _resolve_route(request, event)
                 if route is None:
-                    sessions.pop(_session_key(event), None)
+                    sessions.pop(session_key, None)
+                    _record_recent_event(
+                        request.app,
+                        event,
+                        session_key=session_key,
+                        applied=False,
+                        action="rejected",
+                        reason="bot_route_failed",
+                    )
                     metrics.cron_fallbacks += 1
                     metrics.events_rejected += 1
                     return web.json_response(
                         {"ok": False, "error": "bot route failed"},
                         status=502,
                     ), None
-                request.app[SESSION_CARD_CONFIGS_KEY][_session_key(event)] = (
+                request.app[SESSION_CARD_CONFIGS_KEY][session_key] = (
                     _resolve_session_card_config(request.app, route.bot_id, event)
                 )
                 message_id = await _send_card(
@@ -389,18 +485,27 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                     _render_session_card(request, session),
                     route.bot_id,
                     thread_id=_thread_id_for_event(event),
+                    reply_to_message_id=_reply_to_message_id_for_event(event),
                 )
                 if message_id is None:
-                    sessions.pop(_session_key(event), None)
-                    request.app[SESSION_CARD_CONFIGS_KEY].pop(_session_key(event), None)
+                    sessions.pop(session_key, None)
+                    request.app[SESSION_CARD_CONFIGS_KEY].pop(session_key, None)
+                    _record_recent_event(
+                        request.app,
+                        event,
+                        session_key=session_key,
+                        applied=False,
+                        action="rejected",
+                        reason=_last_send_error(request.app),
+                    )
                     metrics.cron_fallbacks += 1
                     metrics.events_rejected += 1
                     return web.json_response(
                         {"ok": False, "error": "feishu send failed"},
                         status=502,
                     ), None
-                feishu_message_ids[_session_key(event)] = message_id
-                message_bot_ids[_session_key(event)] = route.bot_id
+                feishu_message_ids[session_key] = message_id
+                message_bot_ids[session_key] = route.bot_id
                 _store_card_summary(request.app, event, session, message_id)
                 request.app[DIAGNOSTICS_KEY]["last_terminal_event"] = {
                     "message_id": event.message_id,
@@ -414,12 +519,36 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 metrics.cron_cards_sent += 1
             else:
                 metrics.events_ignored += 1
+            _record_recent_event(
+                request.app,
+                event,
+                session_key=session_key,
+                applied=applied,
+                action="cron_completed",
+                reason="" if applied else "session_apply_rejected",
+            )
             return web.json_response({"ok": True, "applied": applied}), None
+        _record_recent_event(
+            request.app,
+            event,
+            session_key=session_key,
+            applied=False,
+            action="ignored",
+            reason="session_missing",
+        )
         metrics.events_ignored += 1
         return web.json_response({"ok": True, "applied": False}), None
 
-    feishu_message_id = feishu_message_ids.get(_session_key(event))
+    feishu_message_id = feishu_message_ids.get(session_key)
     if _would_apply(session, event) and feishu_message_id is None:
+        _record_recent_event(
+            request.app,
+            event,
+            session_key=session_key,
+            applied=False,
+            action="rejected",
+            reason="feishu_message_id_missing",
+        )
         metrics.events_rejected += 1
         return web.json_response(
             {"ok": False, "error": "feishu_message_id missing"},
@@ -453,7 +582,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
         if should_update:
             if is_terminal:
                 pending_update_requests.pop(session_key, None)
-            # 锁内立即标记，防止后续事件在API完成前重复触发更新
+            # Mark inside the lock so bursts do not schedule duplicate API updates.
             last_update_at[session_key] = time.monotonic()
             card = _render_session_card(request, session)
             bot_id = message_bot_ids.get(_session_key(event))
@@ -502,6 +631,14 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
         metrics.events_applied += 1
     else:
         metrics.events_ignored += 1
+    _record_recent_event(
+        request.app,
+        event,
+        session_key=session_key,
+        applied=applied,
+        action="updated" if applied else "ignored",
+        reason="" if applied else "session_apply_rejected",
+    )
     return web.json_response({"ok": True, "applied": applied}), post_lock_task
 
 
@@ -616,6 +753,31 @@ def _record_attachment_diagnostics(app: web.Application, event: SidecarEvent) ->
     }
 
 
+def _record_recent_event(
+    app: web.Application,
+    event: SidecarEvent,
+    *,
+    session_key: str,
+    applied: bool,
+    action: str,
+    reason: str = "",
+) -> None:
+    app[RECENT_EVENTS_KEY].append(
+        {
+            "event": event.event,
+            "message_id": event.message_id,
+            "conversation_id": event.conversation_id,
+            "chat_id": event.chat_id,
+            "session_key": session_key,
+            "thread_id": _thread_id_for_event(event) or "",
+            "sequence": event.sequence,
+            "applied": applied,
+            "action": action,
+            "reason": reason,
+        }
+    )
+
+
 def _delivery_kind(event: SidecarEvent) -> str:
     data = event.data if isinstance(event.data, dict) else {}
     return str(data.get("delivery_kind") or "").strip().lower()
@@ -701,6 +863,7 @@ async def _send_card(
     card: dict[str, Any],
     bot_id: str | None,
     thread_id: str | None = None,
+    reply_to_message_id: str | None = None,
 ) -> str | None:
     metrics: SidecarMetrics = request.app[METRICS_KEY]
     metrics.feishu_send_attempts += 1
@@ -709,12 +872,20 @@ async def _send_card(
             chat_id,
             card,
             thread_id=thread_id,
+            reply_to_message_id=reply_to_message_id,
         )
-    except Exception:
+    except Exception as exc:
+        request.app[DIAGNOSTICS_KEY]["last_send_error"] = _safe_error_summary(exc)
         metrics.feishu_send_failures += 1
         return None
+    request.app[DIAGNOSTICS_KEY]["last_send_error"] = ""
     metrics.feishu_send_successes += 1
     return message_id
+
+
+def _safe_error_summary(exc: Exception) -> str:
+    message = str(exc).strip() or exc.__class__.__name__
+    return message[:500]
 
 
 async def _update_card(

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -78,6 +78,7 @@ def create_app(
         "last_update_error": "",
         "last_route_error": "",
         "last_terminal_event": {},
+        "last_card_action": {},
     }
     app[RECENT_EVENTS_KEY] = deque(maxlen=25)
     app[ROUTING_DIAGNOSTICS_KEY] = _initial_routing_diagnostics(feishu_client)
@@ -174,6 +175,11 @@ async def _card_actions(request: web.Request) -> web.Response:
     try:
         payload = await request.json()
     except ValueError:
+        _record_card_action_diagnostics(
+            request.app,
+            action="invalid",
+            reason="invalid_json",
+        )
         return web.json_response({"ok": False, "error": "invalid json"}, status=400)
 
     value = _extract_action_value(payload)
@@ -182,11 +188,31 @@ async def _card_actions(request: web.Request) -> web.Response:
     choice = str(value.get("choice") or "").strip()
     choice_label = str(value.get("choice_label") or choice).strip()
     if not interaction_id or not token or not choice:
+        _record_card_action_diagnostics(
+            request.app,
+            action="invalid",
+            reason="invalid_action",
+            interaction_id=interaction_id,
+            choice=choice,
+        )
         return web.json_response({"ok": False, "error": "invalid action"}, status=400)
 
     callback_chat_id = _extract_callback_chat_id(payload)
-    found = _find_session_by_interaction(request.app, interaction_id, token, callback_chat_id)
+    found, failure_reason = _find_session_by_interaction(
+        request.app,
+        interaction_id,
+        token,
+        callback_chat_id,
+    )
     if found is None:
+        _record_card_action_diagnostics(
+            request.app,
+            action="not_found",
+            reason=failure_reason,
+            interaction_id=interaction_id,
+            callback_chat_id=callback_chat_id,
+            choice=choice,
+        )
         return web.json_response({"ok": False, "error": "interaction not found"}, status=404)
     session_key, session = found
     user_name = _extract_operator_name(payload)
@@ -217,7 +243,25 @@ async def _card_actions(request: web.Request) -> web.Response:
     if post_lock_task is not None:
         await post_lock_task
     if response.status >= 400:
+        _record_card_action_diagnostics(
+            request.app,
+            action="rejected",
+            reason=f"event_apply_status_{response.status}",
+            interaction_id=interaction_id,
+            callback_chat_id=callback_chat_id,
+            session_key=session_key,
+            choice=choice,
+        )
         return response
+    _record_card_action_diagnostics(
+        request.app,
+        action="completed",
+        reason="",
+        interaction_id=interaction_id,
+        callback_chat_id=callback_chat_id,
+        session_key=session_key,
+        choice=choice,
+    )
     return web.json_response(
         {
             "ok": True,
@@ -686,24 +730,48 @@ def _extract_operator_name(payload: dict[str, Any]) -> str:
     ).strip()
 
 
+def _record_card_action_diagnostics(
+    app: web.Application,
+    *,
+    action: str,
+    reason: str = "",
+    interaction_id: str = "",
+    callback_chat_id: str = "",
+    session_key: str = "",
+    choice: str = "",
+) -> None:
+    app[DIAGNOSTICS_KEY]["last_card_action"] = {
+        "action": action,
+        "reason": reason,
+        "interaction_id": interaction_id,
+        "callback_chat_id": callback_chat_id,
+        "session_key": session_key,
+        "choice": choice,
+    }
+
+
 def _find_session_by_interaction(
     app: web.Application,
     interaction_id: str,
     token: str,
     callback_chat_id: str,
-) -> tuple[str, CardSession] | None:
+) -> tuple[tuple[str, CardSession] | None, str]:
+    found_interaction = False
     for session_key, session in app[SESSIONS_KEY].items():
         interaction = session.active_interaction
         if interaction is None:
             continue
         if interaction.interaction_id != interaction_id:
             continue
+        found_interaction = True
         if interaction.callback_token != token:
-            return None
+            return None, "token_mismatch"
         if callback_chat_id and callback_chat_id != session.chat_id:
-            return None
-        return str(session_key), session
-    return None
+            return None, "chat_id_mismatch"
+        return (str(session_key), session), ""
+    if found_interaction:
+        return None, "not_matched"
+    return None, "interaction_id_not_found"
 
 
 def _store_card_summary(

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -248,6 +248,14 @@ def _session_key(event: SidecarEvent) -> str:
     return event.message_id
 
 
+def _thread_id_for_event(event: SidecarEvent) -> str | None:
+    """Return a Feishu thread id from sidecar conversation metadata."""
+    raw_thread = event.conversation_id if event.conversation_id != event.chat_id else None
+    if isinstance(raw_thread, str) and raw_thread.startswith(("omt_", "om_")):
+        return raw_thread
+    return None
+
+
 async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tuple[web.Response, Any]:
     """Process event state inside the lock. Returns (response, post_lock_task).
 
@@ -293,6 +301,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 event.chat_id,
                 _render_session_card(request, session),
                 route.bot_id,
+                thread_id=_thread_id_for_event(event),
             )
             if message_id is None:
                 sessions.pop(_session_key(event), None)
@@ -336,6 +345,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                     event.chat_id,
                     _render_session_card(request, session),
                     route.bot_id,
+                    thread_id=_thread_id_for_event(event),
                 )
                 if message_id is None:
                     sessions.pop(_session_key(event), None)
@@ -378,6 +388,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                     event.chat_id,
                     _render_session_card(request, session),
                     route.bot_id,
+                    thread_id=_thread_id_for_event(event),
                 )
                 if message_id is None:
                     sessions.pop(_session_key(event), None)
@@ -685,12 +696,20 @@ def _card_config_for_client(
 
 
 async def _send_card(
-    request: web.Request, chat_id: str, card: dict[str, Any], bot_id: str | None
+    request: web.Request,
+    chat_id: str,
+    card: dict[str, Any],
+    bot_id: str | None,
+    thread_id: str | None = None,
 ) -> str | None:
     metrics: SidecarMetrics = request.app[METRICS_KEY]
     metrics.feishu_send_attempts += 1
     try:
-        message_id = await _client_for_bot(request.app, bot_id).send_card(chat_id, card)
+        message_id = await _client_for_bot(request.app, bot_id).send_card(
+            chat_id,
+            card,
+            thread_id=thread_id,
+        )
     except Exception:
         metrics.feishu_send_failures += 1
         return None

--- a/tests/integration/test_feishu_client_http.py
+++ b/tests/integration/test_feishu_client_http.py
@@ -102,6 +102,31 @@ async def test_send_card_fetches_token_and_posts_interactive_message(feishu_api)
     assert send_request[3]["Authorization"] == "Bearer tenant-token-1"
 
 
+async def test_send_card_posts_to_thread_when_thread_id_present(feishu_api):
+    test_client, requests, token_calls = feishu_api
+    client = FeishuClient(
+        FeishuClientConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            base_url=str(test_client.make_url("/")),
+        )
+    )
+
+    message_id = await client.send_card(
+        "oc_abc",
+        {"schema": "2.0", "body": "你好"},
+        thread_id="omt_thread",
+    )
+
+    assert message_id == "om_message_1"
+    assert token_calls() == 1
+    send_request = requests[1]
+    assert send_request[0] == "send"
+    assert send_request[1] == "thread_id"
+    assert send_request[2]["receive_id"] == "omt_thread"
+    assert send_request[2]["msg_type"] == "interactive"
+
+
 async def test_update_card_reuses_cached_token_and_patches_message(feishu_api):
     test_client, requests, token_calls = feishu_api
     client = FeishuClient(

--- a/tests/integration/test_feishu_client_http.py
+++ b/tests/integration/test_feishu_client_http.py
@@ -52,6 +52,19 @@ async def feishu_api():
             {"code": 0, "msg": "ok", "data": {"message_id": "om_message_1"}}
         )
 
+    async def reply_message(request):
+        requests.append(
+            (
+                "reply",
+                request.match_info["message_id"],
+                await request.json(),
+                dict(request.headers),
+            )
+        )
+        return web.json_response(
+            {"code": 0, "msg": "ok", "data": {"message_id": "om_reply_1"}}
+        )
+
     async def update_message(request):
         requests.append(
             (
@@ -66,6 +79,7 @@ async def feishu_api():
     app = web.Application()
     app.router.add_post("/auth/v3/tenant_access_token/internal", tenant_token)
     app.router.add_post("/im/v1/messages", send_message)
+    app.router.add_post("/im/v1/messages/{message_id}/reply", reply_message)
     app.router.add_patch("/im/v1/messages/{message_id}", update_message)
     server = TestServer(app)
     client = TestClient(server)
@@ -125,6 +139,33 @@ async def test_send_card_posts_to_thread_when_thread_id_present(feishu_api):
     assert send_request[1] == "thread_id"
     assert send_request[2]["receive_id"] == "omt_thread"
     assert send_request[2]["msg_type"] == "interactive"
+
+
+async def test_send_card_replies_in_thread_when_reply_anchor_present(feishu_api):
+    test_client, requests, token_calls = feishu_api
+    client = FeishuClient(
+        FeishuClientConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            base_url=str(test_client.make_url("/")),
+        )
+    )
+
+    message_id = await client.send_card(
+        "oc_abc",
+        {"schema": "2.0", "body": "你好"},
+        thread_id="omt_thread",
+        reply_to_message_id="om_user_message",
+    )
+
+    assert message_id == "om_reply_1"
+    assert token_calls() == 1
+    reply_request = requests[1]
+    assert reply_request[0] == "reply"
+    assert reply_request[1] == "om_user_message"
+    assert reply_request[2]["msg_type"] == "interactive"
+    assert reply_request[2]["reply_in_thread"] is True
+    assert "你好" in reply_request[2]["content"]
 
 
 async def test_update_card_reuses_cached_token_and_patches_message(feishu_api):

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -17,10 +17,10 @@ class FakeFeishuClient:
         self.update_error_message = "update unavailable"
         self.update_delay = 0.0
 
-    async def send_card(self, chat_id, card, thread_id=None):
+    async def send_card(self, chat_id, card, thread_id=None, reply_to_message_id=None):
         if self.fail_send:
             raise RuntimeError("send unavailable")
-        self.sent.append((chat_id, card, thread_id))
+        self.sent.append((chat_id, card, thread_id, reply_to_message_id))
         return f"feishu-message-{len(self.sent)}"
 
     async def update_card_message(self, message_id, card):
@@ -137,6 +137,7 @@ async def test_health_reports_healthy_status_and_active_sessions(client):
     assert body["reply_index"] == {"entries": 0, "last_lookup": {}}
     assert body["cron"] == {"cards_sent": 0, "fallbacks": 0}
     assert body["profile_diagnostics"] == {}
+    assert body["recent_events"] == []
 
 
 async def test_health_reports_profile_diagnostics_for_profile_events():
@@ -279,6 +280,68 @@ async def test_message_started_passes_feishu_thread_id_to_send_card(client):
     assert len(feishu_client.sent) == 1
     assert feishu_client.sent[0][0] == "oc_abc"
     assert feishu_client.sent[0][2] == "omt_thread"
+
+
+async def test_thread_card_uses_reply_anchor_when_present(client):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": "om_user_message"},
+            conversation_id="omt_thread",
+            chat_id="oc_abc",
+        ),
+    )
+
+    assert started.status == 200
+    assert await started.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert feishu_client.sent[0][2] == "omt_thread"
+    assert feishu_client.sent[0][3] == "om_user_message"
+
+
+async def test_delta_before_started_starts_thread_card(client):
+    test_client, feishu_client = client
+
+    delta = await test_client.post(
+        "/events",
+        json=event_payload(
+            "answer.delta",
+            0,
+            {"text": "话题回答"},
+            conversation_id="omt_thread",
+            chat_id="oc_abc",
+        ),
+    )
+    completed = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.completed",
+            1,
+            {"answer": "话题最终回答"},
+            conversation_id="omt_thread",
+            chat_id="oc_abc",
+        ),
+    )
+
+    assert delta.status == 200
+    assert await delta.json() == {"ok": True, "applied": True}
+    assert completed.status == 200
+    assert await completed.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert feishu_client.sent[0][0] == "oc_abc"
+    assert feishu_client.sent[0][2] == "omt_thread"
+    assert len(feishu_client.updated) == 1
+    assert "话题最终回答" in str(feishu_client.updated[-1][1])
+
+    health = await test_client.get("/health")
+    body = await health.json()
+    assert body["recent_events"][0]["event"] == "answer.delta"
+    assert body["recent_events"][0]["action"] == "auto_started"
+    assert body["recent_events"][0]["thread_id"] == "omt_thread"
 
 
 async def test_message_started_ignores_non_feishu_session_key_as_thread_id(client):
@@ -482,7 +545,7 @@ async def test_non_object_json_payload_returns_400_json(client):
     assert feishu_client.updated == []
 
 
-async def test_event_before_started_is_not_applied(client):
+async def test_delta_before_started_auto_starts_card(client):
     test_client, feishu_client = client
 
     response = await test_client.post(
@@ -491,14 +554,16 @@ async def test_event_before_started_is_not_applied(client):
     )
 
     assert response.status == 200
-    assert await response.json() == {"ok": True, "applied": False}
-    assert feishu_client.sent == []
+    assert await response.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
     assert feishu_client.updated == []
     health = await test_client.get("/health")
-    metrics = (await health.json())["metrics"]
+    body = await health.json()
+    metrics = body["metrics"]
     assert metrics["events_received"] == 1
-    assert metrics["events_applied"] == 0
-    assert metrics["events_ignored"] == 1
+    assert metrics["events_applied"] == 1
+    assert metrics["events_ignored"] == 0
+    assert body["recent_events"][0]["action"] == "auto_started"
 
 
 async def test_cron_completed_event_sends_completed_card_without_started(client):

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -423,6 +423,103 @@ async def test_interaction_request_renders_buttons_and_callback_resolves(client)
     assert "已选择：允许一次" in str(feishu_client.updated[-1][1])
 
 
+async def test_thread_interaction_callback_resolves_same_thread_session(client):
+    test_client, feishu_client = client
+    thread_data = {
+        "thread_id": "omt_topic",
+        "reply_to_message_id": "om_original",
+    }
+
+    await test_client.post(
+        "/events",
+        json=event_payload("message.started", 0, thread_data),
+    )
+    requested = await test_client.post(
+        "/events",
+        json=event_payload(
+            "interaction.requested",
+            1,
+            {
+                **thread_data,
+                "interaction_id": "approval-thread-1",
+                "kind": "approval",
+                "prompt": "允许执行命令吗？",
+                "options": [{"label": "允许一次", "value": "once"}],
+            },
+        ),
+    )
+
+    assert requested.status == 200
+    interaction_card = feishu_client.updated[-1][1]
+    button = next(
+        element
+        for element in interaction_card["body"]["elements"]
+        if element.get("tag") == "button"
+    )
+
+    callback = await test_client.post(
+        "/card/actions",
+        json={
+            "event": {
+                "operator": {"open_id": "ou_bailey", "name": "Bailey"},
+                "context": {"open_chat_id": "oc_abc"},
+                "action": {"value": button["behaviors"][0]["value"]},
+            }
+        },
+    )
+    result = await test_client.get("/interactions/approval-thread-1")
+    health = await test_client.get("/health")
+
+    assert callback.status == 200
+    assert await result.json() == {
+        "ok": True,
+        "status": "completed",
+        "choice": "once",
+        "choice_label": "允许一次",
+        "interaction_id": "approval-thread-1",
+    }
+    health_body = await health.json()
+    assert health_body["diagnostics"]["last_card_action"] == {
+        "action": "completed",
+        "reason": "",
+        "interaction_id": "approval-thread-1",
+        "callback_chat_id": "oc_abc",
+        "session_key": "hermes-message-1",
+        "choice": "once",
+    }
+
+
+async def test_card_action_records_failure_diagnostics(client):
+    test_client, _ = client
+
+    callback = await test_client.post(
+        "/card/actions",
+        json={
+            "event": {
+                "context": {"open_chat_id": "oc_abc"},
+                "action": {
+                    "value": {
+                        "interaction_id": "missing",
+                        "token": "bad-token",
+                        "choice": "once",
+                    }
+                },
+            }
+        },
+    )
+    health = await test_client.get("/health")
+
+    assert callback.status == 404
+    assert (await health.json())["diagnostics"]["last_card_action"] == {
+        "action": "not_found",
+        "reason": "interaction_id_not_found",
+        "interaction_id": "missing",
+        "callback_chat_id": "oc_abc",
+        "session_key": "",
+        "choice": "once",
+    }
+
+
 async def test_completed_card_summary_can_be_looked_up_by_feishu_message_id(client):
     test_client, _ = client
     long_answer = "最终答案" * 1000

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -17,10 +17,10 @@ class FakeFeishuClient:
         self.update_error_message = "update unavailable"
         self.update_delay = 0.0
 
-    async def send_card(self, chat_id, card):
+    async def send_card(self, chat_id, card, thread_id=None):
         if self.fail_send:
             raise RuntimeError("send unavailable")
-        self.sent.append((chat_id, card))
+        self.sent.append((chat_id, card, thread_id))
         return f"feishu-message-{len(self.sent)}"
 
     async def update_card_message(self, message_id, card):
@@ -259,6 +259,46 @@ async def test_event_lifecycle_sends_then_updates_final_card(client):
     assert metrics["feishu_update_successes"] == 2
     assert metrics["feishu_update_failures"] == 0
     assert metrics["feishu_update_retries"] == 0
+
+
+async def test_message_started_passes_feishu_thread_id_to_send_card(client):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            conversation_id="omt_thread",
+            chat_id="oc_abc",
+        ),
+    )
+
+    assert started.status == 200
+    assert await started.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert feishu_client.sent[0][0] == "oc_abc"
+    assert feishu_client.sent[0][2] == "omt_thread"
+
+
+async def test_message_started_ignores_non_feishu_session_key_as_thread_id(client):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            conversation_id="agent:main:feishu:dm:oc_abc:omt_thread",
+            chat_id="oc_abc",
+        ),
+    )
+
+    assert started.status == 200
+    assert await started.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert feishu_client.sent[0][0] == "oc_abc"
+    assert feishu_client.sent[0][2] is None
 
 
 async def test_interaction_request_renders_buttons_and_callback_resolves(client):

--- a/tests/unit/test_feishu_client.py
+++ b/tests/unit/test_feishu_client.py
@@ -95,6 +95,23 @@ def test_build_message_payload_uses_thread_id_when_present():
     assert json.loads(payload["content"]) == card
 
 
+def test_build_message_payload_uses_chat_id_for_thread_reply():
+    cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
+    client = FeishuClient(cfg)
+    card = {"schema": "2.0", "header": {"title": "hello"}}
+
+    payload = client.build_message_payload(
+        "oc_abc",
+        card,
+        thread_id="omt_thread",
+        reply_to_message_id="om_user_message",
+    )
+
+    assert payload["receive_id"] == "oc_abc"
+    assert payload["msg_type"] == "interactive"
+    assert json.loads(payload["content"]) == card
+
+
 def test_build_message_payload_preserves_non_ascii_content():
     cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
     client = FeishuClient(cfg)

--- a/tests/unit/test_feishu_client.py
+++ b/tests/unit/test_feishu_client.py
@@ -83,6 +83,18 @@ def test_build_message_payload_serializes_card():
     assert json.loads(payload["content"]) == card
 
 
+def test_build_message_payload_uses_thread_id_when_present():
+    cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
+    client = FeishuClient(cfg)
+    card = {"schema": "2.0", "header": {"title": "hello"}}
+
+    payload = client.build_message_payload("oc_abc", card, thread_id="omt_thread")
+
+    assert payload["receive_id"] == "omt_thread"
+    assert payload["msg_type"] == "interactive"
+    assert json.loads(payload["content"]) == card
+
+
 def test_build_message_payload_preserves_non_ascii_content():
     cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
     client = FeishuClient(cfg)

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -165,8 +165,55 @@ def test_build_event_extracts_gateway_source_object():
 
     assert payload["event"] == "message.started"
     assert payload["chat_id"] == "oc_source"
-    assert payload["conversation_id"] == "session_source"
+    assert payload["conversation_id"] == "oc_source"
     assert payload["message_id"].startswith("hfc_")
+
+
+def test_build_event_uses_feishu_thread_id_as_conversation_id():
+    class ThreadSourceObject:
+        platform = "feishu"
+        chat_id = "oc_source"
+        thread_id = "omt_thread"
+
+    payload = hook_runtime.build_event(
+        "message.started",
+        {
+            "source": ThreadSourceObject(),
+            "session_id": "agent:main:feishu:dm:oc_source:omt_thread",
+        },
+    )
+
+    assert payload["chat_id"] == "oc_source"
+    assert payload["conversation_id"] == "omt_thread"
+
+
+def test_build_event_ignores_hermes_session_key_as_conversation_id():
+    payload = hook_runtime.build_event(
+        "message.started",
+        {
+            "chat_id": "oc_direct",
+            "session_id": "agent:main:feishu:dm:oc_direct:omt_thread",
+        },
+    )
+
+    assert payload["conversation_id"] == "oc_direct"
+
+
+def test_build_event_prefers_feishu_thread_over_hermes_conversation_key():
+    class ThreadSourceObject:
+        platform = "feishu"
+        chat_id = "oc_source"
+        thread_id = "omt_thread"
+
+    payload = hook_runtime.build_event(
+        "message.started",
+        {
+            "source": ThreadSourceObject(),
+            "conversation_id": "agent:main:feishu:dm:oc_source:omt_thread",
+        },
+    )
+
+    assert payload["conversation_id"] == "omt_thread"
 
 
 def test_build_event_uses_gateway_event_message_id_for_card_lifecycle():

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -448,6 +448,26 @@ def test_request_interaction_retries_when_sidecar_reports_not_applied(monkeypatc
     assert [payload["sequence"] for payload in posted] == [0, 1]
 
 
+def test_request_approval_denies_after_sidecar_interaction_timeout(monkeypatch):
+    monkeypatch.setattr(
+        hook_runtime,
+        "request_interaction_from_hermes_locals",
+        lambda *args, **kwargs: {
+            "ok": False,
+            "status": "timeout",
+            "interaction_id": "approval-1",
+        },
+    )
+
+    choice = hook_runtime.request_approval_choice_from_hermes_locals(
+        {"chat_id": "oc_abc", "message_id": "msg_1"},
+        {"command": "curl http://example.test | python3", "description": "Security scan"},
+        interaction_id="approval-1",
+    )
+
+    assert choice == "deny"
+
+
 def test_request_interaction_polls_through_transient_not_found(monkeypatch):
     polls = iter(
         [


### PR DESCRIPTION
## Summary

This fixes Feishu DM topic/thread card delivery so streaming cards are created and updated inside the active topic reply box instead of the main DM.

Key changes:
- Preserve Feishu thread metadata in sidecar events.
- Use the Feishu message reply API with `reply_in_thread=true` for topic replies.
- Prefer `reply_to_message_id` for topic card creation when available.
- Auto-start card sessions from streaming events that arrive before `message.started`.
- Add `/health` diagnostics for card action callbacks.

## Why

Feishu DM replies can carry a root/thread id. Sending cards with `receive_id_type=thread_id` does not work reliably with the real Feishu API. The correct behavior is to reply to the triggering message and set `reply_in_thread=true`, which keeps the card in the topic conversation.

The diagnostics addition makes card action callback failures visible via `/health.diagnostics.last_card_action` without exposing callback tokens.

## Tests

- `/Users/zack/.hermes/hermes-agent/venv/bin/python -m pytest tests/unit/test_feishu_client.py tests/unit/test_hook_runtime.py tests/integration/test_server.py tests/integration/test_feishu_client_http.py -q`
- `203 passed in 4.74s`