### PR TITLE
fix: Windows compatibility - process management and proxy bypass

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -558,13 +558,18 @@ async def _get_json(url: str, timeout: float) -> Any:
     return await loop.run_in_executor(None, _open_json_request, req, timeout)
 
 
+# Build a no-proxy opener so local sidecar calls bypass the system HTTP proxy.
+_NO_PROXY_HANDLER = request.ProxyHandler({})
+_NO_PROXY_OPENER = request.build_opener(_NO_PROXY_HANDLER)
+
+
 def _open_request(req: request.Request, timeout: float) -> None:
-    with request.urlopen(req, timeout=timeout) as response:
+    with _NO_PROXY_OPENER.open(req, timeout=timeout) as response:
         response.read()
 
 
 def _open_json_request(req: request.Request, timeout: float) -> Any:
-    with request.urlopen(req, timeout=timeout) as response:
+    with _NO_PROXY_OPENER.open(req, timeout=timeout) as response:
         body = response.read()
     if not body:
         return None

--- a/hermes_feishu_card/process.py
+++ b/hermes_feishu_card/process.py
@@ -152,10 +152,21 @@ def pid_is_running(pid: int) -> bool:
         return False
     except PermissionError:
         return True
+    except OSError:
+        # Windows: os.kill(pid, 0) raises OSError, not ProcessLookupError
+        import psutil
+        try:
+            psutil.Process(pid)
+            return True
+        except psutil.NoSuchProcess:
+            return False
     return True
 
 
 def stop_pid(pid: int) -> None:
+    if sys.platform == "win32":
+        _stop_pid_windows(pid)
+        return
     for sig in (signal.SIGTERM, signal.SIGKILL):
         try:
             os.killpg(pid, sig)
@@ -171,6 +182,20 @@ def stop_pid(pid: int) -> None:
             if not pid_is_running(pid):
                 return
             time.sleep(0.05)
+
+
+def _stop_pid_windows(pid: int) -> None:
+    import psutil
+    try:
+        proc = psutil.Process(pid)
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except psutil.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=3)
+    except psutil.NoSuchProcess:
+        return
 
 
 def pid_path() -> Path:


### PR DESCRIPTION
Two Windows compatibility fixes:

**process.py**: Replace POSIX-only process signals with psutil
- os.kill(pid,0) raises OSError instead of ProcessLookupError on Windows
- signal.SIGKILL and os.killpg() don't exist on Windows
- Use psutil for process status check and termination on Win32

**hook_runtime.py**: Bypass system HTTP proxy for localhost sidecar
- urllib.request.urlopen routes through system proxy, can't reach 127.0.0.1:8765
- Use ProxyHandler({}) opener to bypass proxy for localhost requests