### PR TITLE
[codex] streamline README and maintainer wiki

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,75 +1,84 @@
-# Agents Guide — hermes-feishu-streaming-card
+# AGENTS.md — hermes-feishu-streaming-card
 
-## What this is
+## Project
 
-A **sidecar-only** plugin that adds Feishu streaming card messages to
-[Hermes Agent](https://github.com/NousResearch/hermes-agent).  Patches
-Hermes's `gateway/run.py` at install time and runs a separate HTTP sidecar.
+Sidecar-only plugin for Hermes Agent Gateway Feishu/Lark streaming cards.
 
-Active source: `hermes_feishu_card/`.  **`legacy/` is V2 archive — never edit.**
+- Active source: `hermes_feishu_card/`
+- Tests: `tests/`
+- Public maintainer wiki: `docs/wiki/`
+- V2 archive: `legacy/` — do not edit unless explicitly asked.
 
-## Development commands
+The Hermes process should keep only minimal hook logic. Feishu/Lark delivery,
+card state, rendering, diagnostics, installer behavior, and release assets live
+in this repository.
+
+## Hard Rules
+
+- Do not edit an installed Hermes `gateway/run.py` by hand. Only
+  `hermes_feishu_card/install/patcher.py` may patch Hermes.
+- Do not commit secrets: Feishu App Secret, tenant token, real chat id, local
+  `.env`, or screenshots with private/unredacted content.
+- Keep hook behavior fail-open for unknown/unsupported paths, but suppress
+  duplicate Feishu native gray text after this plugin has accepted a card path.
+- `legacy/` is not active runtime.
+- User-facing conversation with Bailey is Chinese. Code identifiers, filenames,
+  tool names, and protocol names stay in English.
+
+## Commands
 
 ```bash
-pip install -e ".[test]"               # from repo root
-python -m pytest -q                     # full suite (CI runs exactly this)
-python -m pytest tests/unit/test_config.py::test_load_defaults -q  # one test
+python -m pytest -q
+python -m pytest tests/unit/test_docs.py -q
+python -m pytest tests/unit/test_package_metadata.py -q
+python -m hermes_feishu_card.cli doctor --config config.yaml.example --hermes-dir ~/.hermes/hermes-agent --explain
 ```
-No linter, typechecker, or formatter configured.  CI workflow = `pytest -q`.
 
-## Never edit Hermes directly
+No formatter, linter, or typechecker is configured. CI is pytest-based.
 
-The **patcher** (`install/patcher.py`) is the only code that touches
-`gateway/run.py`.  It uses AST parsing to find `_handle_message_with_agent`,
-inserts 5 marker-wrapped hook blocks, creates SHA256 manifests and backups.
-Corrupt markers → `ValueError("corrupt patch markers")`.  Changed files →
-refuses restore.
+## Change Routing
 
-## Hook runtime uses `locals()` — fragile
+Read `docs/wiki/maintenance-guide.md` before touching these hot areas:
 
-`hook_runtime.py` functions extract data from the caller's `locals()` dict.
-Field names in `build_event()` / `_event_data()` **must match Hermes variable
-names**: `source`, `event`, `response`, `agent_result`, `_response_time`,
-`event_message_id`, `_loop_for_step`, `_run_still_current`.  If Hermes
-renames these, the hook breaks silently.
+- `hermes_feishu_card/hook_runtime.py`
+- `hermes_feishu_card/server.py`
+- `hermes_feishu_card/install/patcher.py`
+- installer scripts, Docker install, release workflow
 
-## Sidecar is ephemeral
+Use these wiki pages for context:
 
-`CardSession` objects live in `request.app[SESSIONS_KEY]` (plain dict keyed
-by `_session_key(event)` in multi-profile mode, `message_id` otherwise).  No
-persistence.  Each session has its own `asyncio.Lock`.  Terminal events
-retry 3× with exponential backoff (1s, 2s, 4s).  Non-terminal update failures
-are silently ignored (next event retries).
+- `docs/wiki/README.md` — maintainer wiki entry
+- `docs/wiki/maintenance-guide.md` — hot files, risk boundaries, test matrix
+- `docs/wiki/event-flow.md` — Hermes event to Feishu card lifecycle
+- `docs/wiki/feishu-acceptance.md` — real Feishu/Lark smoke checklist
+- `docs/wiki/release-playbook.md` — release checklist
 
-## Message ID fallback — don't touch
+## Testing Expectations
 
-Hermes doesn't always provide `message_id`.  The system in
-`hook_runtime.py` (`_fallback_message_id`, `_ACTIVE_FALLBACK_MESSAGE_IDS`,
-`created_at_lifecycle_token`) handles dedup across parallel sessions.  Don't
-simplify it unless you fully understand the lifecycle race conditions.
+Run focused tests while developing, then full suite before release or broad
+claims.
 
-## Key constraints
+- Runtime/topic/notice changes:
+  `python -m pytest tests/unit/test_hook_runtime.py tests/integration/test_server.py -q`
+- Patcher/install changes:
+  `python -m pytest tests/unit/test_patcher.py tests/integration/test_cli_install.py -q`
+- Docs/version changes:
+  `python -m pytest tests/unit/test_docs.py tests/unit/test_package_metadata.py -q`
+- Release gate:
+  `python -m pytest -q && git diff --check`
 
-- Hermes ≥ `v2026.4.23` (checked by `detect_hermes()`)
-- `gateway/run.py` must not be a symlink
-- `UPDATE_MIN_INTERVAL_SECONDS = 0.5` in `server.py`
-- Tenant token cached for `expire - 60` seconds
-- `hermes_feishu_card` must be importable inside Hermes's Python environment
+## Release Checklist
 
-## 语言约定
+1. Bump `pyproject.toml` and `hermes_feishu_card/__init__.py`.
+2. Update `CHANGELOG.md`, `docs/release-notes-vX.Y.Z.md`, README files, and
+   affected docs/wiki pages.
+3. Run full tests and `git diff --check`.
+4. Commit, create annotated tag, push branch and tag.
+5. Ensure GitHub Release exists and release-assets workflow uploaded packages.
 
-思考输出用中文。字段名、变量名、函数名、专用名词、工具名保持英文。
+## Obsidian / LLM Wiki
 
-## Release checklist
+Project-public knowledge belongs in `docs/wiki/`.
 
-1. Bump version in `pyproject.toml` and `hermes_feishu_card/__init__.py`
-2. Update `CHANGELOG.md`, `README.md`, `README.en.md`, `config.yaml.example`, `TODO.md`
-3. `python -m pytest -q` → must be all green
-4. `git tag -a vX.Y.Z` AND `gh release create vX.Y.Z` — **both required**, not just tag
-5. GitHub Release notes from CHANGELOG with `## VX.Y.Z — YYYY-MM-DD`
-
-## Doc test warning
-
-`tests/unit/test_docs.py` uses **exact string matching** (including `。`).  If
-you change `TODO.md`, verify every string the tests assert on still exists.
-Otherwise 5 doc tests fail and you'll waste time hunting Chinese punctuation.
+When adding durable project knowledge, update both the repo wiki and Bailey's
+Obsidian LLM Wiki mirror if it should be reusable across future Codex sessions.

--- a/README.en.md
+++ b/README.en.md
@@ -14,228 +14,32 @@
 
 ![Hermes Feishu Streaming Card cover](docs/assets/readme-cover.png)
 
-Hermes Feishu Streaming Card turns Hermes Agent Gateway replies in Feishu/Lark into one continuously updated interactive card. Reasoning, tool calls, final answers, approvals, choices, and runtime stats stay in one readable card instead of spilling into scattered native text messages.
+Hermes Feishu Streaming Card turns Hermes Agent Gateway replies in Feishu/Lark into one continuously updated interactive card. Reasoning, tool calls, final answers, approvals, choices, system notices, and runtime stats stay inside cards instead of spilling into scattered native gray text messages.
 
-It targets the real pain points of using Hermes inside Feishu: missing or out-of-order streaming text, long tables/code blocks rendered as raw Markdown, invisible tool progress, manual approval replies, sidecar troubleshooting, multi-bot/profile routing, and uncertain hook compatibility after Hermes upgrades.
+It targets the real pain points of running Hermes inside Feishu: missing or out-of-order streaming text, long tables/code blocks rendered as raw Markdown, invisible tool progress, manual approval replies, frozen topic timelines, multi-bot/profile troubleshooting, and uncertain hook compatibility after Hermes upgrades.
 
-![Hermes Feishu card slash command interaction, command result feedback, and tool timeline showcase](docs/assets/feishu-card-showcase-v385.png)
+![Hermes Feishu card command interaction, command result feedback, and tool timeline showcase](docs/assets/feishu-card-showcase-v385.png)
 
-Since V3.8.2, the final answer stays in the primary content area while pre-tool answer blocks follow a "show in main body -> archive when the next block arrives" rhythm. Reasoning and tools use different text sizes and visual weight inside the collapsible auxiliary timeline, and the footer no longer repeats the same tool-call summary.
+## What You Get
 
-## Project Highlights
+- **One continuously updated Feishu card**: `thinking.delta`, `answer.delta`, `tool.updated`, and `message.completed` merge into one card.
+- **Primary answer and process timeline**: the final answer stays in the main content area while pre-tool answers, tool calls, and system notices move into the "Reasoning and Tools" timeline.
+- **In-card interactions**: approval and clarify choices render as buttons; standalone commands such as `/new`, `/reset`, `/undo`, and `/model` use native interactive cards.
+- **Consistent topic replies**: later topic stream events resolve by `reply_to_message_id` and keep updating the original card; system notices no longer spill out as duplicates.
+- **Long content protection**: long Markdown tables and fenced code blocks split on structure boundaries instead of raw character cuts.
+- **Diagnostics and recovery**: `doctor`, `/hfc status`, `/health` metrics, runtime import checks, and safe repair/restore/uninstall cover common failures.
 
-- **Streaming card UX**: `thinking.delta`, `answer.delta`, `tool.updated`, and terminal events update one Feishu card.
-- **In-card interactions**: Hermes approval and clarify choices prefer Feishu buttons. Since V3.8.5, Feishu/Lark WebSocket long-connection deployments also render independent slash-command confirmations, pickers, and execution results such as `/new`, `/reset`, and `/model` as native interactive cards, falling back to Hermes native text only when cards are unavailable.
-- **Runtime notices stay tidy**: Since V3.8.8, native Hermes `Working` heartbeats, context/compression notices, automatic session resets, skill loading, and self-improvement reviews prefer cards or compact notice cards instead of scattered gray native text.
-- **Consistent topic replies**: Since V3.8.9, Feishu/Lark topic reply streams and system notices resolve back to the same card, avoiding frozen topic timelines and duplicate gray native notices.
-- **Long content protection**: Markdown tables and fenced code blocks split on structure boundaries instead of raw character cuts.
-- **Multi-bot / multi-profile**: bot registry, chat bindings, profile-aware session keys, titles, and routing diagnostics.
-- **sidecar-only runtime**: Hermes hook stays fail-open while Feishu delivery, session state, retries, and health checks live in the sidecar.
-- **Install and release friendly**: one-line installers, Release packages, `doctor`, `start/status/stop`, and safe restore/uninstall flows.
+## Problems Solved
 
-## Pain Points Solved
-
-| Pain point | Project capability |
+| Problem | What the plugin does |
 |---|---|
-| Feishu only shows a final wall of text | Reasoning, answer, tool status, and runtime footer stream into one card |
-| Tool-heavy runs lose text, reorder chunks, or spill native gray messages | per-message ordering, PATCH coalescing, terminal priority, and native resend suppression |
-| Hermes emits separate gray `Working`, context, skill loading, or review notices | `system.notice` cardification: session notices enter the auxiliary timeline; task-external notices use compact standalone cards |
-| Topic replies show the first card but the timeline stops updating, while notices also appear outside the card | Topic events resolve by `reply_to_message_id`, keeping updates on the original card and suppressing duplicate native notice text |
-| Approval, choice prompts, or slash-command confirmations require manual text replies | Agent-turn choices stay in the active card; independent slash commands use standalone command cards, with numbered text fallback when cards are unavailable |
-| Long tables/code blocks render as raw Markdown | Markdown-aware table/code splitting with repeated headers and complete fences |
-| Multi-bot, group, and profile routing is hard to inspect | `bindings.chats`, profile-aware sessions, and `/health.routing` diagnostics |
-| Hook or sidecar failures are hard to debug | `doctor`, runtime import checks, `/health` metrics, fail-closed installer, restore/uninstall |
-
-## V3.8.9 Feishu Topic Card Continuity Patch
-
-V3.8.9 fixes Feishu/Lark topic reply flows where the first card appears, but later `answer.delta`, `thinking.delta`, `tool.updated`, or `system.notice` events can miss the same card because Hermes switches to a different internal streaming `message_id`. In that state, system notices can also appear both inside the card timeline and as separate gray native messages.
-
-- **One card keeps updating inside the topic**: the sidecar maps later topic events back to the active card session through `reply_to_message_id`.
-- **No duplicate gray notices after cardification**: when a session-scoped `system.notice` is accepted into the card, the sidecar returns `applied: true`; if card delivery briefly times out, recognized Hermes system notices are still suppressed instead of being resent as gray native text.
-- **Hermes v0.18.x Relay metadata support**: the hook runtime preserves Relay `source.message_id` as the original topic reply anchor.
-
-![Feishu topic reply card continuity and reasoning/tool timeline showcase](docs/assets/feishu-topic-card-showcase-v389.png)
-
-The screenshot above shows a real Feishu topic verification: the topic reply pane keeps the card updating, the reasoning/tool timeline, final answer, and footer stats stay on the same card. Context and self-improvement notices enter cards or compact standalone cards instead of spilling out as extra gray native messages.
-
-Full release notes: [docs/release-notes-v3.8.9.md](docs/release-notes-v3.8.9.md).
-
-## V3.8.8 Hermes Native System Notice Cardification
-
-V3.8.8 folds native Hermes gray runtime notices into the Feishu/Lark card experience. `Working` heartbeats, context-window/compression notices, automatic session resets, skill loading, and self-improvement review messages are classified as `system.notice`. If the active task card can still update, the notice goes into the auxiliary "Reasoning and Tools" timeline; otherwise it is sent as a compact standalone notice card.
-
-- **Fewer scattered gray notices**: context, compression, reset, skill-loading, and review messages prefer card delivery.
-- **Heartbeats update one entry**: `Working — iteration ...` notices reuse the same `notice_id`, avoiding repeated timeline spam.
-- **Still fail-open**: if the sidecar is unavailable, the notice is unknown, or card delivery fails, Hermes native text fallback still runs.
-
-Full release notes: [docs/release-notes-v3.8.8.md](docs/release-notes-v3.8.8.md).
-
-## V3.8.7 Newer Hermes First-Event Compatibility Patch
-
-V3.8.7 fixes issue #75: some newer Hermes streams can start directly with `answer.delta`, `thinking.delta`, `tool.updated`, or `message.completed` instead of sending `message.started` first. Older sidecar versions had no session yet, counted those events as `events_ignored`, and never sent the initial Feishu/Lark card. These message events can now create the card session and send the first card.
-
-- **No hard dependency on `message.started`**: answer, thinking, tool, and completed first events can all start a card.
-- **Existing paths remain compatible**: normal `message.started`, interaction, cron completion, and terminal diagnostics behavior is preserved.
-- **Stacks with V3.8.6**: Docker/source-stripped Hermes roots without `VERSION` still use Gateway anchor fallback.
-
-Full release notes: [docs/release-notes-v3.8.7.md](docs/release-notes-v3.8.7.md).
-
-## V3.8.6 Docker / Hermes v0.18.0 Compatibility Patch
-
-V3.8.6 fixes the issue #70 Docker install path. Upstream Hermes v0.18.0 / `v2026.7.1` can be deployed without a top-level `VERSION` file, and container images often omit local `.git` metadata too. `doctor --explain`, `install`, and `setup` now continue by reading verified `gateway/run.py` anchors; when those anchors match, the installer uses `gateway_run_013_plus` instead of failing with `Hermes VERSION missing, unknown, or invalid`.
-
-- **Hermes v0.18.0**: `v2026.7.1`, `0.18.0`, and `v0.18.0` are in the compatibility matrix and keep using `gateway_run_013_plus`.
-- **Docker no-VERSION fallback**: diagnostics report `version_source: gateway anchors`, `version: unknown`, and the inferred `hook_strategy`.
-- **Explicit bad versions still fail closed**: only missing metadata falls back to anchors; invalid `VERSION` contents still block install.
-
-Full release notes: [docs/release-notes-v3.8.6.md](docs/release-notes-v3.8.6.md).
-
-## V3.8.5 Command Result Card Feedback Patch
-
-V3.8.5 completes the V3.8.4 always-allowed/no-confirm path. When Hermes directly executes `/new`, `/reset`, `/clear`, `/undo`, `/stop`, or direct `/model <model>`, the command result now replies as a Feishu/Lark interactive card instead of gray native text. `/model` switch feedback stays in a green card, while `/update` remains Hermes' background upgrade command and does not render an interaction card.
-
-- **Direct command results become cards**: the patcher passes the current `event` into hook runtime, so Feishu adapter `send()` can recognize standalone slash-command results.
-- **Cleaner interactive updates**: button and dropdown clicks rely on the Feishu callback response to update the original card, without an extra unsupported interactive `message.update` call.
-- **Upgrade compatible**: rerunning `install` rewrites the V3.8.4 command-card hook block into the V3.8.5 `event=event` form.
-
-Full release notes: [docs/release-notes-v3.8.5.md](docs/release-notes-v3.8.5.md). The previous WebSocket-native command-card hotfix is documented in [docs/release-notes-v3.8.4.md](docs/release-notes-v3.8.4.md).
-
-## V3.8.4 Feishu WebSocket Command Cards Hotfix
-
-V3.8.4 fixes the V3.8.3 local/private sidecar gap where slash commands still fell back to gray native text. Confirmations for `/new`, `/reset`, and `/undo` now reuse Hermes' Feishu adapter WebSocket card-action channel to send native interactive cards; `/model` uses the same native card path for model selection. Active Agent streaming cards still own approval, clarify, conversation choices, and reasoning/tool timelines; slash commands do not get merged into an unrelated Agent card.
-
-- **WebSocket-native confirmation cards**: the plugin dynamically installs Feishu adapter `send_slash_confirm(...)`, and button clicks route through `_on_card_action_trigger` into `tools.slash_confirm.resolve(...)`.
-- **WebSocket-native model picker**: when Hermes asks the Feishu adapter for `send_model_picker(...)`, the plugin installs a Feishu-only picker and writes the callback result back to the same command card.
-- **No duplicate choice cards**: when WebSocket-native command cards are available, the sidecar pre-interaction is skipped so `/new` does not show both a sidecar choice card and a native button card.
-- **No `/update` interaction card**: `/update` remains Hermes's background upgrade command and does not render interactive buttons.
-- **Safe fallback**: if native Feishu cards, the sidecar, polling, or completion updates fail, Hermes native text behavior remains available.
-
-Full release notes: [docs/release-notes-v3.8.4.md](docs/release-notes-v3.8.4.md). The previous standalone command-card baseline is documented in [docs/release-notes-v3.8.3.md](docs/release-notes-v3.8.3.md).
-
-## V3.8.2 Card Timeline Readability Patch
-
-V3.8.2 focuses on the real Feishu reading experience inside the auxiliary timeline. Natural-language pre-tool answer blocks stay in the main body until the next pre-tool answer or terminal event arrives, then move into "Reasoning and Tools"; terminal cards strip already archived intermediate prefaces so the primary content keeps only the final answer.
-
-- **Delayed pre-tool answer folding**: a pre-analysis block no longer flashes away immediately; it is archived only when the next block or terminal state arrives.
-- **Cleaner terminal cards**: completed cards remove archived preface text when the final answer already contains it.
-- **Clearer timeline hierarchy**: reasoning entries use small primary text, while tool details use smaller, lighter quoted text so long commands do not dominate the answer.
-- **Raw thinking stays hidden**: low-level `thinking.delta` remains internal stream state; the timeline only shows user-readable pre-tool answer text.
-
-Full release notes: [docs/release-notes-v3.8.2.md](docs/release-notes-v3.8.2.md).
-
-## V3.8.1 High-Frequency Streaming and In-Feishu Diagnostics Patch
-
-V3.8.1 fixes issue #74. With Hermes Agent 0.17.0+, thinking models, long context, and token-by-token high-frequency deltas, the hook now coalesces `thinking.delta` / `answer.delta` inside the Hermes Gateway process before sending fewer events to the sidecar. This reduces object allocation, lock contention, and HTTP scheduling pressure on the stream-reader thread, avoiding `Stream stale for 180s` failures caused by the plugin path.
-
-- **Gateway-side delta coalescing**: adds `HERMES_FEISHU_CARD_DELTA_COALESCE_MS`, `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS`, and `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING`; defaults work without extra config.
-- **Flush before terminal state**: `message.completed` / `message.failed` flush pending deltas for the same message before rendering the terminal card.
-- **Read-only commands inside Feishu**: `/hfc help`, `/hfc status`, `/hfc doctor`, and `/hfc monitor` reply with diagnostic cards and do not perform write actions.
-- **Safer diagnostics**: `/messages/{message_id}/summary` and `/hfc` cards expose hashed chat/message/thread context instead of raw ids.
-
-Full release notes: [docs/release-notes-v3.8.1.md](docs/release-notes-v3.8.1.md).
-
-## V3.8.0 Card UX and Streaming Stability Upgrade
-
-V3.8.0 focuses on the real Feishu reading experience. The final answer remains in the main content area, reasoning / tool timeline data moves into the auxiliary area, and terminal rendering drains pending updates before writing the final card.
-
-- **Clearer primary answer**: long reasoning and tool lists no longer push the final response out of the main reading area.
-- **Less duplication**: when the auxiliary timeline is visible, the footer does not render another "N tool calls" summary.
-- **More stable terminal state**: pending card updates are drained before the terminal card render so stale intermediate snapshots do not win the last PATCH.
-- **More accurate diagnostics**: `doctor` runs the Hermes runtime import check from the Hermes project root, avoiding false positives from the current repository path.
-- **Docker examples updated**: V3.8.0 refreshed the Docker install examples while still using `install-docker.sh` inside existing Hermes containers.
-
-Full release notes: [docs/release-notes-v3.8.0.md](docs/release-notes-v3.8.0.md).
-
-## V3.6.6 Interrupt Dedupe and Install Diagnostics Patch
-
-V3.6.6 fixes issues #67 and #68. `message.completed` now uses the sidecar `applied` response to decide whether the card path really took ownership, and terminal events no longer wait for slow Feishu PATCH calls before ACKing Hermes. This prevents interrupted or backlogged sessions from producing both a streaming card and a native gray text reply. `doctor --explain` / `install` also detect a wrong `--hermes-dir` by reading the `Project:` path from `hermes -V` and suggesting the correct Hermes root.
-
-Full release notes: [docs/release-notes-v3.6.6.md](docs/release-notes-v3.6.6.md).
-
-## V3.7.0 Docker Deployment Adapter
-
-V3.7.0 adds issue #70: existing Hermes Docker container upgrade and install support.
-
-Full release notes: [docs/release-notes-v3.7.0.md](docs/release-notes-v3.7.0.md).
-
-## V3.6.5 Streaming Terminal Stability Patch
-
-V3.6.5 fixes issues #64 and #65. In Feishu thread scenarios, `message.started` now uses the same reply anchor as streaming callbacks for the card session `message_id`, preventing `events_applied=0`. For burst-output models such as DeepSeek, completed events can now backfill the final answer from `message.completed` / `agent_result.final_response` even when no `thinking.delta` or `answer.delta` events were emitted.
-
-Full release notes: [docs/release-notes-v3.6.5.md](docs/release-notes-v3.6.5.md).
-
-## V3.6.4 Thread Reply and Cron Delivery Patch
-
-V3.6.4 fixes issues #61 and #62. When a user sends a message from a Feishu thread, the initial streaming card is now sent back into the same thread through the Feishu reply API and subsequent updates keep patching that card. Cron jobs configured with `deliver: "feishu:oc_xxx"` now parse the chat id from `deliver`, so scheduled jobs can render as cards instead of falling back to plain text.
-
-Full release notes: [docs/release-notes-v3.6.4.md](docs/release-notes-v3.6.4.md).
-
-## V3.6.3 Hermes v0.17 Compatibility and Interaction Patch
-
-V3.6.3 fixes issues #56-#59. For Hermes v0.17.0+ / `v2026.6.19+`, where the real streaming implementation can move into `_run_agent_inner`, the patcher now injects `tool.updated`, `answer.delta`, `thinking.delta`, clarify, and approval hooks into `_run_agent_inner` before falling back to `_run_agent`.
-
-localhost/private sidecars keep numbered text fallback for sidecar-owned choices, while V3.8.5 uses the Feishu/Lark WebSocket long-connection card-action path for native slash/model command cards. Those standalone commands do not require a public HTTP callback, and direct command execution results also stay in cards.
-
-This release also ignores non-Feishu platforms such as Telegram at runtime event construction, and correctly resolves Windows profile paths like `C:\Users\...\AppData\Local\hermes\profiles\thinking`.
-
-Full release notes: [docs/release-notes-v3.6.3.md](docs/release-notes-v3.6.3.md).
-
-## V3.6.2 Runtime Install Patch
-
-V3.6.2 fixes issue #53: `setup` / `install` now detects the Python interpreter that Hermes Gateway actually runs from, such as `~/.hermes/hermes-agent/venv/bin/python`, and installs the same `hermes-feishu-streaming-card` release into that runtime venv before patching `gateway/run.py`.
-
-`doctor --explain` and `doctor --json` now include a `runtime_import` check for `hermes_feishu_card.hook_runtime`. Hook import/emit failures also remain fail-open but are no longer fully silent; Hermes stderr gets a `[hermes-feishu-card] hook failed: ...` diagnostic warning.
-
-Full release notes: [docs/release-notes-v3.6.2.md](docs/release-notes-v3.6.2.md).
-
-## V3.6.1 Compatibility Patch
-
-V3.6.1 fixes issue #47: Hermes `VERSION` values without a leading `v`, such as `0.15.1`, are no longer reported as unsupported by `doctor --explain`. Hermes `0.15.x` / `v0.15.x` continues to use `gateway_run_013_plus` when the required `gateway/run.py` anchors are present.
-
-Full release notes: [docs/release-notes-v3.6.1.md](docs/release-notes-v3.6.1.md).
-
-## V3.6.0 Operations Upgrade
-
-V3.6.0 focuses on real deployment operations after the streaming-card baseline is already in place: diagnosing hook/sidecar/Hermes state, repairing safe installer drift, keeping media/file delivery visible, and making multi-profile routing easier to verify.
-
-- **Readable and machine-readable diagnostics**: `doctor --explain` summarizes the next action for humans, while `doctor --json` reports config, sidecar, Hermes, streaming, install state, and recommendations.
-- **Safe installer repair**: `repair --hermes-dir ... --yes` and `setup --repair` rebuild only verifiable manifest/backup state and refuse unverifiable user edits.
-- **Media/file safety**: structured Hermes `attachments`, `files`, `media_files`, and image/audio/video objects are summarized in cards while native Hermes media/file delivery remains unsuppressed.
-- **Multi-profile operations**: `smoke-feishu-card --profile-id`, `bots test --profile-id`, CLI `status`, and `/health.routing.profiles` expose profile-scoped routing state.
-- **Compatibility matrix**: tests cover Hermes `v2026.4.23`, `v2026.5.7`, `v2026.5.16+`, `v2026.5.29`, `v2026.6.19+`, `v2026.7.1+`, `0.13.x`, `0.14.x`, `0.15.x`, `0.17.x`, `0.18.x`, and semver `VERSION` values with or without a `v` prefix.
-
-Full release notes: [docs/release-notes-v3.6.0.md](docs/release-notes-v3.6.0.md).
-
-## V3.5.x Runtime Baseline
-
-- **End-to-end ordering for one card**: runtime sends, sidecar updates, and terminal Feishu PATCH calls are ordered/coalesced by message id, reducing thinking/answer truncation under backlog.
-- **Faster streaming updates**: sidecar events ACK quickly while card updates are coalesced; terminal events prioritize the final card update in the background.
-- **Feishu JSON 2.0 buttons fixed**: interaction buttons now use direct `button` elements with `behaviors.callback`, avoiding PATCH failures in active cards.
-- **Queued follow-up native text suppression**: queued completions emit `message.completed` into the card path and suppress native resend once the Feishu card is delivered.
-- **`.env` credential fallback**: `load_config()` reads `.env` next to the selected config file, so manual sidecar restarts do not silently enter no-op mode when credentials live beside Hermes config.
-- **Chinese README homepage reorganized**: the homepage leads with user scenarios, V3.5.x value, installation, troubleshooting, and release history.
-- **V3.6.0 operations polish**: profile-targeted smoke checks, routing profile diagnostics, structured attachment summaries, and safe repair build on the V3.5.x baseline.
-
-## V3.5.0 Feature Highlights
-
-- **Feishu button interaction loop**: Hermes approval and choice prompts are rendered inside the same streaming card; clicking a button records the choice in the sidecar, lets the Hermes hook continue, and updates the original card.
-- **issue #41 fixed**: multi-reply and newer Hermes streaming flows keep using card updates, so final answers no longer fall back to native text after the first reply.
-- **PR #42 handled**: cron card routing now prefers `job['deliver']` and scheduler-resolved Feishu targets, so jobs migrated from Discord/Telegram are not skipped because of stale `origin.platform`.
-- **Long table/code protection improved**: a single Markdown table or fenced code block longer than `MAIN_CONTENT_CHUNK_CHARS` is split into multiple still-valid Markdown blocks instead of raw fragments.
-- **thinking truncation fixed**: Hermes interim assistant callbacks are treated as complete thinking blocks via `thinking.delta(mode=append_block)`, preventing missing characters or glued sentences.
-- **Hermes `v0.14.0` / `v2026.5.16+` support remains verified**: the installer selects `gateway_run_013_plus`; `v2026.4.x` remains on `legacy_gateway_run`.
-- **issue #39 fixed**: whitespace-only `message.completed.answer` values no longer clear answers already streamed through `answer.delta`, preventing DeepSeek V4 Pro tool-call flows from ending with an empty Feishu card.
-- **issue #31 fixed**: PATCH updates for the same Feishu card are serialized per session, preventing older snapshots from landing after newer content and making thinking/answer text flicker, truncate, or roll back.
-- **safer concurrent event sequences**: runtime sequence allocation is locked so concurrent Hermes callbacks cannot produce duplicate sequence ids for valid `thinking.delta` / `answer.delta` chunks.
-- **issue #25 fixed**: Hermes v2026.5.7 started hooks now treat `event_message_id` as the explicit `message_id`, preventing `message.started` and `message.completed` fallback card ids from diverging.
-- **Hermes 0.13.0+/0.14.0 and later**: the installer selects the `gateway_run_013_plus` hook strategy from the Hermes version and code anchors.
-- **older Hermes remains supported**: Hermes `v2026.4.23` through `0.12.x` continues to use the `legacy_gateway_run` strategy; no plugin downgrade is required.
-- **doctor reports compatibility**: `doctor` prints `hook_strategy`, `compatibility`, and anchor detection results so you can confirm the selected path.
-- **Reinstall the hook after upgrading**: run `install --hermes-dir ... --yes` after upgrading so Hermes uses the matching hook implementation.
-- **issue #23 fixed**: multi Hermes profile + multi Feishu bot deployments explicitly identify profile ids and route to the matching bot.
-- **Multi-profile / multi-bot polish**: per-bot/profile title, cron final cards, attachment summaries + native media delivery, and reply card context.
-
-## One-Line Install
+| Feishu only shows a final wall of text | Streams reasoning, answer, tool status, and footer stats into one card |
+| Hermes emits separate `Working`, compression, skill loading, or review messages | Classifies them as `system.notice` and routes them into the active card or a compact notice card |
+| Topic replies show the first card but the timeline stops updating | Anchors topic events with `source.message_id` / `reply_to_message_id` |
+| Approval, choices, and model switching require manual numbered replies | Uses Feishu buttons or dropdowns first, then falls back to text when cards are unavailable |
+| Hermes upgrades make hook compatibility unclear | `doctor --explain` reports `version_source`, `hook_strategy`, `compatibility`, anchors, and recommendations |
+
+## Quick Install
 
 macOS / Linux:
 
@@ -249,114 +53,26 @@ Windows PowerShell:
 irm https://raw.githubusercontent.com/baileyh8/hermes-feishu-streaming-card/main/install.ps1 | iex
 ```
 
-The installer installs or upgrades the package, reads or prompts for Feishu credentials, writes `~/.hermes/.env`, and runs the integrated setup command:
+The installer installs or upgrades the plugin, reads or prompts for Feishu credentials, writes a local `.env`, and runs the integrated setup command:
 
 ```bash
-python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --config ~/.hermes/config.yaml --yes
+python3 -m hermes_feishu_card.cli setup \
+  --hermes-dir ~/.hermes/hermes-agent \
+  --config ~/.hermes/config.yaml \
+  --yes
 ```
 
-After installation:
+Check the sidecar after install:
 
 ```bash
 python3 -m hermes_feishu_card.cli status --config ~/.hermes/config.yaml
 ```
 
-Common environment variables:
+For Release packages, Docker, PEP 668, uv, and installer details, see [README-install.md](README-install.md) and the [full user guide](docs/user-guide.en.md).
 
-| Variable | Default | Description |
-|---|---|---|
-| `HFC_VERSION` | `latest` | Version to install, such as `v3.8.9`, `v3.6.6`, or `main` |
-| `HERMES_DIR` | `~/.hermes/hermes-agent` | Hermes Agent Gateway directory |
-| `HFC_CONFIG` | `~/.hermes/config.yaml` | sidecar config path |
-| `HFC_ENV_FILE` | `.env` next to `HFC_CONFIG` | Feishu credential file |
-| `HFC_SKIP_START` | `0` | Set to `1` to install the hook without starting sidecar |
-| `HFC_NO_PROMPT` | `0` | Set to `1` for non-interactive automation |
+## Minimal Config
 
-High-frequency streaming knobs usually do not need manual tuning:
-
-| Variable | Default | Description |
-|---|---|---|
-| `HERMES_FEISHU_CARD_DELTA_COALESCE_MS` | `250` | Maximum Gateway-runtime wait before flushing coalesced deltas; set `0` to disable |
-| `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS` | `600` | Flush immediately once pending deltas reach this character count |
-| `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING` | `128` | Maximum pending delta sessions kept in Gateway runtime |
-
-## Docker Containers
-
-Use `install-docker.sh` inside an existing Hermes container. It defaults to
-`/opt/hermes` for Hermes and `/opt/data/config.yaml` for sidecar config. The
-script selects Hermes venv Python and does not fall back to system Python unless
-`HFC_PYTHON` is set.
-
-Example:
-
-```bash
-export FEISHU_APP_ID=cli_xxx
-export FEISHU_APP_SECRET=xxx
-export HFC_VERSION=v3.8.9
-bash install-docker.sh
-```
-
-GitHub Releases also include `hermes-feishu-card-<version>-macos.tar.gz`, `hermes-feishu-card-<version>-linux.tar.gz`, and `hermes-feishu-card-<version>-windows.zip`. Download one, extract it, and run `install.sh` or `install.ps1`. See [README-install.md](README-install.md) for package details.
-
-## Manual Install
-
-```bash
-git clone https://github.com/baileyh8/hermes-feishu-streaming-card.git
-cd hermes-feishu-streaming-card && pip install -e ".[test]"
-export FEISHU_APP_ID=cli_xxx FEISHU_APP_SECRET=xxx
-python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --yes
-```
-
-`setup` generates config, validates Hermes (older Hermes from `v2026.4.23` through `v2026.4.x`, plus Hermes `0.13.0+`, `0.14.0`, `0.15.x`, `0.17.x`, `0.18.x` / `v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` anchors), installs the package into the Hermes Gateway runtime venv Python, installs the hook, starts the sidecar, and checks health — all in one pass. Hermes semantic `VERSION` values may include or omit the `v` prefix. Since V3.8.6, Docker/source-stripped installs without `VERSION` or `.git` metadata can fall back to verified `gateway/run.py` anchors.
-
-## Core Features
-
-- **Multi-profile in-process** (new in V3.3.0): one sidecar serves multiple Hermes profiles with `profile_id:message_id` composite keys for session isolation and per-profile credentials/bot routing
-- **Multi-bot routing & group chat**: register bots in `bots.items`, map `bindings.chats` to `chat_id`, fallback/default bot for unmatched sessions
-- **Profile / bot card titles**: global, profile, and bot card titles are supported, with bot-level titles taking precedence
-- **Streaming thinking**: renders `thinking.delta`, filters `<think>`/`</think>` and DeepSeek `<thinking>`/`</thinking>` tags
-- **Progressive answer**: streams `answer.delta` into one card, replaces thinking on completion
-- **Approval/choice interactions**: Hermes approval, clarify choices, and independent slash commands prefer Feishu button cards; when unavailable they fall back to numbered/text choices and Hermes' native text reply path
-- **Cron final cards and reply context**: cron jobs can deliver final cards, and reply cards preserve the needed context
-- **Attachment summaries and native media delivery**: cards show attachment summaries while the hook keeps Hermes native media/file delivery paths unsuppressed
-- **Tool call tracking**: `tool.updated` shows cumulative call count and status
-- **Runtime footer**: duration, model, tokens, context %. Non-terminal cards show a rotating braille spinner
-- **Table limit protection** (new in V3.3.0): auto-truncates tables exceeding Feishu's 5-table limit with a notice appended
-- **Platform check fix** (new in V3.3.0): non-Feishu platforms no longer swallowed by the complete hook
-- **Fault isolation**: sidecar unavailable → Hermes hook fail-open, native text continues working
-- **Safe installer**: fail-closed, checks version and code structure before writing. `restore`/`uninstall` refuse on modified files
-
-## Upgrading
-
-Upgrading from V3.2.x/V3.3.0/V3.4.x/V3.5.x/V3.6.x/V3.7.x/V3.8.0/V3.8.1/V3.8.2/V3.8.3/V3.8.4/V3.8.5/V3.8.6/V3.8.7/V3.8.8 to V3.8.9 is backward-compatible. **Single-profile configs need no changes.** If Hermes uses its own venv, rerun `setup` or `install` after upgrading so the package also lands in the Hermes runtime Python and the hook is refreshed. V3.8.9 keeps V3.8.8's native Hermes system notice cardification, V3.8.7's newer-Hermes first-event compatibility, and V3.8.6's Docker/Hermes v0.18.0 compatibility, then fixes topic reply card continuity and duplicate native notice fallback; run `doctor --explain` once after upgrading and verify both a normal Feishu chat and a topic reply with a normal prompt, `/new`, `/model`, or a long-running/context-notice task.
-
-```bash
-# 1. Stop sidecar
-python3 -m hermes_feishu_card.cli stop --config ~/.hermes_feishu_card/config.yaml
-
-# 2. Update code
-cd /path/to/hermes-feishu-streaming-card
-git checkout v3.8.9 && pip install -e ".[test]" --upgrade
-
-# 3. Diagnose Hermes hook strategy and anchors
-python3 -m hermes_feishu_card.cli doctor --config ~/.hermes_feishu_card/config.yaml --hermes-dir ~/.hermes/hermes-agent
-
-# 4. Reinstall hook when hook_strategy should change
-python3 -m hermes_feishu_card.cli install --hermes-dir ~/.hermes/hermes-agent --yes
-
-# 5. Start sidecar
-python3 -m hermes_feishu_card.cli start --config ~/.hermes_feishu_card/config.yaml
-```
-
-**Using multi-profile**: add a `profiles` section to `config.yaml` (see multi-profile config example below) with per-profile `feishu.app_id`/`app_secret`. Environment variables `FEISHU_APP_ID`/`FEISHU_APP_SECRET` are ignored in multi-profile mode.
-
-**Rolling back to V3.2**: stop sidecar, `git checkout v3.2.1`, reinstall `pip`, restore backed-up `config.yaml`, re-run `install` + `start`.
-
-## Configuration
-
-Copy `config.yaml.example` locally. Never commit real credentials. Three common setups:
-
-**Single Profile (minimal)** — quickest way to start:
+Copy `config.yaml.example` locally and never commit real credentials.
 
 ```yaml
 server:
@@ -370,184 +86,109 @@ card:
   footer_fields: [duration, model, input_tokens, output_tokens, context]
 ```
 
-**Single Profile + Multi-bot** — register bots, route by chat_id:
-
-```yaml
-server:
-  host: 127.0.0.1
-  port: 8765
-feishu:
-  app_id: ""
-  app_secret: ""          # fallback only
-bots:
-  default: default
-  items:
-    sales:
-      app_id: "cli_sales_xxx"
-      app_secret: "xxx"
-    support:
-      app_id: "cli_support_yyy"
-      app_secret: "yyy"
-bindings:
-  fallback_bot: default
-  chats:
-    oc_5cc6a25d8815790fa890dd0226005e83: sales
-  group_rules:
-    enabled: false
-card:
-  title: Hermes Agent
-  footer_fields: [duration, model, input_tokens, output_tokens, context]
-```
-
-**Multi-profile** (new in V3.3.0) — one sidecar, multiple Hermes instances, isolated per profile:
-
-```yaml
-server:
-  host: 127.0.0.1
-  port: 8765
-profiles:
-  engineering:
-    feishu:
-      app_id: "cli_eng_xxx"
-      app_secret: "xxx"
-    bots:
-      default: default
-      items:
-        default:
-          app_id: "cli_eng_xxx"
-          app_secret: "xxx"
-    bindings:
-      fallback_bot: default
-      chats: {}
-  sales:
-    feishu:
-      app_id: "cli_sales_xxx"
-      app_secret: "xxx"
-    bots:
-      default: default
-      items:
-        default:
-          app_id: "cli_sales_xxx"
-          app_secret: "xxx"
-    bindings:
-      fallback_bot: default
-      chats: {}
-  group_rules:
-    enabled: false
-card:
-  title: Hermes Agent
-  footer_fields: [duration, model, input_tokens, output_tokens, context]
-```
-
-In multi-profile mode, `FEISHU_APP_ID`/`FEISHU_APP_SECRET` env vars are ignored. `footer_fields` accepts: `duration`, `model`, `input_tokens`, `output_tokens`, `context`.
-
-## Feishu App Setup
+Feishu credentials can also live in a `.env` next to the config:
 
 ```bash
-export FEISHU_APP_ID=cli_xxx FEISHU_APP_SECRET=xxx
-# Real Feishu smoke test:
-python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example --chat-id oc_xxx
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+FEISHU_CONNECTION_MODE=websocket
+FEISHU_HOME_CHANNEL=oc_xxx
 ```
 
-## Hermes Gateway Streaming And Thinking
+Multi-bot routing, group chat bindings, multi-profile config, profile-aware routing, footer fields, and no-op client behavior are covered in the [full user guide](docs/user-guide.en.md#configuration).
 
-Ensure Hermes `config.yaml` has `streaming.enabled: true` and `streaming.transport: edit`. Avoid `display.platforms.feishu.streaming: false`. Do not treat `display.show_reasoning` as required — it may prepend a reasoning code block to the final text, interfering with the card streaming experience. If the model only returns final answers (no thinking deltas), the card shows the final answer directly.
+## Hermes Streaming Config
 
-## CLI Commands
+Confirm `streaming.enabled` is `true`, and let Hermes use edit transport.
 
-| Command | Description |
-|---------|-------------|
-| `setup --hermes-dir ... --yes` | One-shot install (config, check, hook, sidecar, health) |
-| `doctor --config ... --hermes-dir ...` | Diagnostics: `version_source`, `version`, `minimum_supported_version`, `run_py_exists`, `hook_strategy`, `compatibility`, anchors, `reason`; supports `--explain` / `--json` |
-| `install --hermes-dir ... --yes` | Install hook into Hermes |
-| `repair --hermes-dir ... --yes` | Repair verifiable hook manifest/backup state without overwriting user edits |
-| `restore --hermes-dir ... --yes` | Restore original Hermes files |
-| `uninstall --hermes-dir ... --yes` | Uninstall and restore |
-| `start --config ...` | Start sidecar |
-| `stop --config ...` | Stop sidecar (validates PID/token against `/health` `process_pid/process_token_hash`) |
-| `status --config ...` | Sidecar status, routing, profile diagnostics, and metrics |
-| `smoke-feishu-card --profile-id ... --chat-id ...` | Send a real Feishu smoke card for a specific profile |
-| `bots list|show|add|remove --config ...` | Manage bot registry |
-| `bots test --profile-id ... --chat-id ...` | Run a real Feishu bot smoke for a specific profile/bot |
-| `bots bind-chat|unbind-chat --config ...` | Manage chat bindings |
+Make sure Hermes `config.yaml` enables streaming edits:
 
-## Architecture
+```yaml
+streaming:
+  enabled: true
+  transport: edit
+```
+
+Do not set `display.platforms.feishu.streaming: false`. Do not treat `display.show_reasoning` as required for this plugin; it can append reasoning blocks to the final answer and disrupt the streaming card experience. The plugin consumes Hermes `thinking.delta` / `answer.delta` directly.
+
+The compatibility matrix covers older Hermes starting at `v2026.4.23` and Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x. `doctor` prefers `VERSION` or Git tag `v2026.4.23+` when deciding support. After upgrading Hermes or this plugin, rerun `setup` or `install --hermes-dir ... --yes`.
+
+## Docker Container Install
+
+For an existing Hermes container:
+
+```bash
+export FEISHU_APP_ID=cli_xxx
+export FEISHU_APP_SECRET=xxx
+export HFC_VERSION=v3.8.9
+bash install-docker.sh
+```
+
+Defaults:
+
+| Variable | Default |
+|---|---|
+| `HERMES_DIR` | `/opt/hermes` |
+| `HFC_CONFIG` | `/opt/data/config.yaml` |
+| `HFC_ENV_FILE` | `/opt/data/.env` |
+| `HFC_VERSION` | `latest` |
+
+`docker-compose.example.yml` is an integration example, not an official image. Since V3.8.6, Docker/source-stripped Hermes roots without `VERSION` or `.git` can fall back to Gateway anchors and still choose `gateway_run_013_plus`.
+
+## Common Commands
+
+| Command | Purpose |
+|---|---|
+| `setup --hermes-dir ... --yes` | Configure, diagnose, install hook, and start sidecar |
+| `doctor --config ... --hermes-dir ... --explain` | Diagnose Hermes version, runtime import, hook strategy, anchors, and recommendations |
+| `install --hermes-dir ... --yes` | Install the plugin into Hermes runtime venv and patch Hermes |
+| `repair --hermes-dir ... --yes` | Repair verifiable hook manifest/backup state |
+| `restore --hermes-dir ... --yes` | Restore the original Hermes file |
+| `start --config ...` / `status --config ...` / `stop --config ...` | Manage the sidecar process and `/health` checks |
+| `smoke-feishu-card --profile-id ... --chat-id ...` | Send a real Feishu card smoke test |
+| `bots list|show|add|remove|test` | Manage and test multi-bot routing |
+
+High-frequency stream tuning usually needs no change. For DeepSeek burst, token-by-token, or long-context pressure:
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MS` | `250` | Max Gateway-side delta coalescing wait |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS` | `600` | Flush pending delta when this character budget is reached |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING` | `128` | Pending delta session cap |
+
+## Latest Releases
+
+![Feishu topic reply card continuity and reasoning/tool timeline showcase](docs/assets/feishu-topic-card-showcase-v389.png)
+
+| Version | Highlights |
+|---|---|
+| [v3.8.9](docs/release-notes-v3.8.9.md) | Feishu/Lark topic card continuity; `system.notice` no longer duplicates outside the card |
+| [v3.8.8](docs/release-notes-v3.8.8.md) | Cardifies native Hermes notices: Working, context compression, skill loading, and self-improvement review |
+| [v3.8.7](docs/release-notes-v3.8.7.md) | Newer Hermes streams can create cards even when `message.started` is missing |
+| [v3.8.6](docs/release-notes-v3.8.6.md) | Docker/source-stripped Hermes can fall back from missing `VERSION` to Gateway anchors; Hermes v0.18.0 support |
+| [v3.8.5](docs/release-notes-v3.8.5.md) | Direct command results for `/new`, `/model`, and similar commands stay in cards |
+
+Full history: [CHANGELOG.md](CHANGELOG.md). Longer historical notes remain in the [full user guide](docs/user-guide.en.md#version-history).
+
+## Architecture At A Glance
 
 ```text
 Hermes Gateway
-  └─ minimal hook in gateway/run.py
-       └─ hermes_feishu_card.hook_runtime
-            └─ HTTP POST /events ——→  sidecar server
-                                      ├─ CardSession state machine
-                                      ├─ render_card() card rendering
-                                      ├─ FeishuClient tenant token / send / update
-                                      ├─ throttling, retry, locks, diagnostics
-                                      └─ /health metrics
+  -> minimal hook in gateway/run.py
+     -> hermes_feishu_card.hook_runtime
+        -> HTTP POST /events
+           -> sidecar server
+              -> CardSession state
+              -> Feishu CardKit send/update
+              -> retry / coalescing / metrics / /health
 ```
 
-The Hermes hook converts `message.started` / `thinking.delta` / `answer.delta` / `tool.updated` / `message.completed` / `message.failed` into `SidecarEvent` and forwards to the sidecar. The sidecar owns full session state and the Feishu CardKit boundary — independently testable, restartable, and diagnosable. Historical code is archived under `legacy/` (`installer_v2.py`, `gateway_run_patch.py`, `patch_feishu.py`, etc.) — not the active runtime. Current development uses `hermes_feishu_card/`. See [docs/migration.en.md](docs/migration.en.md).
-
-## FAQ
-
-- **No thinking / not streaming**: check Hermes `streaming.enabled: true` + `streaming.transport: edit`, confirm model exposes reasoning deltas. Don't blindly enable `show_reasoning`.
-- **No real Feishu cards**: without credentials, the sidecar uses a no-op client. In multi-profile mode, check each profile's `feishu` config.
-- **Hook installed but cards never arrive**: run `doctor --explain` and check `Runtime import`. If Hermes runtime cannot import `hook_runtime`, rerun `setup` or `install --hermes-dir ... --yes`.
-- **Duplicate cards**: inspect `/health` metrics (`events_received`, `feishu_send_successes`). V3.3.0 per-message lock + `profile_id:message_id` keys ensure one card per message.
-- **Multi-profile route is unclear**: run `status --config ...` and inspect `routing.last_route`, `profile.<id>.events`, and `profile.<id>.last_profile_source`, then verify directly with `smoke-feishu-card --profile-id ...` or `bots test --profile-id ...`.
-- **Gray native text**: after sidecar accepts `message.completed`, Hermes hook suppresses native text; fail-open on sidecar unavailable. V3.3.0 fixes non-Feishu platforms being swallowed.
-- **`doctor` unsupported**: Hermes ≥ `v2026.4.23` (reads `VERSION` or Git tag `v2026.4.23+`), `gateway/run.py` must exist.
-- **No cards after upgrading Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x**: run `doctor --config ... --hermes-dir ...` to inspect `hook_strategy`, `compatibility`, and anchors, then re-run `install --hermes-dir ... --yes` if needed.
-- **Restore fails**: file modified → `restore`/`uninstall` refuse to overwrite. Run `doctor --explain` to inspect manifest/backup/run.py state; if it reports an automatic repair path, run `repair --hermes-dir ... --yes`, otherwise back up and manually diff.
-- **Footer tokens wrong**: abnormal values filtered; if still wrong, inspect Hermes `tokens`/`context` metadata.
-- **Table limit exceeded**: V3.3.0 auto-truncates >5 tables with a notice. Reduce Markdown tables.
-
-## Version History
-
-| Version | Date | Highlights |
-|---------|------|-----------|
-| [v3.8.9](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.9) | 2026-07 | Feishu/Lark topic card continuity: later stream events and `system.notice` resolve by `reply_to_message_id`, keeping the topic timeline updating and avoiding duplicate gray notices |
-| [v3.8.8](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.8) | 2026-07 | Native Hermes system notice cardification: Working heartbeats, context/compression notices, session resets, skill loading, and self-improvement reviews enter cards or compact notice cards |
-| [v3.8.7](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.7) | 2026-07 | issue #75: first `answer.delta` / `thinking.delta` / `tool.updated` / `message.completed` events create a card when newer Hermes omits `message.started` |
-| [v3.8.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.6) | 2026-07 | issue #70 Docker/source-stripped Hermes fallback from missing `VERSION` to Gateway anchors, plus Hermes v0.18.0 / `v2026.7.1` compatibility |
-| [v3.8.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.5) | 2026-07 | Keeps always-allowed `/new` and similar direct command results in Feishu/Lark cards, and removes unsupported interactive direct updates |
-| [v3.8.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.4) | 2026-07 | Feishu/Lark WebSocket-native slash/model command cards, fixing the V3.8.3 local sidecar gray text fallback gap |
-| [v3.8.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.3) | 2026-07 | Standalone slash-command cards for `/new`/`/reset`/`/undo` confirmations, `/model` picker cards, `/update` non-interactive boundary, and text fallback |
-| [v3.8.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.2) | 2026-07 | Card timeline readability patch with delayed pre-tool answer archival, terminal body de-duplication, separate reasoning/tool hierarchy, and fresh collapsed/expanded screenshots |
-| [v3.8.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.1) | 2026-07 | Fixes issue #74 with Gateway-side high-frequency delta coalescing, terminal pre-flush, read-only `/hfc` diagnostics, and hashed diagnostic context |
-| [v3.8.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.0) | 2026-07 | Separates the primary answer from the auxiliary timeline, removes duplicate tool summaries, drains terminal updates, fixes runtime import diagnostics, and updates Docker examples |
-| [v3.7.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.7.0) | 2026-06 | Adds issue #70 Docker container install/update support with `/opt/hermes` and `/opt/data` defaults |
-| [v3.6.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.6) | 2026-06 | Fixes issues #67/#68 by preventing interrupt/slow-PATCH card + native double replies and by suggesting the real Hermes `Project:` path from `hermes -V` |
-| [v3.6.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.5) | 2026-06 | Fixes issues #64/#65 with Feishu thread `message_id` normalization and DeepSeek completed-only final-answer backfill |
-| [v3.6.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.4) | 2026-06 | Fixes issues #61/#62 with Feishu thread card replies and cron `deliver: "feishu:oc_xxx"` card routing |
-| [v3.6.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.3) | 2026-06 | Fixes issues #56-#59 with Hermes v0.17 `_run_agent_inner` hooks, localhost interaction text fallback, Telegram isolation, and Windows profile paths |
-| [v3.6.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.2) | 2026-06 | Fixes issue #53 with Hermes runtime venv installs, doctor runtime import checks, and hook failure warnings |
-| [v3.6.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.1) | 2026-06 | Fixes issue #47, supports Hermes `0.15.x` and no-`v` VERSION values so `doctor --explain` no longer reports them unsupported |
-| [v3.6.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.0) | 2026-06 | `doctor --json/--explain`, safe `repair`, structured media/file summaries, profile-targeted smoke checks, routing profile diagnostics, Hermes compatibility matrix |
-| [v3.5.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.2) | 2026-06 | Cross-platform one-line installers, Release packages, safer macOS `.env` parsing, uv/PEP 668 Python install handling, Windows installer CI parser validation |
-| [v3.5.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.1) | 2026-06 | Streaming update ordering/coalescing, Feishu JSON 2.0 button fix, queued follow-up suppression, `.env` credential fallback, Chinese README refresh |
-| [v3.5.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.0) | 2026-06 | Feishu button interaction loop, issue #41, PR #42, long table/code splitting, thinking truncation fix |
-| [v3.4.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.3) | 2026-05 | Fixes issue #39, adds structure-aware Markdown splitting, and verifies Hermes v0.14.0/v2026.5.16+ support |
-| [v3.4.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.2) | 2026-05 | Fixes issue #31, preventing concurrent PATCH and sequence races from rolling back or dropping streaming card text |
-| [v3.4.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.1) | 2026-05 | Fixes issue #25, keeping Hermes v2026.5.7 fallback message ids lifecycle-stable |
-| [v3.4.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.0) | 2026-05 | Hermes 0.13.0+ compatibility, older Hermes strategy preserved, issue #23, multi-profile/multi-bot, attachments and reply context |
-| [v3.3.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.3.0) | 2026-05 | Multi-profile, DeepSeek compat, table protection, footer spinner, platform fix |
-| [v3.2.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.1) | 2026-04 | Accept-Encoding fix |
-| [v3.2.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.0) | 2026-04 | Multi-bot routing, group chat bindings, Bot CLI, routing diagnostics |
-| [v3.1.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.1.0) | 2026-04 | Sidecar architecture, streaming cards, health endpoint, install wizard |
-| [v3.0.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.0.0) | 2026-04 | Initial sidecar-only release (migrated from V2.x monolith hook) |
-
-Full changelog: [CHANGELOG.md](CHANGELOG.md).
-
-## Testing
-
-```bash
-python3 -m pytest -q    # run the full automated regression suite
-```
-
-Coverage: real Hermes Gateway E2E, real Feishu app card verification, 16k long-card stress test, `doctor → install → restore` loop, multi-profile routing, DeepSeek tag filtering.
+This is a sidecar-only design: the Hermes hook stays fail-open, while Feishu delivery, card updates, session state, retries, and diagnostics live in the sidecar. Historical V2 code is archived under `legacy/` and is not the active runtime.
 
 ## Documentation
 
+- Full user guide: [中文](docs/user-guide.md) / [English](docs/user-guide.en.md)
+- Installer package guide: [README-install.md](README-install.md)
 - Architecture: [中文](docs/architecture.md) / [English](docs/architecture.en.md)
 - Event protocol: [中文](docs/event-protocol.md) / [English](docs/event-protocol.en.md)
 - Installer safety: [中文](docs/installer-safety.md) / [English](docs/installer-safety.en.md)
@@ -555,19 +196,18 @@ Coverage: real Hermes Gateway E2E, real Feishu app card verification, 16k long-c
 - E2E verification: [中文](docs/e2e-verification.md) / [English](docs/e2e-verification.en.md)
 - Release readiness: [中文](docs/release-readiness.md) / [English](docs/release-readiness.en.md)
 - Testing: [中文](docs/testing.md) / [English](docs/testing.en.md)
+- Maintainer wiki: [docs/wiki](docs/wiki/README.md)
+
+## Contributors
+
+- [gischuck](https://github.com/gischuck) - [PR #12](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/12) Accept-Encoding fix
+- [gischuck](https://github.com/gischuck) - [PR #76](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/76) reasoning/tool timeline UX proposal and implementation exploration
+- [fengs2021](https://github.com/fengs2021) - [PR #17](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/17) lock optimization and update interval improvement
+
+## Security
+
+Do not commit App Secret, tenant token, real chat_id, or unredacted screenshots. Screenshots demonstrate card rendering only. Production credentials belong in local config or environment variables.
 
 ## License
 
 MIT License. See [LICENSE](LICENSE).
-
-## Contributors
-
-Thanks to these contributors for improving the project:
-
-- [gischuck](https://github.com/gischuck) — [PR #12](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/12) Accept-Encoding fix (V3.2.1 brotli compatibility)
-- [gischuck](https://github.com/gischuck) — [PR #76](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/76) reasoning/tool timeline UX proposal and implementation exploration (V3.8.x)
-- [fengs2021](https://github.com/fengs2021) — [PR #17](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/17) lock optimization and update interval improvement (V3.3.0)
-
-## Security
-
-Do not commit App Secret, tenant token, or real chat_id. Screenshots demonstrate card rendering only. Production credentials belong in local config or environment variables.

--- a/README.md
+++ b/README.md
@@ -14,252 +14,32 @@
 
 ![Hermes Feishu Streaming Card 封面](docs/assets/readme-cover.png)
 
-Hermes 飞书流式卡片插件把 Hermes Agent Gateway 的飞书/Lark 回复变成一张持续更新的交互式卡片：思考过程、工具调用、最终答案、授权确认、选项选择和运行统计都能收束在同一张飞书卡片里，而不是被拆成刷屏的灰色原生消息。
+Hermes 飞书流式卡片插件把 Hermes Agent Gateway 的飞书/Lark 回复变成一张持续更新的交互式卡片。思考过程、工具调用、最终答案、授权确认、选项选择、系统提示和运行统计会收束在卡片内，而不是散落成多条灰色原生消息。
 
-它重点解决飞书接入 Hermes 时最常见的痛点：流式内容漏字/乱序、长表格和代码块渲染成 raw markdown、工具调用过程不可见、approval/clarify 需要手工回复、sidecar 故障难排查、多 bot / 多 profile 难运维，以及升级 Hermes 后 hook 兼容不确定。
+它面向真实飞书使用场景：流式内容漏字/乱序、长表格和代码块变成 raw markdown、工具过程不可见、approval/clarify 需要手工回复、话题里卡片不更新、多 bot / 多 profile 难排查，以及 Hermes 升级后 hook 兼容不确定。
 
-![Hermes 飞书卡片命令交互、结果反馈与工具 timeline 横向展示](docs/assets/feishu-card-showcase-v385.png)
+![Hermes 飞书卡片命令交互、结果反馈与工具 timeline 展示](docs/assets/feishu-card-showcase-v385.png)
 
-V3.8.2 起，最终答案保留在主内容区，pre-tool answer 会按“正文展示 -> 下一段到来后归档进 timeline”的节奏收束，思考与工具在折叠区使用不同字号和灰度层级；卡片底部不再重复展示同一份工具调用摘要。
+## 你能看到什么
 
-## 项目亮点
+- **一张持续更新的飞书卡片**：`thinking.delta`、`answer.delta`、`tool.updated`、`message.completed` 会合并到同一张卡片。
+- **主答案和过程分区**：最终答案留在正文区，pre-tool answer、工具调用、系统 notice 进入“思考与工具” timeline。
+- **卡片内交互**：approval / clarify choices 渲染为按钮；`/new`、`/reset`、`/undo`、`/model` 等独立命令使用原生 interactive card。
+- **飞书话题一致体验**：话题里的后续流式事件通过 `reply_to_message_id` 回到原卡片，系统提示不再重复外溢。
+- **长内容保护**：长 Markdown 表格、fenced code block 按结构边界拆分，降低 raw markdown 和半截围栏问题。
+- **可诊断、可恢复**：`doctor`、`/hfc status`、`/health` metrics、runtime import 检查、safe repair/restore/uninstall 覆盖常见故障。
 
-- **流式卡片体验**：`thinking.delta`、`answer.delta`、`tool.updated`、`message.completed` 聚合到同一张飞书卡片，减少刷屏和上下文断裂。
-- **卡片内交互**：Hermes approval / clarify choices 优先渲染成飞书按钮；V3.8.5 起，飞书/Lark WebSocket 长连接场景下 `/new`、`/reset`、`/model` 等独立 slash 命令的确认、选择和执行结果都会使用原生 interactive card，不可用时再退回 Hermes 原生文本 fallback。
-- **运行提示收束**：V3.8.8 起，Hermes 原生 `Working` 心跳、上下文窗口/压缩提示、自动 session reset、skill 加载和自我改进 review 会优先进入卡片或独立小卡片，减少灰色原生消息散落。
-- **话题内体验一致**：V3.8.9 起，飞书/Lark 话题回复里的流式事件和系统提示会回到同一张卡片更新，避免话题面板中 timeline 不动、灰色提示重复外溢。
-- **长内容更稳**：长 Markdown 表格和 fenced code block 按结构边界切分，降低飞书 raw markdown 和半截代码围栏问题。
-- **多 bot / 多 profile**：支持多飞书机器人、多 Hermes profile、群聊绑定、bot/profile 标题和路由诊断。
-- **sidecar-only 架构**：Hermes hook fail-open，飞书发送/更新、状态机、重试、健康检查都在 sidecar 中独立运行。
-- **安装和发布友好**：支持一行安装、Release 安装包、`doctor` 诊断、`start/status/stop` 进程管理和安全 restore/uninstall。
+## 适用场景
 
-## 解决的真实痛点
+| 你遇到的问题 | 插件做的事 |
+|---|---|
+| 飞书里只看到最终文本，看不到 Agent 过程 | 把思考、工具、答案、footer 统计放进同一张卡片 |
+| 运行中不断出现 `Working`、压缩提示、skill loading、自我改进 review | 识别为 `system.notice`，进入当前卡片或独立小卡片 |
+| 话题回复里卡片发出来了，但 timeline 不更新 | 用 `source.message_id` / `reply_to_message_id` 锚定同一张话题卡片 |
+| 授权、选择、模型切换要手工回编号 | 优先使用飞书按钮或下拉选择，失败时再退回文本 fallback |
+| Hermes 升级后不知道 hook 是否兼容 | `doctor --explain` 展示 `version_source`、`hook_strategy`、`compatibility`、anchors 和建议 |
 
-| 痛点 | 项目能力 |
-|------|----------|
-| 飞书里只能看到一大段最终文本，看不到 Agent 思考和工具进度 | 思考、答案、工具状态、footer 统计持续更新在同一张卡片 |
-| 模型调用工具时内容乱序、漏字、完成后又冒出灰色原生消息 | per-message 顺序、PATCH 合并、终态优先和原生 resend 抑制 |
-| Hermes 运行中不断冒出 Working、上下文提示、skill loading 等灰色提示 | `system.notice` 卡片化：当前任务内进入“思考与工具”，任务外用独立小卡片 |
-| 飞书话题里卡片发出来了，但思考/工具不更新，系统提示还在外面重复出现 | 话题事件按 `reply_to_message_id` 回到原卡片，系统提示被 sidecar 接管后不再原生重复发送 |
-| Hermes 请求授权、让用户选择选项，或 slash 命令需要确认时，需要手工输入编号 | Agent 任务内选项留在当前卡片，独立 slash 命令使用独立命令卡片；不可用时退回编号文本 |
-| 长表格/长代码块被飞书渲染成 raw markdown | Markdown-aware split，重复表头和完整 code fence |
-| 多机器人、多群聊、多 profile 难确认路由 | `bindings.chats`、profile-aware session key、`/health.routing` 诊断 |
-| sidecar 或 hook 出问题难定位 | `doctor`、runtime import 检查、`/health` metrics、fail-closed installer、restore/uninstall |
-
-## V3.8.9 飞书话题卡片连续更新补丁
-
-V3.8.9 修复飞书/Lark 话题回复场景：创建话题后与 bot 对话，首张卡片能出现，但后续 `answer.delta`、`thinking.delta`、`tool.updated` 或 `system.notice` 可能因为 Hermes 内部流式 `message_id` 变化而没有更新同一张卡片，系统提示还可能同时出现在卡片 timeline 和外部灰色消息里。
-
-- **话题内同一张卡持续更新**：sidecar 会用 `reply_to_message_id` 把后续 topic 事件映射回当前运行中的卡片 session。
-- **系统提示不再重复外溢**：session-scoped `system.notice` 成功进入卡片后返回 `applied: true`；如果卡片投递短暂超时，已识别的 Hermes 系统提示也会被抑制，不再继续发送原生灰色文本。
-- **适配 Hermes v0.18.x Relay 元数据**：hook runtime 会把 Relay `source.message_id` 保留下来作为话题原消息锚点。
-
-![飞书话题内卡片连续更新与思考工具 timeline 展示](docs/assets/feishu-topic-card-showcase-v389.png)
-
-上图为真实飞书话题验证：话题回复面板里的卡片能持续更新，思考与工具 timeline、最终答案和 footer 统计保持在同一张卡片内；上下文窗口、自我改进等系统提示会进入卡片或独立小卡片，不再额外溢出成外部灰色消息。
-
-完整发布说明见 [V3.8.9 release notes](docs/release-notes-v3.8.9.md)。
-
-## V3.8.8 Hermes 原生系统提示卡片化
-
-V3.8.8 把 Hermes 原生灰色运行提示统一收束到飞书卡片体验里：`Working` 长任务心跳、上下文窗口/压缩提示、自动 session reset、skill 加载和 self-improvement review 会被识别为 `system.notice`。如果当前任务卡片仍可更新，提示会进入“思考与工具”区域；如果没有可用任务卡片，则发送一张紧凑的独立提示卡片。
-
-- **少一些灰色散落消息**：上下文窗口、压缩、session reset、skill loading、自我改进 review 等提示优先卡片化。
-- **长任务心跳会更新同一条记录**：`Working — iteration ...` 这类 heartbeat 会复用同一个 `notice_id`，避免 timeline 里刷出多条重复提示。
-- **保持 fail-open**：sidecar 不可用、提示无法识别或卡片发送失败时，Hermes 原生文本路径继续可用，不阻断任务。
-
-完整发布说明见 [V3.8.8 release notes](docs/release-notes-v3.8.8.md)。
-
-## V3.8.7 新版 Hermes 首事件兼容补丁
-
-V3.8.7 修复 issue #75：部分新版 Hermes 流式事件可能不再先发送 `message.started`，而是直接从 `answer.delta`、`thinking.delta`、`tool.updated` 或 `message.completed` 开始。旧版 sidecar 因为没有现成 session，会把这些首事件全部计为 `events_ignored`，导致飞书里没有初始卡片。现在这些消息事件也可以创建 session 并立即发送首张 Feishu/Lark 卡片。
-
-- **不再依赖 `message.started`**：首个 answer/thinking/tool/completed 事件都会触发卡片创建。
-- **保留既有链路**：已有 `message.started`、interaction、cron completion 和终态诊断逻辑保持兼容。
-- **与 V3.8.6 叠加**：Docker/source-stripped Hermes 缺 `VERSION` 的 Gateway anchor 兜底继续有效。
-
-完整发布说明见 [V3.8.7 release notes](docs/release-notes-v3.8.7.md)。
-
-## V3.8.6 Docker / Hermes v0.18.0 兼容补丁
-
-V3.8.6 修复 issue #70 的 Docker 容器安装场景：Hermes v0.18.0 / `v2026.7.1` 上游发布包可能没有顶层 `VERSION` 文件，容器镜像也常常不保留 `.git` 元数据。现在 `doctor --explain`、`install` 和 `setup` 会在缺少版本文件时继续读取 `gateway/run.py` 的真实代码 anchor，只要 anchor 可验证，就按 `gateway_run_013_plus` 安装，不再误报 `Hermes VERSION missing, unknown, or invalid`。
-
-- **Hermes v0.18.0**：`v2026.7.1` / `0.18.0` / `v0.18.0` 已加入兼容矩阵，继续使用 `gateway_run_013_plus`。
-- **Docker 无 VERSION 兜底**：诊断会显示 `version_source: gateway anchors`、`version: unknown` 和推断出的 `hook_strategy`。
-- **显式坏版本仍 fail-closed**：只有缺失版本元数据才走 anchor 兜底；如果 `VERSION` 文件内容非法，仍会拒绝安装。
-
-完整发布说明见 [V3.8.6 release notes](docs/release-notes-v3.8.6.md)。
-
-## V3.8.5 命令结果反馈卡片补丁
-
-V3.8.5 补齐 V3.8.4 的“始终允许/无需确认”路径：当 Hermes 直接执行 `/new`、`/reset`、`/clear`、`/undo`、`/stop` 或直接 `/model <model>` 后，执行结果也会以 Feishu/Lark interactive card 回复，而不是退回灰色原生文本。`/model` 切换后的反馈继续稳定留在绿色卡片里，`/update` 仍保持 Hermes 后台升级命令，不弹交互卡片。
-
-- **直通结果卡片化**：patcher 会把当前 `event` 传给 hook runtime，Feishu adapter `send()` 能识别独立 slash command 的返回结果。
-- **交互更新更干净**：按钮/下拉点击后只依赖 Feishu callback response 更新原卡片，不再额外调用飞书不支持的 interactive `message.update`。
-- **升级兼容**：重新运行 `install` 会把 V3.8.4 的旧 command-card hook block 升级为 V3.8.5 的 `event=event` 形式。
-
-完整发布说明见 [V3.8.5 release notes](docs/release-notes-v3.8.5.md)；上一版 WebSocket 原生命令卡片说明见 [V3.8.4 release notes](docs/release-notes-v3.8.4.md)。
-
-## V3.8.4 Feishu WebSocket 命令卡片热修
-
-V3.8.4 修正 V3.8.3 在本地/private sidecar 场景下只能退回灰色文本的问题：`/new`、`/reset`、`/undo` 这类确认命令现在会直接复用 Hermes Feishu adapter 的 WebSocket card action 通道发送原生 interactive card；`/model` 也会用同一套原生卡片完成选择。正在运行的 Agent 流式卡片仍只承接 approval、clarify、对话选项和思考/工具 timeline，不和独立命令混在一起。
-
-- **WebSocket 原生确认卡片**：插件动态补上 Feishu adapter 的 `send_slash_confirm(...)`，按钮点击由 `_on_card_action_trigger` 进入 `tools.slash_confirm.resolve(...)`。
-- **WebSocket 原生模型选择卡片**：当 Hermes 请求 Feishu adapter 的 `send_model_picker(...)` 时，插件会补上 Feishu-only picker，选择模型后回写同一张命令卡片。
-- **不重复弹选择卡**：WebSocket 原生卡片可用时会跳过 sidecar 预交互，`/new` 不再同时出现 sidecar 选项卡和原生按钮卡。
-- **`/update` 不弹卡片**：`/update` 仍按 Hermes 后台升级命令处理，不做交互按钮卡片，避免把升级流程误当成用户确认。
-- **安全 fallback**：Feishu 原生卡片不可用、sidecar 不可用、卡片应用失败、超时或完成态更新失败时，继续交给 Hermes 原生文本路径，避免命令卡死。
-
-完整发布说明见 [V3.8.4 release notes](docs/release-notes-v3.8.4.md)；上一版独立命令卡片基础说明见 [V3.8.3 release notes](docs/release-notes-v3.8.3.md)。
-
-## V3.8.2 卡片 timeline 阅读体验补丁
-
-V3.8.2 聚焦飞书卡片折叠区的真实阅读体验：工具调用前的自然语言预分析会先停留在正文区，直到下一段预分析或完成态再归档到“思考与工具”；完成态会剥离已经归档过的中间说明，只把最终答案留在主内容区。
-
-- **pre-tool answer 延迟折叠**：上一段预分析不会一闪而过，只有下一段预分析或终态到来时才移入折叠 timeline。
-- **完成态正文更干净**：若最终答案包含已经归档的 preface，terminal card 会自动去重，避免“分析过程 + 最终答案”一起挤在正文。
-- **timeline 层级更清楚**：思考条目保持小字号主层级，工具详情使用更小字号和弱化灰度，长命令不再抢主回答注意力。
-- **raw thinking 保持隐藏**：底层 `thinking.delta` 仍只作为内部流式状态，不混入正文和折叠区；折叠区只展示用户可读的 pre-tool answer。
-
-完整发布说明见 [V3.8.2 release notes](docs/release-notes-v3.8.2.md)。
-
-## V3.8.1 高频流式与飞书内诊断补丁
-
-V3.8.1 修复 issue #74：在 Hermes Agent 0.17.0+、thinking model、长上下文和 token-by-token 高频 delta 场景下，hook 会先在 Hermes Gateway 进程内合并 `thinking.delta` / `answer.delta`，再发送到 sidecar，降低 stream-reader 线程上的对象构造、锁竞争和 HTTP 调度压力，避免启用插件后触发 `Stream stale for 180s`。
-
-- **Gateway-side delta 合并**：新增 `HERMES_FEISHU_CARD_DELTA_COALESCE_MS`、`HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS`、`HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING`，默认无需配置。
-- **终态前主动 flush**：`message.completed` / `message.failed` 前会先 flush 同一消息的 pending delta，避免最后卡片缺少尾部内容。
-- **飞书内只读诊断命令**：支持 `/hfc help`、`/hfc status`、`/hfc doctor`、`/hfc monitor`，结果以飞书卡片回复，不会执行写操作。
-- **诊断信息脱敏**：`/messages/{message_id}/summary` 和 `/hfc` 卡片只展示 hash 后的 chat/message/thread 上下文。
-
-完整发布说明见 [V3.8.1 release notes](docs/release-notes-v3.8.1.md)。
-
-## V3.8.0 卡片体验与流式稳定性升级
-
-V3.8.0 聚焦真实飞书阅读体验：最终答案固定在最重要的主内容区，reasoning / tool timeline 收进辅助区域；长表格、代码块、工具 burst 和终态事件堆积时，卡片会先合并并 drain 待更新内容，再写入最终态。
-
-- **主回答更清楚**：最终答案不被长思考和工具列表挤到卡片底部，工具过程进入辅助 timeline。
-- **减少重复展示**：启用辅助 timeline 时，底部不再额外渲染一份“工具调用 N 次”摘要。
-- **流式终态更稳**：terminal card 渲染前 drain pending updates，避免最后一张卡被旧的中间状态覆盖。
-- **诊断更准**：`doctor` 的 Hermes runtime import 检查会在 Hermes 项目根目录执行，避免当前仓库路径导致误判。
-- **Docker 同步发布**：V3.8.0 发布时同步了 Docker 安装示例，容器内安装仍使用 `install-docker.sh`。
-
-完整发布说明见 [V3.8.0 release notes](docs/release-notes-v3.8.0.md)。
-
-## V3.6.6 中断去重与安装诊断补丁
-
-V3.6.6 修复 issues #67 和 #68：`message.completed` 会基于 sidecar 返回的 `applied` 结果判断卡片链路是否真正接管，terminal 事件不再等待慢 Feishu PATCH 才响应 Hermes，避免中断或更新堆积后同时出现流式卡片和灰色原生答复；`doctor --explain` / `install` 在 `--hermes-dir` 指错时会读取 `hermes -V` 的 `Project:` 路径，并直接提示正确的 Hermes 目录。
-
-完整发布说明见 [V3.6.6 release notes](docs/release-notes-v3.6.6.md)。
-
-## V3.7.0 Docker 容器适配
-
-V3.7.0 在已有 Hermes 容器中补齐安装与升级路径（issue #70）。`install-docker.sh` 会按容器默认路径执行更新。
-
-完整发布说明见 [V3.7.0 release notes](docs/release-notes-v3.7.0.md)。
-
-## V3.6.5 流式终态稳定性补丁
-
-V3.6.5 修复 issues #64 和 #65：Feishu thread / 话题场景下，`message.started` 现在会使用和 streaming callbacks 一致的 reply anchor 作为 card session `message_id`，避免 `events_applied=0`；DeepSeek 等一次性返回最终答案的模型，即使没有任何 `thinking.delta` / `answer.delta`，也会从 `message.completed` / `agent_result.final_response` 回填最终内容并完成同一张卡片。
-
-完整发布说明见 [V3.6.5 release notes](docs/release-notes-v3.6.5.md)。
-
-## V3.6.4 话题回复与定时投递补丁
-
-V3.6.4 修复 issues #61 和 #62：用户在飞书 thread / 话题里发消息时，初始 streaming card 会使用飞书 reply API 发回同一 thread，并继续用同一张卡片做后续 PATCH 更新；cron job 配置 `deliver: "feishu:oc_xxx"` 时也能从 `deliver` 字段解析 chat id，避免定时任务退回普通文本。
-
-完整发布说明见 [V3.6.4 release notes](docs/release-notes-v3.6.4.md)。
-
-## V3.6.3 Hermes v0.17 兼容与交互补丁
-
-V3.6.3 修复 issues #56-#59：Hermes v0.17.0+ / `v2026.6.19+` 将真实 streaming callback 移到 `_run_agent_inner` 后，patcher 会优先在 `_run_agent_inner` 注入 `tool.updated`、`answer.delta`、`thinking.delta`、clarify 和 approval hook，避免卡片停在“思考中”。
-
-localhost/private sidecar 默认使用 `card.interaction_mode: auto`，sidecar-owned choices 会降级成卡片内编号选项，并立即交还 Hermes 原生文本交互流程。V3.8.5 的 `/new`、`/reset`、`/model` 独立命令不依赖公网 HTTP 回调，而是直接复用 Feishu/Lark WebSocket 长连接 card action；命令执行结果也会保持卡片反馈。
-
-这一版还隔离了非飞书平台事件，安装插件后不会影响 Telegram 原生消息；Windows `HERMES_HOME=C:\Users\...\AppData\Local\hermes\profiles\thinking` 也能正确解析 profile。
-
-完整发布说明见 [V3.6.3 release notes](docs/release-notes-v3.6.3.md)。
-
-## V3.6.2 安装可靠性补丁
-
-V3.6.2 修复 issue #53：`setup` / `install` 不只把插件装进当前用户 Python，还会检测 Hermes Gateway 实际运行的 venv Python（例如 `~/.hermes/hermes-agent/venv/bin/python`），并在打 hook 前把同一版本的 `hermes-feishu-streaming-card` 安装进去。
-
-`doctor --explain` / `doctor --json` 新增 `runtime_import` 检查，会明确告诉你 Hermes runtime 是否能 import `hermes_feishu_card.hook_runtime`。hook import/emit 失败也不再完全静默，仍保持 fail-open，但会在 Hermes stderr 写入 `[hermes-feishu-card] hook failed: ...` 诊断 warning。
-
-完整发布说明见 [V3.6.2 release notes](docs/release-notes-v3.6.2.md)。
-
-## V3.6.1 兼容补丁
-
-V3.6.1 修复 issue #47：Hermes `VERSION` 文件写成 `0.15.1` 这类无 `v` 前缀语义版本时，`doctor --explain` 不再误报 unsupported。`0.15.x` / `v0.15.x` 会继续按新版 Hermes 走 `gateway_run_013_plus`，前提是 `gateway/run.py` 的必要 anchor 仍存在。
-
-完整发布说明见 [V3.6.1 release notes](docs/release-notes-v3.6.1.md)。
-
-## V3.6.0 运维增强
-
-V3.6.0 面向真实线上使用后的排障和维护场景：当 Hermes 升级、hook 状态异常、媒体/文件消息进入会话，或一个 sidecar 服务多个 profile/bot 时，用户可以更快判断“哪里坏了、能不能自动修、该验证哪条路由”。
-
-- **诊断可读可机器解析**：`doctor --explain` 给人工排障摘要，`doctor --json` 输出 config、sidecar、Hermes、streaming、install_state 和 recommendations。
-- **安装状态可自救**：新增 `repair --hermes-dir ... --yes` 和 `setup --repair`，只修复可验证的 manifest/backup 状态，遇到用户改动会拒绝覆盖。
-- **媒体/文件更安全**：识别 Hermes 结构化 `attachments` / `files` / `media_files` / image/audio/video 对象，卡片保留摘要，同时不抑制 Hermes 原生媒体/文件投递路径。
-- **多 Profile 更好排障**：`smoke-feishu-card --profile-id`、`bots test --profile-id`、CLI `status` 和 `/health.routing.profiles` 都能按 profile 展示路由状态。
-- **兼容矩阵更明确**：自动化覆盖 Hermes `v2026.4.23`、`v2026.5.7`、`v2026.5.16+`、`v2026.5.29`、`0.13.x`、`0.14.x`、`0.15.x` 和带/不带 `v` 前缀语义版本的 hook strategy。
-
-完整发布说明见 [V3.6.0 release notes](docs/release-notes-v3.6.0.md)，历史路线见 [docs/roadmap-v3.6.0.md](docs/roadmap-v3.6.0.md)。
-
-## V3.6.0 解决了什么
-
-| 场景 | V3.6.0 的变化 |
-|------|---------------|
-| 用户只知道“卡片没回来”，不知道 hook、sidecar 还是 Hermes anchor 出问题 | `doctor --explain` 给出分区诊断和下一步建议 |
-| manifest/backup 丢失导致 restore/install 拒绝，但当前 patch 其实可验证 | `repair` 自动重建缺失状态文件，无法验证时保持拒绝 |
-| 图片、文件、音频、视频进入 Hermes locals 后卡片里看不到上下文 | 卡片显示附件摘要，原生媒体/文件发送路径继续保留 |
-| 多 profile / 多 bot 下不知道消息走了哪个机器人 | `status` 和 `/health.routing.profiles` 展示 bot 数、群聊绑定、last_route、last_route_error |
-| 升级 Hermes 后不确定用新版还是旧版 hook strategy | 测试和文档明确各 Hermes key release 对应的 `gateway_run_013_plus` / `legacy_gateway_run`，并覆盖 `0.15.x` |
-
-## V3.5.x 功能基线
-
-**交互能力**
-
-- 新增飞书按钮交互闭环：`interaction.requested` 渲染按钮，`/card/actions` 记录选择，Hermes hook 轮询 `/interactions/{interaction_id}` 后继续执行。
-- 授权/选项按钮采用飞书 JSON 2.0 `button + behaviors.callback`，避免旧式 action 容器在飞书端更新失败。
-- approval / clarify hook 透传 Hermes event loop，交互请求和流式 delta 共用同一条 message send lock，减少事件乱序。
-
-**流式稳定性**
-
-- 修复 issue #41：多条回复和新版 Hermes streaming flow 继续走卡片更新，最终回答不再从第二条开始退回原生 text。
-- 修复 issue #39：`message.completed.answer` 为空时不再清空已通过 `answer.delta` 展示的内容，避免 DeepSeek V4 Pro 工具调用后卡片最终无内容。
-- 修复 issue #31：同一张飞书卡片 PATCH 串行化，避免旧快照后到覆盖新内容。
-- 修复 issue #25：Hermes v2026.5.7 的 `event_message_id` 作为显式 `message_id` 使用，保证 `message.started` 和 `message.completed` 落在同一张 fallback 卡片。
-- 同一消息的 HTTP 事件发送按 message id 加锁；多线程 Hermes callback 产生的 sequence 不会互相踩踏。
-- `answer.delta` / `thinking.delta` 保留原始边界空格，避免中文、英文、代码片段被拼坏。
-- `thinking.delta(mode=append_block)` 以完整思考片段追加，修复思考过程句子漏字、截断和粘连。
-- sidecar 事件快速 ACK，卡片 PATCH 合并更新，刷新间隔降到 `0.2s`，终态事件在后台优先补齐最终卡片。
-- queued follow-up 完成后抑制原生 resend，避免“卡片已完成但下面又冒出一大段灰色原生消息”。
-
-**长内容与渲染**
-
-- 长 Markdown 表格超过 `MAIN_CONTENT_CHUNK_CHARS` 后重复表头分块，仍保持合法表格。
-- fenced code block 超长后拆成多个完整 fenced block，避免飞书显示半截代码围栏。
-- 保留 V3.3.0 的飞书 5 表格限制保护，超限时自动截断并提示。
-
-**兼容与安装**
-
-- Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x、`v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` 使用 `gateway_run_013_plus`。
-- 旧版本 Hermes（`v2026.4.23` 到 `v2026.4.x` / `0.12.x`）继续使用 `legacy_gateway_run`。
-- `doctor` 输出 `version_source`、`version`、`hook_strategy`、`compatibility`、anchor/anchors 和 `reason`，便于安装前确认。
-- 升级插件后必须重新安装 hook：运行 `install --hermes-dir ... --yes`，让 Hermes 使用匹配当前版本的 hook。
-- 处理 PR #42：cron 卡片路由优先使用 `job['deliver']` 和 scheduler 解析出的 Feishu target。
-- 多 profile / multi bot 体验补齐：issue #23、per-bot/profile title、cron final cards、attachment summaries + native media delivery、reply card context。
-- V3.6.0 进一步补齐 profile 定向 smoke、routing profile diagnostics、structured attachment summaries 和 safe repair。
-
-**配置与运行安全**
-
-- `--config` 指向的配置文件同目录存在 `.env` 时，会自动读取 `FEISHU_APP_ID`、`FEISHU_APP_SECRET`、`HERMES_FEISHU_CARD_HOST`、`HERMES_FEISHU_CARD_PORT`。
-- 真实进程环境变量优先级高于同目录 `.env`。
-- 多 Profile 模式下继续要求每个 profile 显式配置 Feishu 凭据，顶层环境变量不会覆盖 profile 凭据。
-- 无凭据时 sidecar 使用 no-op client，只做本地状态，不会向真实飞书发卡；`/health.routing.bot_count` 可用于确认是否加载到真实 bot。
-
-## 一行安装
+## 快速安装
 
 macOS / Linux：
 
@@ -273,141 +53,26 @@ Windows PowerShell：
 irm https://raw.githubusercontent.com/baileyh8/hermes-feishu-streaming-card/main/install.ps1 | iex
 ```
 
-安装脚本会自动安装/升级插件、读取或提示填写飞书凭据、写入 `~/.hermes/.env`，并调用整合安装器：
+安装脚本会安装或升级插件、读取/提示飞书凭据、写入本地 `.env`，并调用整合安装器：
 
 ```bash
-python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --config ~/.hermes/config.yaml --yes
+python3 -m hermes_feishu_card.cli setup \
+  --hermes-dir ~/.hermes/hermes-agent \
+  --config ~/.hermes/config.yaml \
+  --yes
 ```
 
-安装完成后可以检查 sidecar 状态：
+安装完成后检查 sidecar：
 
 ```bash
 python3 -m hermes_feishu_card.cli status --config ~/.hermes/config.yaml
 ```
 
-常用环境变量：
+更完整的安装包、Release 下载、Docker 和 PEP 668/uv 说明见 [README-install.md](README-install.md) 与 [详细使用手册](docs/user-guide.md)。
 
-| 变量 | 默认值 | 说明 |
-|------|--------|------|
-| `HFC_VERSION` | `latest` | 指定安装版本，例如 `v3.8.9`、`v3.6.6` 或 `main` |
-| `HERMES_DIR` | `~/.hermes/hermes-agent` | Hermes Agent Gateway 目录 |
-| `HFC_CONFIG` | `~/.hermes/config.yaml` | sidecar 配置路径 |
-| `HFC_ENV_FILE` | `HFC_CONFIG` 同目录 `.env` | 飞书凭据保存位置 |
-| `HFC_SKIP_START` | `0` | 设为 `1` 时只安装 hook，不启动 sidecar |
-| `HFC_NO_PROMPT` | `0` | 设为 `1` 时禁止交互式输入，适合自动化安装 |
-
-高频流式调优变量默认无需配置，只有在超高频 thinking/burst 场景下才需要调整：
-
-| 变量 | 默认值 | 说明 |
-|------|--------|------|
-| `HERMES_FEISHU_CARD_DELTA_COALESCE_MS` | `250` | Gateway runtime 内合并 delta 的最大等待时间；设为 `0` 可关闭 |
-| `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS` | `600` | pending delta 累积到该字符数后立即 flush |
-| `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING` | `128` | 同时保留的 pending delta session 上限 |
-
-## Docker 容器内安装 / 更新
-
-如果 Hermes 运行在已有 Docker 容器里，优先使用 `install-docker.sh`。它默认读取：
-
-| 变量 | 默认值 | 说明 |
-|------|--------|------|
-| `HERMES_DIR` | `/opt/hermes` | 容器内 Hermes Agent Gateway 目录 |
-| `HFC_CONFIG` | `/opt/data/config.yaml` | sidecar 配置路径 |
-| `HFC_ENV_FILE` | `/opt/data/.env` | 飞书凭据文件 |
-| `HFC_VERSION` | `latest`（脚本）/ `v3.8.9`（Compose 示例） | 指定安装 tag 或分支 |
-| `HFC_PYTHON` | 自动检测 Hermes venv | 显式指定容器内 Python |
-
-示例：
-
-```bash
-export FEISHU_APP_ID=cli_xxx
-export FEISHU_APP_SECRET=xxx
-export HFC_VERSION=v3.8.9
-bash install-docker.sh
-```
-
-`docker-compose.example.yml` 只是适配示例，不是官方镜像。它展示 `/opt/hermes`、`/opt/data` 挂载和非交互安装方式。
-
-也可以从 Release 下载 `hermes-feishu-card-<version>-macos.tar.gz`、`hermes-feishu-card-<version>-linux.tar.gz` 或 `hermes-feishu-card-<version>-windows.zip`，解压后运行包内的 `install.sh` / `install.ps1`。完整安装包说明见 [README-install.md](README-install.md)。
-
-## 手动安装
-
-```bash
-git clone https://github.com/baileyh8/hermes-feishu-streaming-card.git
-cd hermes-feishu-streaming-card
-pip install -e ".[test]"
-
-export FEISHU_APP_ID=cli_xxx
-export FEISHU_APP_SECRET=xxx
-
-python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --yes
-```
-
-`setup` 是整合安装器：自动生成配置、检查 Hermes 版本和代码 anchor、把插件安装到 Hermes Gateway 实际运行的 venv Python、安装 hook、启动 sidecar 并做健康检查。它支持 `v2026.4.23` 起的旧版 Hermes，也支持 Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 与 `v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` 新版 anchor；Hermes `VERSION` 可带或不带 `v` 前缀。V3.8.6 起，Docker/source-stripped 环境缺少 `VERSION` 和 `.git` 时也可用 `gateway/run.py` anchor 兜底识别。
-
-如果你使用 Hermes 默认目录，也可以把凭据放在 `~/.hermes/.env`：
-
-```bash
-FEISHU_APP_ID=cli_xxx
-FEISHU_APP_SECRET=xxx
-FEISHU_CONNECTION_MODE=websocket
-FEISHU_HOME_CHANNEL=oc_xxx
-```
-
-之后使用：
-
-```bash
-python3 -m hermes_feishu_card.cli start --config ~/.hermes/config.yaml
-```
-
-V3.6.2 会继续自动读取 `~/.hermes/config.yaml` 同目录的 `~/.hermes/.env`。更宽泛的 `.env` 搜索路径会作为独立小项评估，不和 venv 安装修复混在同一版里。
-
-## 升级
-
-从 V3.2.x/V3.3.0/V3.4.x/V3.5.x/V3.6.x/V3.7.x/V3.8.0/V3.8.1/V3.8.2/V3.8.3/V3.8.4/V3.8.5/V3.8.6/V3.8.7/V3.8.8 升级到 V3.8.9 向后兼容，**单 Profile 配置无需任何修改**。如果 Hermes 使用自己的 venv，升级后请重新跑 `setup` 或 `install`，让插件同时进入 Hermes runtime Python 并刷新 hook。V3.8.9 保留 V3.8.8 的原生系统提示卡片化、V3.8.7 的新版 Hermes 首事件兼容和 V3.8.6 的 Docker/Hermes v0.18.0 兼容补丁，并修复飞书/Lark 话题内卡片 timeline 不更新与系统提示重复外溢；建议升级后执行一次 `doctor --explain`，并在普通会话和话题里各发送一次普通问题、`/new`、`/model` 或触发一次长任务/上下文提示验证状态。
-
-```bash
-# 1. 停止 sidecar
-python3 -m hermes_feishu_card.cli stop --config ~/.hermes_feishu_card/config.yaml
-
-# 2. 更新代码
-cd /path/to/hermes-feishu-streaming-card
-git checkout v3.8.9
-pip install -e ".[test]" --upgrade
-
-# 3. 诊断 Hermes hook strategy 与 anchors
-python3 -m hermes_feishu_card.cli doctor \
-  --config ~/.hermes_feishu_card/config.yaml \
-  --hermes-dir ~/.hermes/hermes-agent
-
-# 4. 重新安装 hook
-python3 -m hermes_feishu_card.cli install --hermes-dir ~/.hermes/hermes-agent --yes
-
-# 5. 启动 sidecar
-python3 -m hermes_feishu_card.cli start --config ~/.hermes_feishu_card/config.yaml
-```
-
-`doctor` 会优先从 `VERSION` 或 Git tag `v2026.4.23+` 判断 Hermes 支持状态。Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 与 `v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` 应命中 `gateway_run_013_plus`；旧版本 Hermes 应命中 `legacy_gateway_run`。如果 Docker 镜像缺少 `VERSION` 和 `.git` 元数据，V3.8.6 会用 `gateway/run.py` anchor 兜底，输出 `version_source: gateway anchors`。若 `doctor --explain` 提示可自动修复，先执行 `repair --hermes-dir ... --yes` 再重新安装 hook。
-
-## 核心功能
-
-- **飞书流式卡片**：`message.started`、`thinking.delta`、`answer.delta`、`tool.updated`、`message.completed`、`message.failed` 汇聚到同一张卡片。
-- **授权/选项交互**：Hermes approval、clarify choices 和独立 slash 命令优先显示为飞书按钮卡片；不可用时显示编号/文本 fallback，并交还 Hermes 原生文本选择流程。
-- **多 bot 与群聊绑定**：`bots.items` 注册多个飞书机器人，`bindings.chats` 按 `chat_id` 路由，`group_rules` 预留群聊策略。
-- **多 Profile 进程内隔离**：一个 sidecar 服务多个 Hermes profile，使用 `profile_id:message_id` 隔离 session。
-- **Profile / Bot 卡片标题**：全局、profile、bot 均可设置标题，bot 级优先。
-- **Cron 最终卡片与回复上下文**：cron 任务可发送最终卡片，reply card context 保留必要上下文。
-- **附件摘要与原生媒体投递**：卡片内展示 attachment summaries，hook 不抑制 Hermes 原生媒体/文件投递路径。
-- **DeepSeek 思维链兼容**：过滤 `<think>`/`</think>` 与 `<thinking>`/`</thinking>` 标签。
-- **工具调用跟踪**：累计工具调用次数和每个工具的当前状态。
-- **运行统计 footer**：显示耗时、模型、token、上下文占比；非终态卡片显示旋转生成中状态。
-- **故障隔离**：sidecar 不可用时 hook fail-open，Hermes 原生文本继续运行。
-- **安全安装/恢复**：安装器 fail-closed，`restore`/`uninstall` 检测文件改动后拒绝覆盖。
-
-## 配置
+## 最小配置
 
 复制 `config.yaml.example` 到本地使用，不要提交真实凭据。
-
-**单 Profile 最小配置**
 
 ```yaml
 server:
@@ -421,96 +86,20 @@ card:
   footer_fields: [duration, model, input_tokens, output_tokens, context]
 ```
 
-**单 Profile + 多 Bot / 群聊**
-
-```yaml
-server:
-  host: 127.0.0.1
-  port: 8765
-feishu:
-  app_id: ""
-  app_secret: ""          # fallback
-bots:
-  default: default
-  items:
-    sales:
-      app_id: "cli_sales_xxx"
-      app_secret: "xxx"
-    support:
-      app_id: "cli_support_yyy"
-      app_secret: "yyy"
-bindings:
-  fallback_bot: default
-  chats:
-    oc_5cc6a25d8815790fa890dd0226005e83: sales
-  group_rules:
-    enabled: false
-card:
-  title: Hermes Agent
-  footer_fields: [duration, model, input_tokens, output_tokens, context]
-```
-
-**多 Profile**
-
-```yaml
-server:
-  host: 127.0.0.1
-  port: 8765
-profiles:
-  engineering:
-    feishu:
-      app_id: "cli_eng_xxx"
-      app_secret: "xxx"
-    bots:
-      default: default
-      items:
-        default:
-          app_id: "cli_eng_xxx"
-          app_secret: "xxx"
-    bindings:
-      fallback_bot: default
-      chats: {}
-  sales:
-    feishu:
-      app_id: "cli_sales_xxx"
-      app_secret: "xxx"
-    bots:
-      default: default
-      items:
-        default:
-          app_id: "cli_sales_xxx"
-          app_secret: "xxx"
-    bindings:
-      fallback_bot: default
-      chats: {}
-card:
-  title: Hermes Agent
-  footer_fields: [duration, model, input_tokens, output_tokens, context]
-```
-
-多 Profile 模式下，`FEISHU_APP_ID` / `FEISHU_APP_SECRET` 不会覆盖 profile 内的 `feishu` 配置。`footer_fields` 支持 `duration`、`model`、`input_tokens`、`output_tokens`、`context`。
-
-## 飞书应用配置
+飞书凭据也可以放在配置同目录 `.env`：
 
 ```bash
-export FEISHU_APP_ID=cli_xxx
-export FEISHU_APP_SECRET=xxx
-
-# 真实飞书 smoke 测试
-python3 -m hermes_feishu_card.cli smoke-feishu-card \
-  --config config.yaml.example \
-  --chat-id oc_xxx
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+FEISHU_CONNECTION_MODE=websocket
+FEISHU_HOME_CHANNEL=oc_xxx
 ```
 
-如果凭据未配置，sidecar 会使用 no-op client；这适合本地单元测试，但不会向真实飞书发卡。真实联调前请检查：
+多 bot、群聊绑定、`bindings.chats`、multi profile、profile-aware routing、footer 字段和 no-op client 说明见 [详细使用手册](docs/user-guide.md#配置)。
 
-```bash
-python3 -m hermes_feishu_card.cli status --config ~/.hermes/config.yaml
-```
+## Hermes 流式配置
 
-确认 `/health.routing.bot_count` 大于 0，且 `last_route_error` 为空。
-
-## Hermes Gateway 流式配置
+确认 `streaming.enabled` 为 `true`，并让 Hermes 使用 edit transport。
 
 确保 Hermes `config.yaml` 中启用流式编辑：
 
@@ -520,107 +109,86 @@ streaming:
   transport: edit
 ```
 
-不要设置 `display.platforms.feishu.streaming: false`。也不要把 `display.show_reasoning` 当成本插件的必需开关；它可能在最终回复中追加 reasoning 代码块，反而干扰卡片流式体验。若模型只返回最终答案、没有 thinking 增量，卡片会直接显示最终答案。
+不要设置 `display.platforms.feishu.streaming: false`。也不要把 `display.show_reasoning` 当成本插件必需开关；它可能把 reasoning 追加到最终回复里，反而干扰卡片流式体验。插件会直接处理 Hermes 的 `thinking.delta` / `answer.delta`。
 
-## CLI 命令
+Hermes `v2026.4.23` 起的旧版和 Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 均有兼容策略；`doctor` 会优先从 `VERSION` 或 Git tag `v2026.4.23+` 判断支持状态。升级 Hermes 或插件后建议重新执行 `setup` 或 `install --hermes-dir ... --yes`。
+
+## Docker 容器内安装
+
+已有 Hermes 容器优先使用：
+
+```bash
+export FEISHU_APP_ID=cli_xxx
+export FEISHU_APP_SECRET=xxx
+export HFC_VERSION=v3.8.9
+bash install-docker.sh
+```
+
+默认路径：
+
+| 变量 | 默认值 |
+|---|---|
+| `HERMES_DIR` | `/opt/hermes` |
+| `HFC_CONFIG` | `/opt/data/config.yaml` |
+| `HFC_ENV_FILE` | `/opt/data/.env` |
+| `HFC_VERSION` | `latest` |
+
+`docker-compose.example.yml` 是适配示例，不是官方镜像。V3.8.6 起，Docker/source-stripped Hermes 缺少 `VERSION` 和 `.git` 时也会用 Gateway anchors 兜底判断 `gateway_run_013_plus`。
+
+## 常用命令
 
 | 命令 | 说明 |
-|------|------|
-| `setup --hermes-dir ... --yes` | 一键安装：配置、检测、hook、sidecar、健康检查 |
-| `doctor --config ... --hermes-dir ...` | 诊断 Hermes 版本、runtime import、`hook_strategy`、`compatibility`、anchors 和原因；支持 `--explain` / `--json` |
-| `install --hermes-dir ... --yes` | 安装插件到 Hermes runtime venv，并安装 hook 到 Hermes |
-| `repair --hermes-dir ... --yes` | 修复可验证的 hook manifest/backup 状态，不覆盖用户改动 |
+|---|---|
+| `setup --hermes-dir ... --yes` | 一键配置、检测、安装 hook、启动 sidecar |
+| `doctor --config ... --hermes-dir ... --explain` | 诊断 Hermes 版本、runtime import、hook strategy、anchors 和建议 |
+| `install --hermes-dir ... --yes` | 安装插件到 Hermes runtime venv，并安装 hook |
+| `repair --hermes-dir ... --yes` | 修复可验证的 hook manifest/backup 状态 |
 | `restore --hermes-dir ... --yes` | 恢复原始 Hermes 文件 |
-| `uninstall --hermes-dir ... --yes` | 卸载并恢复 |
-| `start --config ...` | 启动 sidecar |
-| `stop --config ...` | 停止 sidecar；校验 PID/token 与 `/health` 的 `process_pid/process_token_hash` 后才停止 |
-| `status --config ...` | 查看 sidecar 状态、routing、profile diagnostics 与 metrics |
-| `smoke-feishu-card --profile-id ... --chat-id ...` | 按指定 profile 发送真实飞书 smoke 卡片 |
-| `bots list|show|add|remove --config ...` | 管理飞书 Bot 注册 |
-| `bots test --profile-id ... --chat-id ...` | 按指定 profile/bot 做真实飞书 bot smoke |
-| `bots bind-chat|unbind-chat --config ...` | 管理 `bindings.chats` 群聊绑定 |
+| `start --config ...` / `status --config ...` / `stop --config ...` | sidecar 进程管理和 `/health` 检查 |
+| `smoke-feishu-card --profile-id ... --chat-id ...` | 真实飞书卡片 smoke test |
+| `bots list|show|add|remove|test` | 多 bot 注册、查看和联调 |
 
-## 架构
+高频流式调优通常不需要改。遇到 DeepSeek burst、token-by-token 或长上下文压力时再看：
+
+| 变量 | 默认值 | 用途 |
+|---|---:|---|
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MS` | `250` | Gateway 内 delta 最大合并等待时间 |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS` | `600` | pending delta 达到字符数后立即 flush |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING` | `128` | pending delta session 上限 |
+
+## 最新版本
+
+![飞书话题内卡片连续更新与思考工具 timeline 展示](docs/assets/feishu-topic-card-showcase-v389.png)
+
+| 版本 | 重点 |
+|---|---|
+| [v3.8.9](docs/release-notes-v3.8.9.md) | 飞书/Lark 话题内卡片连续更新，`system.notice` 不再重复外溢 |
+| [v3.8.8](docs/release-notes-v3.8.8.md) | Hermes 原生系统提示卡片化：Working、上下文压缩、skill loading、自我改进 review |
+| [v3.8.7](docs/release-notes-v3.8.7.md) | 新版 Hermes 缺少 `message.started` 时也能从首个 delta/completed 事件创建卡片 |
+| [v3.8.6](docs/release-notes-v3.8.6.md) | Docker/source-stripped Hermes 缺 `VERSION` 时用 Gateway anchors 兜底，兼容 Hermes v0.18.0 |
+| [v3.8.5](docs/release-notes-v3.8.5.md) | `/new`、`/model` 等直通命令执行结果保持卡片反馈 |
+
+完整版本历史见 [CHANGELOG.md](CHANGELOG.md)，更长的历史说明保留在 [详细使用手册](docs/user-guide.md#版本历史)。
+
+## 架构简图
 
 ```text
 Hermes Gateway
-  └─ minimal hook in gateway/run.py
-       └─ hermes_feishu_card.hook_runtime
-            └─ HTTP POST /events ——→  sidecar server
-                                      ├─ CardSession 状态机
-                                      ├─ render_card() 卡片渲染
-                                      ├─ Feishu CardKit HTTP client 已实现
-                                      ├─ tenant token / send / update
-                                      ├─ 节流、合并、重试、锁、诊断
-                                      └─ /health 指标
+  -> minimal hook in gateway/run.py
+     -> hermes_feishu_card.hook_runtime
+        -> HTTP POST /events
+           -> sidecar server
+              -> CardSession state
+              -> Feishu CardKit send/update
+              -> retry / coalescing / metrics / /health
 ```
 
-Hermes hook 将事件 fail-open 转发给 sidecar。sidecar 持有完整会话状态和飞书边界，可独立测试、重启、诊断。历史实现集中归档在 `legacy/`（`installer_v2.py`、`gateway_run_patch.py`、`patch_feishu.py` 等），不是 active runtime；当前主线以 `hermes_feishu_card/` 为准。迁移说明见 [docs/migration.md](docs/migration.md)。
+这是 sidecar-only 设计：Hermes hook 保持 fail-open，飞书发送、更新、状态机、重试、诊断都在 sidecar 中运行。历史 V2 实现归档在 `legacy/`，不是 active runtime。
 
-## 常见问题
+## 文档入口
 
-- **卡片没有思考/不流式**：检查 `streaming.enabled: true` 与 `streaming.transport: edit`，确认模型确实输出 `thinking.delta`。
-- **真实飞书没有卡片**：检查凭据是否进入 sidecar；没有凭据时是 no-op client。V3.6.2 会读取 config 同目录 `.env`，真实环境变量仍优先。
-- **hook 已安装但 Hermes 卡片完全不工作**：跑 `doctor --explain`，查看 `Runtime import` 是否为 `ok`。如果 Hermes venv 不能 import `hook_runtime`，重新执行 `setup` 或 `install --hermes-dir ... --yes`。
-- **卡片停在“思考中”**：看 `/health.diagnostics.last_terminal_event` 和 `feishu_update_failures`，确认终态事件是否到达、飞书 PATCH 是否成功。
-- **出现灰色原生文本**：通常说明 sidecar 未成功接收或更新终态；V3.5.x 已补 queued follow-up suppression 和终态优先更新。
-- **思考过程漏字/截断**：V3.5.x 已用 ordered send、append_block、PATCH 合并与终态优先修复；若仍出现，先检查 `/health.metrics.feishu_update_failures`。
-- **长表格/代码显示成 raw markdown**：V3.5.x 会结构化拆分；如果仍异常，减少单个表格列宽或代码块长度。
-- **重复卡片**：检查 `/health` metrics（`events_received`、`events_applied`、`feishu_send_successes`）。多 Profile 下 session key 为 `profile_id:message_id`。
-- **多 Profile 路由不确定**：跑 `status --config ...`，查看 `routing.last_route`、`profile.<id>.events`、`profile.<id>.last_profile_source`，再用 `smoke-feishu-card --profile-id ...` 或 `bots test --profile-id ...` 定向验证。
-- **Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 升级后无卡片**：先跑 `doctor --config ... --hermes-dir ...`，确认 `hook_strategy` 为 `gateway_run_013_plus`，再按需重新安装 hook。
-- **恢复失败**：`restore`/`uninstall` 检测到文件改动会拒绝覆盖，先跑 `doctor --explain` 看 manifest/backup/run.py 状态；若提示可自动修复，执行 `repair --hermes-dir ... --yes`，否则先备份再人工确认差异。
-- **只想验证本地 sidecar**：可以用 no-op client 跑测试；真实飞书 smoke 需要真实 App ID/Secret 和 chat id。
-
-## 版本历史
-
-| 版本 | 日期 | 主要变更 |
-|------|------|---------|
-| [v3.8.9](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.9) | 2026-07 | 飞书/Lark 话题内卡片连续更新：后续流式事件和 `system.notice` 通过 `reply_to_message_id` 回到原卡片，避免 timeline 停住和灰色提示重复 |
-| [v3.8.8](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.8) | 2026-07 | Hermes 原生系统提示卡片化：Working 心跳、上下文窗口/压缩提示、session reset、skill loading、自我改进 review 进入卡片或独立小卡片 |
-| [v3.8.7](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.7) | 2026-07 | issue #75，新版 Hermes 缺少 `message.started` 时，`answer.delta` / `thinking.delta` / `tool.updated` / `message.completed` 首事件也会创建卡片 |
-| [v3.8.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.6) | 2026-07 | issue #70，Docker/source-stripped Hermes 缺少 `VERSION` 时用 Gateway anchor 兜底，补齐 Hermes v0.18.0 / `v2026.7.1` 兼容 |
-| [v3.8.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.5) | 2026-07 | 始终允许 `/new` 等直通命令的执行结果也保持 Feishu/Lark 卡片反馈，移除无效 interactive direct update |
-| [v3.8.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.4) | 2026-07 | Feishu/Lark WebSocket 长连接 slash/model 原生命令卡片，修复 V3.8.3 本地 sidecar 只显示灰色文本 fallback 的问题 |
-| [v3.8.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.3) | 2026-07 | 独立 slash 命令卡片，`/new`/`/reset`/`/undo` 确认、`/model` 选择卡片、`/update` 非交互边界和文本 fallback |
-| [v3.8.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.2) | 2026-07 | 卡片 timeline 阅读体验补丁，pre-tool answer 延迟归档、终态正文去重、思考/工具折叠区层级区分、真实折叠/展开截图更新 |
-| [v3.8.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.1) | 2026-07 | issue #74，高频 delta Gateway-side 合并、终态前 flush、飞书内 `/hfc` 只读诊断命令、summary/诊断上下文 hash 脱敏 |
-| [v3.8.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.0) | 2026-07 | 卡片主回答与辅助 timeline 分离、工具摘要去重、terminal drain、Hermes runtime import 诊断修正、Docker 示例同步 |
-| [v3.7.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.7.0) | 2026-06 | issue #70，补齐现有 Hermes Docker 容器内安装与更新路径 |
-| [v3.6.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.6) | 2026-06 | issues #67/#68，中断/慢 PATCH 场景避免卡片和原生答复双发，doctor/install 提示 `hermes -V` 的真实 Project 目录 |
-| [v3.6.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.5) | 2026-06 | issues #64/#65，Feishu thread `message_id` 归一化、DeepSeek completed-only 最终答案回填并更新同一卡片 |
-| [v3.6.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.4) | 2026-06 | issues #61/#62，飞书 thread 卡片回复到原话题、cron `deliver: "feishu:oc_xxx"` 解析为卡片投递 |
-| [v3.6.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.3) | 2026-06 | issues #56-#59，Hermes v0.17 `_run_agent_inner` hook、localhost 交互 text fallback、Telegram 隔离、Windows profile path |
-| [v3.6.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.2) | 2026-06 | issue #53，安装到 Hermes runtime venv、doctor runtime import 检查、hook 失败 warning 诊断 |
-| [v3.6.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.1) | 2026-06 | issue #47，支持 Hermes `0.15.x` 和无 `v` 前缀 VERSION，避免 `doctor --explain` 误报 unsupported |
-| [v3.6.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.0) | 2026-06 | `doctor --json/--explain`、安全 `repair`、结构化媒体/文件摘要、多 profile 定向 smoke、routing profile diagnostics、Hermes 兼容矩阵 |
-| [v3.5.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.2) | 2026-06 | 跨平台一行安装、Release 安装包、macOS `.env` 安全解析、uv/PEP 668 Python 安装适配、Windows installer CI 解析验证 |
-| [v3.5.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.1) | 2026-06 | 流式更新排序与合并、飞书 JSON 2.0 按钮修复、queued follow-up 原生消息抑制、`.env` 凭据回退、README 首页重整 |
-| [v3.5.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.0) | 2026-06 | 飞书按钮交互闭环、issue #41、PR #42、长表格/代码块结构拆分、thinking 漏字修复 |
-| [v3.4.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.3) | 2026-05 | issue #39、Markdown 结构化切分、Hermes v0.14.0 / v2026.5.16+ 验证 |
-| [v3.4.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.2) | 2026-05 | issue #31，避免并发 PATCH 和 sequence 竞争导致内容回退/漏字 |
-| [v3.4.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.1) | 2026-05 | issue #25，Hermes v2026.5.7 fallback message id 生命周期一致 |
-| [v3.4.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.0) | 2026-05 | Hermes 0.13.0+ 兼容、旧版本 strategy、issue #23、多 profile/multi bot、附件与回复上下文 |
-| [v3.3.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.3.0) | 2026-05 | 多 Profile、DeepSeek 兼容、表格保护、Footer 动画、平台判断修复 |
-| [v3.2.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.1) | 2026-04 | Accept-Encoding 修复 |
-| [v3.2.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.0) | 2026-04 | 多 Bot 路由、群聊绑定、Bot CLI、路由诊断 |
-| [v3.1.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.1.0) | 2026-04 | Sidecar 架构、流式卡片、健康端点、安装向导 |
-| [v3.0.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.0.0) | 2026-04 | Sidecar-only 初始发布 |
-
-完整更新日志：[CHANGELOG.md](CHANGELOG.md)。
-
-## 测试与验收
-
-```bash
-python3 -m pytest -q
-```
-
-本版本自动化覆盖配置加载、hook patch、Hermes runtime event、sidecar session、飞书按钮 callback、长表格/代码块切分、queued follow-up completion、cron deliver precedence 和文档约束。
-
-已完成的人工/集成验收包括：真实 Feishu E2E 主链路、真实 Hermes Gateway E2E、真实飞书应用卡片验证、16k 长卡压力测试、`doctor -> install -> restore` 闭环、多 Profile 路由、DeepSeek 标签过滤。Feishu CardKit HTTP client 已实现，并通过 mock Feishu server 和真实飞书 smoke 验证。
-
-## 文档
-
+- 详细使用手册：[中文](docs/user-guide.md) / [English](docs/user-guide.en.md)
+- 安装包说明：[README-install.md](README-install.md)
 - 架构说明：[中文](docs/architecture.md) / [English](docs/architecture.en.md)
 - 事件协议：[中文](docs/event-protocol.md) / [English](docs/event-protocol.en.md)
 - 安装安全：[中文](docs/installer-safety.md) / [English](docs/installer-safety.en.md)
@@ -628,18 +196,17 @@ python3 -m pytest -q
 - 端到端验证：[中文](docs/e2e-verification.md) / [English](docs/e2e-verification.en.md)
 - 发布准备：[中文](docs/release-readiness.md) / [English](docs/release-readiness.en.md)
 - 测试说明：[中文](docs/testing.md) / [English](docs/testing.en.md)
+- 项目维护 Wiki：[docs/wiki](docs/wiki/README.md)
 
 ## 贡献者
 
-感谢以下贡献者对项目的改进：
-
-- [gischuck](https://github.com/gischuck) — [PR #12](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/12) Accept-Encoding 修复（V3.2.1 brotli 兼容）
-- [gischuck](https://github.com/gischuck) — [PR #76](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/76) 思考与工具 timeline 体验建议与实现探索（V3.8.x）
-- [fengs2021](https://github.com/fengs2021) — [PR #17](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/17) 锁架构优化与更新间隔改进（V3.3.0）
+- [gischuck](https://github.com/gischuck) - [PR #12](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/12) Accept-Encoding 修复
+- [gischuck](https://github.com/gischuck) - [PR #76](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/76) 思考与工具 timeline 体验建议与实现探索
+- [fengs2021](https://github.com/fengs2021) - [PR #17](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/17) 锁架构优化与更新间隔改进
 
 ## 安全说明
 
-不要把 App Secret、tenant token、真实 chat_id 提交到仓库。效果图仅用于展示卡片效果，生产凭据保存在本机配置或环境变量中。
+不要把 App Secret、tenant token、真实 chat_id、未脱敏截图提交到仓库。效果图仅用于展示卡片体验，生产凭据应保存在本机配置或环境变量中。
 
 ## License
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,0 +1,574 @@
+# Hermes Feishu Streaming Card Plugin
+
+[中文](user-guide.md) | [Project home](../README.en.md)
+
+<p align="center">
+  <a href="https://github.com/baileyh8/hermes-feishu-streaming-card/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&logo=github&label=Stars&color=2f80ed"></a>
+  <a href="https://github.com/baileyh8/hermes-feishu-streaming-card/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&logo=githubactions&label=Release&color=22c55e"></a>
+  <a href="https://github.com/baileyh8/hermes-feishu-streaming-card/actions/workflows/tests.yml"><img alt="Tests" src="https://img.shields.io/github/actions/workflow/status/baileyh8/hermes-feishu-streaming-card/tests.yml?branch=main&style=for-the-badge&label=Tests&logo=githubactions"></a>
+  <img alt="Python 3.9+" src="https://img.shields.io/badge/Python-3.9%2B-3776AB?style=for-the-badge&logo=python&logoColor=white">
+  <img alt="Feishu/Lark" src="https://img.shields.io/badge/Feishu%20%2F%20Lark-Streaming%20Cards-00D6B4?style=for-the-badge">
+  <img alt="Sidecar only" src="https://img.shields.io/badge/Runtime-Sidecar--only-7C3AED?style=for-the-badge">
+  <a href="../LICENSE"><img alt="License" src="https://img.shields.io/github/license/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&color=64748b"></a>
+</p>
+
+![Hermes Feishu Streaming Card cover](assets/readme-cover.png)
+
+Hermes Feishu Streaming Card turns Hermes Agent Gateway replies in Feishu/Lark into one continuously updated interactive card. Reasoning, tool calls, final answers, approvals, choices, and runtime stats stay in one readable card instead of spilling into scattered native text messages.
+
+It targets the real pain points of using Hermes inside Feishu: missing or out-of-order streaming text, long tables/code blocks rendered as raw Markdown, invisible tool progress, manual approval replies, sidecar troubleshooting, multi-bot/profile routing, and uncertain hook compatibility after Hermes upgrades.
+
+![Hermes Feishu card slash command interaction, command result feedback, and tool timeline showcase](assets/feishu-card-showcase-v385.png)
+
+Since V3.8.2, the final answer stays in the primary content area while pre-tool answer blocks follow a "show in main body -> archive when the next block arrives" rhythm. Reasoning and tools use different text sizes and visual weight inside the collapsible auxiliary timeline, and the footer no longer repeats the same tool-call summary.
+
+## Project Highlights
+
+- **Streaming card UX**: `thinking.delta`, `answer.delta`, `tool.updated`, and terminal events update one Feishu card.
+- **In-card interactions**: Hermes approval and clarify choices prefer Feishu buttons. Since V3.8.5, Feishu/Lark WebSocket long-connection deployments also render independent slash-command confirmations, pickers, and execution results such as `/new`, `/reset`, and `/model` as native interactive cards, falling back to Hermes native text only when cards are unavailable.
+- **Runtime notices stay tidy**: Since V3.8.8, native Hermes `Working` heartbeats, context/compression notices, automatic session resets, skill loading, and self-improvement reviews prefer cards or compact notice cards instead of scattered gray native text.
+- **Consistent topic replies**: Since V3.8.9, Feishu/Lark topic reply streams and system notices resolve back to the same card, avoiding frozen topic timelines and duplicate gray native notices.
+- **Long content protection**: Markdown tables and fenced code blocks split on structure boundaries instead of raw character cuts.
+- **Multi-bot / multi-profile**: bot registry, chat bindings, profile-aware session keys, titles, and routing diagnostics.
+- **sidecar-only runtime**: Hermes hook stays fail-open while Feishu delivery, session state, retries, and health checks live in the sidecar.
+- **Install and release friendly**: one-line installers, Release packages, `doctor`, `start/status/stop`, and safe restore/uninstall flows.
+
+## Pain Points Solved
+
+| Pain point | Project capability |
+|---|---|
+| Feishu only shows a final wall of text | Reasoning, answer, tool status, and runtime footer stream into one card |
+| Tool-heavy runs lose text, reorder chunks, or spill native gray messages | per-message ordering, PATCH coalescing, terminal priority, and native resend suppression |
+| Hermes emits separate gray `Working`, context, skill loading, or review notices | `system.notice` cardification: session notices enter the auxiliary timeline; task-external notices use compact standalone cards |
+| Topic replies show the first card but the timeline stops updating, while notices also appear outside the card | Topic events resolve by `reply_to_message_id`, keeping updates on the original card and suppressing duplicate native notice text |
+| Approval, choice prompts, or slash-command confirmations require manual text replies | Agent-turn choices stay in the active card; independent slash commands use standalone command cards, with numbered text fallback when cards are unavailable |
+| Long tables/code blocks render as raw Markdown | Markdown-aware table/code splitting with repeated headers and complete fences |
+| Multi-bot, group, and profile routing is hard to inspect | `bindings.chats`, profile-aware sessions, and `/health.routing` diagnostics |
+| Hook or sidecar failures are hard to debug | `doctor`, runtime import checks, `/health` metrics, fail-closed installer, restore/uninstall |
+
+## V3.8.9 Feishu Topic Card Continuity Patch
+
+V3.8.9 fixes Feishu/Lark topic reply flows where the first card appears, but later `answer.delta`, `thinking.delta`, `tool.updated`, or `system.notice` events can miss the same card because Hermes switches to a different internal streaming `message_id`. In that state, system notices can also appear both inside the card timeline and as separate gray native messages.
+
+- **One card keeps updating inside the topic**: the sidecar maps later topic events back to the active card session through `reply_to_message_id`.
+- **No duplicate gray notices after cardification**: when a session-scoped `system.notice` is accepted into the card, the sidecar returns `applied: true`; if card delivery briefly times out, recognized Hermes system notices are still suppressed instead of being resent as gray native text.
+- **Hermes v0.18.x Relay metadata support**: the hook runtime preserves Relay `source.message_id` as the original topic reply anchor.
+
+![Feishu topic reply card continuity and reasoning/tool timeline showcase](assets/feishu-topic-card-showcase-v389.png)
+
+The screenshot above shows a real Feishu topic verification: the topic reply pane keeps the card updating, the reasoning/tool timeline, final answer, and footer stats stay on the same card. Context and self-improvement notices enter cards or compact standalone cards instead of spilling out as extra gray native messages.
+
+Full release notes: [docs/release-notes-v3.8.9.md](release-notes-v3.8.9.md).
+
+## V3.8.8 Hermes Native System Notice Cardification
+
+V3.8.8 folds native Hermes gray runtime notices into the Feishu/Lark card experience. `Working` heartbeats, context-window/compression notices, automatic session resets, skill loading, and self-improvement review messages are classified as `system.notice`. If the active task card can still update, the notice goes into the auxiliary "Reasoning and Tools" timeline; otherwise it is sent as a compact standalone notice card.
+
+- **Fewer scattered gray notices**: context, compression, reset, skill-loading, and review messages prefer card delivery.
+- **Heartbeats update one entry**: `Working — iteration ...` notices reuse the same `notice_id`, avoiding repeated timeline spam.
+- **Still fail-open**: if the sidecar is unavailable, the notice is unknown, or card delivery fails, Hermes native text fallback still runs.
+
+Full release notes: [docs/release-notes-v3.8.8.md](release-notes-v3.8.8.md).
+
+## V3.8.7 Newer Hermes First-Event Compatibility Patch
+
+V3.8.7 fixes issue #75: some newer Hermes streams can start directly with `answer.delta`, `thinking.delta`, `tool.updated`, or `message.completed` instead of sending `message.started` first. Older sidecar versions had no session yet, counted those events as `events_ignored`, and never sent the initial Feishu/Lark card. These message events can now create the card session and send the first card.
+
+- **No hard dependency on `message.started`**: answer, thinking, tool, and completed first events can all start a card.
+- **Existing paths remain compatible**: normal `message.started`, interaction, cron completion, and terminal diagnostics behavior is preserved.
+- **Stacks with V3.8.6**: Docker/source-stripped Hermes roots without `VERSION` still use Gateway anchor fallback.
+
+Full release notes: [docs/release-notes-v3.8.7.md](release-notes-v3.8.7.md).
+
+## V3.8.6 Docker / Hermes v0.18.0 Compatibility Patch
+
+V3.8.6 fixes the issue #70 Docker install path. Upstream Hermes v0.18.0 / `v2026.7.1` can be deployed without a top-level `VERSION` file, and container images often omit local `.git` metadata too. `doctor --explain`, `install`, and `setup` now continue by reading verified `gateway/run.py` anchors; when those anchors match, the installer uses `gateway_run_013_plus` instead of failing with `Hermes VERSION missing, unknown, or invalid`.
+
+- **Hermes v0.18.0**: `v2026.7.1`, `0.18.0`, and `v0.18.0` are in the compatibility matrix and keep using `gateway_run_013_plus`.
+- **Docker no-VERSION fallback**: diagnostics report `version_source: gateway anchors`, `version: unknown`, and the inferred `hook_strategy`.
+- **Explicit bad versions still fail closed**: only missing metadata falls back to anchors; invalid `VERSION` contents still block install.
+
+Full release notes: [docs/release-notes-v3.8.6.md](release-notes-v3.8.6.md).
+
+## V3.8.5 Command Result Card Feedback Patch
+
+V3.8.5 completes the V3.8.4 always-allowed/no-confirm path. When Hermes directly executes `/new`, `/reset`, `/clear`, `/undo`, `/stop`, or direct `/model <model>`, the command result now replies as a Feishu/Lark interactive card instead of gray native text. `/model` switch feedback stays in a green card, while `/update` remains Hermes' background upgrade command and does not render an interaction card.
+
+- **Direct command results become cards**: the patcher passes the current `event` into hook runtime, so Feishu adapter `send()` can recognize standalone slash-command results.
+- **Cleaner interactive updates**: button and dropdown clicks rely on the Feishu callback response to update the original card, without an extra unsupported interactive `message.update` call.
+- **Upgrade compatible**: rerunning `install` rewrites the V3.8.4 command-card hook block into the V3.8.5 `event=event` form.
+
+Full release notes: [docs/release-notes-v3.8.5.md](release-notes-v3.8.5.md). The previous WebSocket-native command-card hotfix is documented in [docs/release-notes-v3.8.4.md](release-notes-v3.8.4.md).
+
+## V3.8.4 Feishu WebSocket Command Cards Hotfix
+
+V3.8.4 fixes the V3.8.3 local/private sidecar gap where slash commands still fell back to gray native text. Confirmations for `/new`, `/reset`, and `/undo` now reuse Hermes' Feishu adapter WebSocket card-action channel to send native interactive cards; `/model` uses the same native card path for model selection. Active Agent streaming cards still own approval, clarify, conversation choices, and reasoning/tool timelines; slash commands do not get merged into an unrelated Agent card.
+
+- **WebSocket-native confirmation cards**: the plugin dynamically installs Feishu adapter `send_slash_confirm(...)`, and button clicks route through `_on_card_action_trigger` into `tools.slash_confirm.resolve(...)`.
+- **WebSocket-native model picker**: when Hermes asks the Feishu adapter for `send_model_picker(...)`, the plugin installs a Feishu-only picker and writes the callback result back to the same command card.
+- **No duplicate choice cards**: when WebSocket-native command cards are available, the sidecar pre-interaction is skipped so `/new` does not show both a sidecar choice card and a native button card.
+- **No `/update` interaction card**: `/update` remains Hermes's background upgrade command and does not render interactive buttons.
+- **Safe fallback**: if native Feishu cards, the sidecar, polling, or completion updates fail, Hermes native text behavior remains available.
+
+Full release notes: [docs/release-notes-v3.8.4.md](release-notes-v3.8.4.md). The previous standalone command-card baseline is documented in [docs/release-notes-v3.8.3.md](release-notes-v3.8.3.md).
+
+## V3.8.2 Card Timeline Readability Patch
+
+V3.8.2 focuses on the real Feishu reading experience inside the auxiliary timeline. Natural-language pre-tool answer blocks stay in the main body until the next pre-tool answer or terminal event arrives, then move into "Reasoning and Tools"; terminal cards strip already archived intermediate prefaces so the primary content keeps only the final answer.
+
+- **Delayed pre-tool answer folding**: a pre-analysis block no longer flashes away immediately; it is archived only when the next block or terminal state arrives.
+- **Cleaner terminal cards**: completed cards remove archived preface text when the final answer already contains it.
+- **Clearer timeline hierarchy**: reasoning entries use small primary text, while tool details use smaller, lighter quoted text so long commands do not dominate the answer.
+- **Raw thinking stays hidden**: low-level `thinking.delta` remains internal stream state; the timeline only shows user-readable pre-tool answer text.
+
+Full release notes: [docs/release-notes-v3.8.2.md](release-notes-v3.8.2.md).
+
+## V3.8.1 High-Frequency Streaming and In-Feishu Diagnostics Patch
+
+V3.8.1 fixes issue #74. With Hermes Agent 0.17.0+, thinking models, long context, and token-by-token high-frequency deltas, the hook now coalesces `thinking.delta` / `answer.delta` inside the Hermes Gateway process before sending fewer events to the sidecar. This reduces object allocation, lock contention, and HTTP scheduling pressure on the stream-reader thread, avoiding `Stream stale for 180s` failures caused by the plugin path.
+
+- **Gateway-side delta coalescing**: adds `HERMES_FEISHU_CARD_DELTA_COALESCE_MS`, `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS`, and `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING`; defaults work without extra config.
+- **Flush before terminal state**: `message.completed` / `message.failed` flush pending deltas for the same message before rendering the terminal card.
+- **Read-only commands inside Feishu**: `/hfc help`, `/hfc status`, `/hfc doctor`, and `/hfc monitor` reply with diagnostic cards and do not perform write actions.
+- **Safer diagnostics**: `/messages/{message_id}/summary` and `/hfc` cards expose hashed chat/message/thread context instead of raw ids.
+
+Full release notes: [docs/release-notes-v3.8.1.md](release-notes-v3.8.1.md).
+
+## V3.8.0 Card UX and Streaming Stability Upgrade
+
+V3.8.0 focuses on the real Feishu reading experience. The final answer remains in the main content area, reasoning / tool timeline data moves into the auxiliary area, and terminal rendering drains pending updates before writing the final card.
+
+- **Clearer primary answer**: long reasoning and tool lists no longer push the final response out of the main reading area.
+- **Less duplication**: when the auxiliary timeline is visible, the footer does not render another "N tool calls" summary.
+- **More stable terminal state**: pending card updates are drained before the terminal card render so stale intermediate snapshots do not win the last PATCH.
+- **More accurate diagnostics**: `doctor` runs the Hermes runtime import check from the Hermes project root, avoiding false positives from the current repository path.
+- **Docker examples updated**: V3.8.0 refreshed the Docker install examples while still using `install-docker.sh` inside existing Hermes containers.
+
+Full release notes: [docs/release-notes-v3.8.0.md](release-notes-v3.8.0.md).
+
+## V3.6.6 Interrupt Dedupe and Install Diagnostics Patch
+
+V3.6.6 fixes issues #67 and #68. `message.completed` now uses the sidecar `applied` response to decide whether the card path really took ownership, and terminal events no longer wait for slow Feishu PATCH calls before ACKing Hermes. This prevents interrupted or backlogged sessions from producing both a streaming card and a native gray text reply. `doctor --explain` / `install` also detect a wrong `--hermes-dir` by reading the `Project:` path from `hermes -V` and suggesting the correct Hermes root.
+
+Full release notes: [docs/release-notes-v3.6.6.md](release-notes-v3.6.6.md).
+
+## V3.7.0 Docker Deployment Adapter
+
+V3.7.0 adds issue #70: existing Hermes Docker container upgrade and install support.
+
+Full release notes: [docs/release-notes-v3.7.0.md](release-notes-v3.7.0.md).
+
+## V3.6.5 Streaming Terminal Stability Patch
+
+V3.6.5 fixes issues #64 and #65. In Feishu thread scenarios, `message.started` now uses the same reply anchor as streaming callbacks for the card session `message_id`, preventing `events_applied=0`. For burst-output models such as DeepSeek, completed events can now backfill the final answer from `message.completed` / `agent_result.final_response` even when no `thinking.delta` or `answer.delta` events were emitted.
+
+Full release notes: [docs/release-notes-v3.6.5.md](release-notes-v3.6.5.md).
+
+## V3.6.4 Thread Reply and Cron Delivery Patch
+
+V3.6.4 fixes issues #61 and #62. When a user sends a message from a Feishu thread, the initial streaming card is now sent back into the same thread through the Feishu reply API and subsequent updates keep patching that card. Cron jobs configured with `deliver: "feishu:oc_xxx"` now parse the chat id from `deliver`, so scheduled jobs can render as cards instead of falling back to plain text.
+
+Full release notes: [docs/release-notes-v3.6.4.md](release-notes-v3.6.4.md).
+
+## V3.6.3 Hermes v0.17 Compatibility and Interaction Patch
+
+V3.6.3 fixes issues #56-#59. For Hermes v0.17.0+ / `v2026.6.19+`, where the real streaming implementation can move into `_run_agent_inner`, the patcher now injects `tool.updated`, `answer.delta`, `thinking.delta`, clarify, and approval hooks into `_run_agent_inner` before falling back to `_run_agent`.
+
+localhost/private sidecars keep numbered text fallback for sidecar-owned choices, while V3.8.5 uses the Feishu/Lark WebSocket long-connection card-action path for native slash/model command cards. Those standalone commands do not require a public HTTP callback, and direct command execution results also stay in cards.
+
+This release also ignores non-Feishu platforms such as Telegram at runtime event construction, and correctly resolves Windows profile paths like `C:\Users\...\AppData\Local\hermes\profiles\thinking`.
+
+Full release notes: [docs/release-notes-v3.6.3.md](release-notes-v3.6.3.md).
+
+## V3.6.2 Runtime Install Patch
+
+V3.6.2 fixes issue #53: `setup` / `install` now detects the Python interpreter that Hermes Gateway actually runs from, such as `~/.hermes/hermes-agent/venv/bin/python`, and installs the same `hermes-feishu-streaming-card` release into that runtime venv before patching `gateway/run.py`.
+
+`doctor --explain` and `doctor --json` now include a `runtime_import` check for `hermes_feishu_card.hook_runtime`. Hook import/emit failures also remain fail-open but are no longer fully silent; Hermes stderr gets a `[hermes-feishu-card] hook failed: ...` diagnostic warning.
+
+Full release notes: [docs/release-notes-v3.6.2.md](release-notes-v3.6.2.md).
+
+## V3.6.1 Compatibility Patch
+
+V3.6.1 fixes issue #47: Hermes `VERSION` values without a leading `v`, such as `0.15.1`, are no longer reported as unsupported by `doctor --explain`. Hermes `0.15.x` / `v0.15.x` continues to use `gateway_run_013_plus` when the required `gateway/run.py` anchors are present.
+
+Full release notes: [docs/release-notes-v3.6.1.md](release-notes-v3.6.1.md).
+
+## V3.6.0 Operations Upgrade
+
+V3.6.0 focuses on real deployment operations after the streaming-card baseline is already in place: diagnosing hook/sidecar/Hermes state, repairing safe installer drift, keeping media/file delivery visible, and making multi-profile routing easier to verify.
+
+- **Readable and machine-readable diagnostics**: `doctor --explain` summarizes the next action for humans, while `doctor --json` reports config, sidecar, Hermes, streaming, install state, and recommendations.
+- **Safe installer repair**: `repair --hermes-dir ... --yes` and `setup --repair` rebuild only verifiable manifest/backup state and refuse unverifiable user edits.
+- **Media/file safety**: structured Hermes `attachments`, `files`, `media_files`, and image/audio/video objects are summarized in cards while native Hermes media/file delivery remains unsuppressed.
+- **Multi-profile operations**: `smoke-feishu-card --profile-id`, `bots test --profile-id`, CLI `status`, and `/health.routing.profiles` expose profile-scoped routing state.
+- **Compatibility matrix**: tests cover Hermes `v2026.4.23`, `v2026.5.7`, `v2026.5.16+`, `v2026.5.29`, `v2026.6.19+`, `v2026.7.1+`, `0.13.x`, `0.14.x`, `0.15.x`, `0.17.x`, `0.18.x`, and semver `VERSION` values with or without a `v` prefix.
+
+Full release notes: [docs/release-notes-v3.6.0.md](release-notes-v3.6.0.md).
+
+## V3.5.x Runtime Baseline
+
+- **End-to-end ordering for one card**: runtime sends, sidecar updates, and terminal Feishu PATCH calls are ordered/coalesced by message id, reducing thinking/answer truncation under backlog.
+- **Faster streaming updates**: sidecar events ACK quickly while card updates are coalesced; terminal events prioritize the final card update in the background.
+- **Feishu JSON 2.0 buttons fixed**: interaction buttons now use direct `button` elements with `behaviors.callback`, avoiding PATCH failures in active cards.
+- **Queued follow-up native text suppression**: queued completions emit `message.completed` into the card path and suppress native resend once the Feishu card is delivered.
+- **`.env` credential fallback**: `load_config()` reads `.env` next to the selected config file, so manual sidecar restarts do not silently enter no-op mode when credentials live beside Hermes config.
+- **Chinese README homepage reorganized**: the homepage leads with user scenarios, V3.5.x value, installation, troubleshooting, and release history.
+- **V3.6.0 operations polish**: profile-targeted smoke checks, routing profile diagnostics, structured attachment summaries, and safe repair build on the V3.5.x baseline.
+
+## V3.5.0 Feature Highlights
+
+- **Feishu button interaction loop**: Hermes approval and choice prompts are rendered inside the same streaming card; clicking a button records the choice in the sidecar, lets the Hermes hook continue, and updates the original card.
+- **issue #41 fixed**: multi-reply and newer Hermes streaming flows keep using card updates, so final answers no longer fall back to native text after the first reply.
+- **PR #42 handled**: cron card routing now prefers `job['deliver']` and scheduler-resolved Feishu targets, so jobs migrated from Discord/Telegram are not skipped because of stale `origin.platform`.
+- **Long table/code protection improved**: a single Markdown table or fenced code block longer than `MAIN_CONTENT_CHUNK_CHARS` is split into multiple still-valid Markdown blocks instead of raw fragments.
+- **thinking truncation fixed**: Hermes interim assistant callbacks are treated as complete thinking blocks via `thinking.delta(mode=append_block)`, preventing missing characters or glued sentences.
+- **Hermes `v0.14.0` / `v2026.5.16+` support remains verified**: the installer selects `gateway_run_013_plus`; `v2026.4.x` remains on `legacy_gateway_run`.
+- **issue #39 fixed**: whitespace-only `message.completed.answer` values no longer clear answers already streamed through `answer.delta`, preventing DeepSeek V4 Pro tool-call flows from ending with an empty Feishu card.
+- **issue #31 fixed**: PATCH updates for the same Feishu card are serialized per session, preventing older snapshots from landing after newer content and making thinking/answer text flicker, truncate, or roll back.
+- **safer concurrent event sequences**: runtime sequence allocation is locked so concurrent Hermes callbacks cannot produce duplicate sequence ids for valid `thinking.delta` / `answer.delta` chunks.
+- **issue #25 fixed**: Hermes v2026.5.7 started hooks now treat `event_message_id` as the explicit `message_id`, preventing `message.started` and `message.completed` fallback card ids from diverging.
+- **Hermes 0.13.0+/0.14.0 and later**: the installer selects the `gateway_run_013_plus` hook strategy from the Hermes version and code anchors.
+- **older Hermes remains supported**: Hermes `v2026.4.23` through `0.12.x` continues to use the `legacy_gateway_run` strategy; no plugin downgrade is required.
+- **doctor reports compatibility**: `doctor` prints `hook_strategy`, `compatibility`, and anchor detection results so you can confirm the selected path.
+- **Reinstall the hook after upgrading**: run `install --hermes-dir ... --yes` after upgrading so Hermes uses the matching hook implementation.
+- **issue #23 fixed**: multi Hermes profile + multi Feishu bot deployments explicitly identify profile ids and route to the matching bot.
+- **Multi-profile / multi-bot polish**: per-bot/profile title, cron final cards, attachment summaries + native media delivery, and reply card context.
+
+## One-Line Install
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/baileyh8/hermes-feishu-streaming-card/main/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/baileyh8/hermes-feishu-streaming-card/main/install.ps1 | iex
+```
+
+The installer installs or upgrades the package, reads or prompts for Feishu credentials, writes `~/.hermes/.env`, and runs the integrated setup command:
+
+```bash
+python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --config ~/.hermes/config.yaml --yes
+```
+
+After installation:
+
+```bash
+python3 -m hermes_feishu_card.cli status --config ~/.hermes/config.yaml
+```
+
+Common environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HFC_VERSION` | `latest` | Version to install, such as `v3.8.9`, `v3.6.6`, or `main` |
+| `HERMES_DIR` | `~/.hermes/hermes-agent` | Hermes Agent Gateway directory |
+| `HFC_CONFIG` | `~/.hermes/config.yaml` | sidecar config path |
+| `HFC_ENV_FILE` | `.env` next to `HFC_CONFIG` | Feishu credential file |
+| `HFC_SKIP_START` | `0` | Set to `1` to install the hook without starting sidecar |
+| `HFC_NO_PROMPT` | `0` | Set to `1` for non-interactive automation |
+
+High-frequency streaming knobs usually do not need manual tuning:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MS` | `250` | Maximum Gateway-runtime wait before flushing coalesced deltas; set `0` to disable |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS` | `600` | Flush immediately once pending deltas reach this character count |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING` | `128` | Maximum pending delta sessions kept in Gateway runtime |
+
+## Docker Containers
+
+Use `install-docker.sh` inside an existing Hermes container. It defaults to
+`/opt/hermes` for Hermes and `/opt/data/config.yaml` for sidecar config. The
+script selects Hermes venv Python and does not fall back to system Python unless
+`HFC_PYTHON` is set.
+
+Example:
+
+```bash
+export FEISHU_APP_ID=cli_xxx
+export FEISHU_APP_SECRET=xxx
+export HFC_VERSION=v3.8.9
+bash install-docker.sh
+```
+
+GitHub Releases also include `hermes-feishu-card-<version>-macos.tar.gz`, `hermes-feishu-card-<version>-linux.tar.gz`, and `hermes-feishu-card-<version>-windows.zip`. Download one, extract it, and run `install.sh` or `install.ps1`. See [README-install.md](../README-install.md) for package details.
+
+## Manual Install
+
+```bash
+git clone https://github.com/baileyh8/hermes-feishu-streaming-card.git
+cd hermes-feishu-streaming-card && pip install -e ".[test]"
+export FEISHU_APP_ID=cli_xxx FEISHU_APP_SECRET=xxx
+python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --yes
+```
+
+`setup` generates config, validates Hermes (older Hermes from `v2026.4.23` through `v2026.4.x`, plus Hermes `0.13.0+`, `0.14.0`, `0.15.x`, `0.17.x`, `0.18.x` / `v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` anchors), installs the package into the Hermes Gateway runtime venv Python, installs the hook, starts the sidecar, and checks health — all in one pass. Hermes semantic `VERSION` values may include or omit the `v` prefix. Since V3.8.6, Docker/source-stripped installs without `VERSION` or `.git` metadata can fall back to verified `gateway/run.py` anchors.
+
+## Core Features
+
+- **Multi-profile in-process** (new in V3.3.0): one sidecar serves multiple Hermes profiles with `profile_id:message_id` composite keys for session isolation and per-profile credentials/bot routing
+- **Multi-bot routing & group chat**: register bots in `bots.items`, map `bindings.chats` to `chat_id`, fallback/default bot for unmatched sessions
+- **Profile / bot card titles**: global, profile, and bot card titles are supported, with bot-level titles taking precedence
+- **Streaming thinking**: renders `thinking.delta`, filters `<think>`/`</think>` and DeepSeek `<thinking>`/`</thinking>` tags
+- **Progressive answer**: streams `answer.delta` into one card, replaces thinking on completion
+- **Approval/choice interactions**: Hermes approval, clarify choices, and independent slash commands prefer Feishu button cards; when unavailable they fall back to numbered/text choices and Hermes' native text reply path
+- **Cron final cards and reply context**: cron jobs can deliver final cards, and reply cards preserve the needed context
+- **Attachment summaries and native media delivery**: cards show attachment summaries while the hook keeps Hermes native media/file delivery paths unsuppressed
+- **Tool call tracking**: `tool.updated` shows cumulative call count and status
+- **Runtime footer**: duration, model, tokens, context %. Non-terminal cards show a rotating braille spinner
+- **Table limit protection** (new in V3.3.0): auto-truncates tables exceeding Feishu's 5-table limit with a notice appended
+- **Platform check fix** (new in V3.3.0): non-Feishu platforms no longer swallowed by the complete hook
+- **Fault isolation**: sidecar unavailable → Hermes hook fail-open, native text continues working
+- **Safe installer**: fail-closed, checks version and code structure before writing. `restore`/`uninstall` refuse on modified files
+
+## Upgrading
+
+Upgrading from V3.2.x/V3.3.0/V3.4.x/V3.5.x/V3.6.x/V3.7.x/V3.8.0/V3.8.1/V3.8.2/V3.8.3/V3.8.4/V3.8.5/V3.8.6/V3.8.7/V3.8.8 to V3.8.9 is backward-compatible. **Single-profile configs need no changes.** If Hermes uses its own venv, rerun `setup` or `install` after upgrading so the package also lands in the Hermes runtime Python and the hook is refreshed. V3.8.9 keeps V3.8.8's native Hermes system notice cardification, V3.8.7's newer-Hermes first-event compatibility, and V3.8.6's Docker/Hermes v0.18.0 compatibility, then fixes topic reply card continuity and duplicate native notice fallback; run `doctor --explain` once after upgrading and verify both a normal Feishu chat and a topic reply with a normal prompt, `/new`, `/model`, or a long-running/context-notice task.
+
+```bash
+# 1. Stop sidecar
+python3 -m hermes_feishu_card.cli stop --config ~/.hermes_feishu_card/config.yaml
+
+# 2. Update code
+cd /path/to/hermes-feishu-streaming-card
+git checkout v3.8.9 && pip install -e ".[test]" --upgrade
+
+# 3. Diagnose Hermes hook strategy and anchors
+python3 -m hermes_feishu_card.cli doctor --config ~/.hermes_feishu_card/config.yaml --hermes-dir ~/.hermes/hermes-agent
+
+# 4. Reinstall hook when hook_strategy should change
+python3 -m hermes_feishu_card.cli install --hermes-dir ~/.hermes/hermes-agent --yes
+
+# 5. Start sidecar
+python3 -m hermes_feishu_card.cli start --config ~/.hermes_feishu_card/config.yaml
+```
+
+**Using multi-profile**: add a `profiles` section to `config.yaml` (see multi-profile config example below) with per-profile `feishu.app_id`/`app_secret`. Environment variables `FEISHU_APP_ID`/`FEISHU_APP_SECRET` are ignored in multi-profile mode.
+
+**Rolling back to V3.2**: stop sidecar, `git checkout v3.2.1`, reinstall `pip`, restore backed-up `config.yaml`, re-run `install` + `start`.
+
+## Configuration
+
+Copy `config.yaml.example` locally. Never commit real credentials. Three common setups:
+
+**Single Profile (minimal)** — quickest way to start:
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8765
+feishu:
+  app_id: ""
+  app_secret: ""
+card:
+  title: Hermes Agent
+  footer_fields: [duration, model, input_tokens, output_tokens, context]
+```
+
+**Single Profile + Multi-bot** — register bots, route by chat_id:
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8765
+feishu:
+  app_id: ""
+  app_secret: ""          # fallback only
+bots:
+  default: default
+  items:
+    sales:
+      app_id: "cli_sales_xxx"
+      app_secret: "xxx"
+    support:
+      app_id: "cli_support_yyy"
+      app_secret: "yyy"
+bindings:
+  fallback_bot: default
+  chats:
+    oc_5cc6a25d8815790fa890dd0226005e83: sales
+  group_rules:
+    enabled: false
+card:
+  title: Hermes Agent
+  footer_fields: [duration, model, input_tokens, output_tokens, context]
+```
+
+**Multi-profile** (new in V3.3.0) — one sidecar, multiple Hermes instances, isolated per profile:
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8765
+profiles:
+  engineering:
+    feishu:
+      app_id: "cli_eng_xxx"
+      app_secret: "xxx"
+    bots:
+      default: default
+      items:
+        default:
+          app_id: "cli_eng_xxx"
+          app_secret: "xxx"
+    bindings:
+      fallback_bot: default
+      chats: {}
+  sales:
+    feishu:
+      app_id: "cli_sales_xxx"
+      app_secret: "xxx"
+    bots:
+      default: default
+      items:
+        default:
+          app_id: "cli_sales_xxx"
+          app_secret: "xxx"
+    bindings:
+      fallback_bot: default
+      chats: {}
+  group_rules:
+    enabled: false
+card:
+  title: Hermes Agent
+  footer_fields: [duration, model, input_tokens, output_tokens, context]
+```
+
+In multi-profile mode, `FEISHU_APP_ID`/`FEISHU_APP_SECRET` env vars are ignored. `footer_fields` accepts: `duration`, `model`, `input_tokens`, `output_tokens`, `context`.
+
+## Feishu App Setup
+
+```bash
+export FEISHU_APP_ID=cli_xxx FEISHU_APP_SECRET=xxx
+# Real Feishu smoke test:
+python3 -m hermes_feishu_card.cli smoke-feishu-card --config config.yaml.example --chat-id oc_xxx
+```
+
+## Hermes Gateway Streaming And Thinking
+
+Ensure Hermes `config.yaml` has `streaming.enabled: true` and `streaming.transport: edit`. Avoid `display.platforms.feishu.streaming: false`. Do not treat `display.show_reasoning` as required — it may prepend a reasoning code block to the final text, interfering with the card streaming experience. If the model only returns final answers (no thinking deltas), the card shows the final answer directly.
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `setup --hermes-dir ... --yes` | One-shot install (config, check, hook, sidecar, health) |
+| `doctor --config ... --hermes-dir ...` | Diagnostics: `version_source`, `version`, `minimum_supported_version`, `run_py_exists`, `hook_strategy`, `compatibility`, anchors, `reason`; supports `--explain` / `--json` |
+| `install --hermes-dir ... --yes` | Install hook into Hermes |
+| `repair --hermes-dir ... --yes` | Repair verifiable hook manifest/backup state without overwriting user edits |
+| `restore --hermes-dir ... --yes` | Restore original Hermes files |
+| `uninstall --hermes-dir ... --yes` | Uninstall and restore |
+| `start --config ...` | Start sidecar |
+| `stop --config ...` | Stop sidecar (validates PID/token against `/health` `process_pid/process_token_hash`) |
+| `status --config ...` | Sidecar status, routing, profile diagnostics, and metrics |
+| `smoke-feishu-card --profile-id ... --chat-id ...` | Send a real Feishu smoke card for a specific profile |
+| `bots list|show|add|remove --config ...` | Manage bot registry |
+| `bots test --profile-id ... --chat-id ...` | Run a real Feishu bot smoke for a specific profile/bot |
+| `bots bind-chat|unbind-chat --config ...` | Manage chat bindings |
+
+## Architecture
+
+```text
+Hermes Gateway
+  └─ minimal hook in gateway/run.py
+       └─ hermes_feishu_card.hook_runtime
+            └─ HTTP POST /events ——→  sidecar server
+                                      ├─ CardSession state machine
+                                      ├─ render_card() card rendering
+                                      ├─ FeishuClient tenant token / send / update
+                                      ├─ throttling, retry, locks, diagnostics
+                                      └─ /health metrics
+```
+
+The Hermes hook converts `message.started` / `thinking.delta` / `answer.delta` / `tool.updated` / `message.completed` / `message.failed` into `SidecarEvent` and forwards to the sidecar. The sidecar owns full session state and the Feishu CardKit boundary — independently testable, restartable, and diagnosable. Historical code is archived under `legacy/` (`installer_v2.py`, `gateway_run_patch.py`, `patch_feishu.py`, etc.) — not the active runtime. Current development uses `hermes_feishu_card/`. See [docs/migration.en.md](migration.en.md).
+
+## FAQ
+
+- **No thinking / not streaming**: check Hermes `streaming.enabled: true` + `streaming.transport: edit`, confirm model exposes reasoning deltas. Don't blindly enable `show_reasoning`.
+- **No real Feishu cards**: without credentials, the sidecar uses a no-op client. In multi-profile mode, check each profile's `feishu` config.
+- **Hook installed but cards never arrive**: run `doctor --explain` and check `Runtime import`. If Hermes runtime cannot import `hook_runtime`, rerun `setup` or `install --hermes-dir ... --yes`.
+- **Duplicate cards**: inspect `/health` metrics (`events_received`, `feishu_send_successes`). V3.3.0 per-message lock + `profile_id:message_id` keys ensure one card per message.
+- **Multi-profile route is unclear**: run `status --config ...` and inspect `routing.last_route`, `profile.<id>.events`, and `profile.<id>.last_profile_source`, then verify directly with `smoke-feishu-card --profile-id ...` or `bots test --profile-id ...`.
+- **Gray native text**: after sidecar accepts `message.completed`, Hermes hook suppresses native text; fail-open on sidecar unavailable. V3.3.0 fixes non-Feishu platforms being swallowed.
+- **`doctor` unsupported**: Hermes ≥ `v2026.4.23` (reads `VERSION` or Git tag `v2026.4.23+`), `gateway/run.py` must exist.
+- **No cards after upgrading Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x**: run `doctor --config ... --hermes-dir ...` to inspect `hook_strategy`, `compatibility`, and anchors, then re-run `install --hermes-dir ... --yes` if needed.
+- **Restore fails**: file modified → `restore`/`uninstall` refuse to overwrite. Run `doctor --explain` to inspect manifest/backup/run.py state; if it reports an automatic repair path, run `repair --hermes-dir ... --yes`, otherwise back up and manually diff.
+- **Footer tokens wrong**: abnormal values filtered; if still wrong, inspect Hermes `tokens`/`context` metadata.
+- **Table limit exceeded**: V3.3.0 auto-truncates >5 tables with a notice. Reduce Markdown tables.
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|-----------|
+| [v3.8.9](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.9) | 2026-07 | Feishu/Lark topic card continuity: later stream events and `system.notice` resolve by `reply_to_message_id`, keeping the topic timeline updating and avoiding duplicate gray notices |
+| [v3.8.8](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.8) | 2026-07 | Native Hermes system notice cardification: Working heartbeats, context/compression notices, session resets, skill loading, and self-improvement reviews enter cards or compact notice cards |
+| [v3.8.7](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.7) | 2026-07 | issue #75: first `answer.delta` / `thinking.delta` / `tool.updated` / `message.completed` events create a card when newer Hermes omits `message.started` |
+| [v3.8.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.6) | 2026-07 | issue #70 Docker/source-stripped Hermes fallback from missing `VERSION` to Gateway anchors, plus Hermes v0.18.0 / `v2026.7.1` compatibility |
+| [v3.8.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.5) | 2026-07 | Keeps always-allowed `/new` and similar direct command results in Feishu/Lark cards, and removes unsupported interactive direct updates |
+| [v3.8.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.4) | 2026-07 | Feishu/Lark WebSocket-native slash/model command cards, fixing the V3.8.3 local sidecar gray text fallback gap |
+| [v3.8.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.3) | 2026-07 | Standalone slash-command cards for `/new`/`/reset`/`/undo` confirmations, `/model` picker cards, `/update` non-interactive boundary, and text fallback |
+| [v3.8.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.2) | 2026-07 | Card timeline readability patch with delayed pre-tool answer archival, terminal body de-duplication, separate reasoning/tool hierarchy, and fresh collapsed/expanded screenshots |
+| [v3.8.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.1) | 2026-07 | Fixes issue #74 with Gateway-side high-frequency delta coalescing, terminal pre-flush, read-only `/hfc` diagnostics, and hashed diagnostic context |
+| [v3.8.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.0) | 2026-07 | Separates the primary answer from the auxiliary timeline, removes duplicate tool summaries, drains terminal updates, fixes runtime import diagnostics, and updates Docker examples |
+| [v3.7.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.7.0) | 2026-06 | Adds issue #70 Docker container install/update support with `/opt/hermes` and `/opt/data` defaults |
+| [v3.6.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.6) | 2026-06 | Fixes issues #67/#68 by preventing interrupt/slow-PATCH card + native double replies and by suggesting the real Hermes `Project:` path from `hermes -V` |
+| [v3.6.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.5) | 2026-06 | Fixes issues #64/#65 with Feishu thread `message_id` normalization and DeepSeek completed-only final-answer backfill |
+| [v3.6.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.4) | 2026-06 | Fixes issues #61/#62 with Feishu thread card replies and cron `deliver: "feishu:oc_xxx"` card routing |
+| [v3.6.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.3) | 2026-06 | Fixes issues #56-#59 with Hermes v0.17 `_run_agent_inner` hooks, localhost interaction text fallback, Telegram isolation, and Windows profile paths |
+| [v3.6.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.2) | 2026-06 | Fixes issue #53 with Hermes runtime venv installs, doctor runtime import checks, and hook failure warnings |
+| [v3.6.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.1) | 2026-06 | Fixes issue #47, supports Hermes `0.15.x` and no-`v` VERSION values so `doctor --explain` no longer reports them unsupported |
+| [v3.6.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.0) | 2026-06 | `doctor --json/--explain`, safe `repair`, structured media/file summaries, profile-targeted smoke checks, routing profile diagnostics, Hermes compatibility matrix |
+| [v3.5.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.2) | 2026-06 | Cross-platform one-line installers, Release packages, safer macOS `.env` parsing, uv/PEP 668 Python install handling, Windows installer CI parser validation |
+| [v3.5.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.1) | 2026-06 | Streaming update ordering/coalescing, Feishu JSON 2.0 button fix, queued follow-up suppression, `.env` credential fallback, Chinese README refresh |
+| [v3.5.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.0) | 2026-06 | Feishu button interaction loop, issue #41, PR #42, long table/code splitting, thinking truncation fix |
+| [v3.4.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.3) | 2026-05 | Fixes issue #39, adds structure-aware Markdown splitting, and verifies Hermes v0.14.0/v2026.5.16+ support |
+| [v3.4.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.2) | 2026-05 | Fixes issue #31, preventing concurrent PATCH and sequence races from rolling back or dropping streaming card text |
+| [v3.4.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.1) | 2026-05 | Fixes issue #25, keeping Hermes v2026.5.7 fallback message ids lifecycle-stable |
+| [v3.4.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.0) | 2026-05 | Hermes 0.13.0+ compatibility, older Hermes strategy preserved, issue #23, multi-profile/multi-bot, attachments and reply context |
+| [v3.3.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.3.0) | 2026-05 | Multi-profile, DeepSeek compat, table protection, footer spinner, platform fix |
+| [v3.2.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.1) | 2026-04 | Accept-Encoding fix |
+| [v3.2.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.0) | 2026-04 | Multi-bot routing, group chat bindings, Bot CLI, routing diagnostics |
+| [v3.1.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.1.0) | 2026-04 | Sidecar architecture, streaming cards, health endpoint, install wizard |
+| [v3.0.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.0.0) | 2026-04 | Initial sidecar-only release (migrated from V2.x monolith hook) |
+
+Full changelog: [CHANGELOG.md](../CHANGELOG.md).
+
+## Testing
+
+```bash
+python3 -m pytest -q    # run the full automated regression suite
+```
+
+Coverage: real Hermes Gateway E2E, real Feishu app card verification, 16k long-card stress test, `doctor → install → restore` loop, multi-profile routing, DeepSeek tag filtering.
+
+## Documentation
+
+- Maintainer wiki: [docs/wiki](wiki/README.md)
+- Architecture: [中文](architecture.md) / [English](architecture.en.md)
+- Event protocol: [中文](event-protocol.md) / [English](event-protocol.en.md)
+- Installer safety: [中文](installer-safety.md) / [English](installer-safety.en.md)
+- Migration: [中文](migration.md) / [English](migration.en.md)
+- E2E verification: [中文](e2e-verification.md) / [English](e2e-verification.en.md)
+- Release readiness: [中文](release-readiness.md) / [English](release-readiness.en.md)
+- Testing: [中文](testing.md) / [English](testing.en.md)
+
+## License
+
+MIT License. See [LICENSE](../LICENSE).
+
+## Contributors
+
+Thanks to these contributors for improving the project:
+
+- [gischuck](https://github.com/gischuck) — [PR #12](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/12) Accept-Encoding fix (V3.2.1 brotli compatibility)
+- [gischuck](https://github.com/gischuck) — [PR #76](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/76) reasoning/tool timeline UX proposal and implementation exploration (V3.8.x)
+- [fengs2021](https://github.com/fengs2021) — [PR #17](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/17) lock optimization and update interval improvement (V3.3.0)
+
+## Security
+
+Do not commit App Secret, tenant token, or real chat_id. Screenshots demonstrate card rendering only. Production credentials belong in local config or environment variables.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,647 @@
+# Hermes 飞书流式卡片插件
+
+[项目首页](../README.md) | [English](user-guide.en.md)
+
+<p align="center">
+  <a href="https://github.com/baileyh8/hermes-feishu-streaming-card/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&logo=github&label=Stars&color=2f80ed"></a>
+  <a href="https://github.com/baileyh8/hermes-feishu-streaming-card/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&logo=githubactions&label=Release&color=22c55e"></a>
+  <a href="https://github.com/baileyh8/hermes-feishu-streaming-card/actions/workflows/tests.yml"><img alt="Tests" src="https://img.shields.io/github/actions/workflow/status/baileyh8/hermes-feishu-streaming-card/tests.yml?branch=main&style=for-the-badge&label=Tests&logo=githubactions"></a>
+  <img alt="Python 3.9+" src="https://img.shields.io/badge/Python-3.9%2B-3776AB?style=for-the-badge&logo=python&logoColor=white">
+  <img alt="Feishu/Lark" src="https://img.shields.io/badge/Feishu%20%2F%20Lark-Streaming%20Cards-00D6B4?style=for-the-badge">
+  <img alt="Sidecar only" src="https://img.shields.io/badge/Runtime-Sidecar--only-7C3AED?style=for-the-badge">
+  <a href="../LICENSE"><img alt="License" src="https://img.shields.io/github/license/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&color=64748b"></a>
+</p>
+
+![Hermes Feishu Streaming Card 封面](assets/readme-cover.png)
+
+Hermes 飞书流式卡片插件把 Hermes Agent Gateway 的飞书/Lark 回复变成一张持续更新的交互式卡片：思考过程、工具调用、最终答案、授权确认、选项选择和运行统计都能收束在同一张飞书卡片里，而不是被拆成刷屏的灰色原生消息。
+
+它重点解决飞书接入 Hermes 时最常见的痛点：流式内容漏字/乱序、长表格和代码块渲染成 raw markdown、工具调用过程不可见、approval/clarify 需要手工回复、sidecar 故障难排查、多 bot / 多 profile 难运维，以及升级 Hermes 后 hook 兼容不确定。
+
+![Hermes 飞书卡片命令交互、结果反馈与工具 timeline 横向展示](assets/feishu-card-showcase-v385.png)
+
+V3.8.2 起，最终答案保留在主内容区，pre-tool answer 会按“正文展示 -> 下一段到来后归档进 timeline”的节奏收束，思考与工具在折叠区使用不同字号和灰度层级；卡片底部不再重复展示同一份工具调用摘要。
+
+## 项目亮点
+
+- **流式卡片体验**：`thinking.delta`、`answer.delta`、`tool.updated`、`message.completed` 聚合到同一张飞书卡片，减少刷屏和上下文断裂。
+- **卡片内交互**：Hermes approval / clarify choices 优先渲染成飞书按钮；V3.8.5 起，飞书/Lark WebSocket 长连接场景下 `/new`、`/reset`、`/model` 等独立 slash 命令的确认、选择和执行结果都会使用原生 interactive card，不可用时再退回 Hermes 原生文本 fallback。
+- **运行提示收束**：V3.8.8 起，Hermes 原生 `Working` 心跳、上下文窗口/压缩提示、自动 session reset、skill 加载和自我改进 review 会优先进入卡片或独立小卡片，减少灰色原生消息散落。
+- **话题内体验一致**：V3.8.9 起，飞书/Lark 话题回复里的流式事件和系统提示会回到同一张卡片更新，避免话题面板中 timeline 不动、灰色提示重复外溢。
+- **长内容更稳**：长 Markdown 表格和 fenced code block 按结构边界切分，降低飞书 raw markdown 和半截代码围栏问题。
+- **多 bot / 多 profile**：支持多飞书机器人、多 Hermes profile、群聊绑定、bot/profile 标题和路由诊断。
+- **sidecar-only 架构**：Hermes hook fail-open，飞书发送/更新、状态机、重试、健康检查都在 sidecar 中独立运行。
+- **安装和发布友好**：支持一行安装、Release 安装包、`doctor` 诊断、`start/status/stop` 进程管理和安全 restore/uninstall。
+
+## 解决的真实痛点
+
+| 痛点 | 项目能力 |
+|------|----------|
+| 飞书里只能看到一大段最终文本，看不到 Agent 思考和工具进度 | 思考、答案、工具状态、footer 统计持续更新在同一张卡片 |
+| 模型调用工具时内容乱序、漏字、完成后又冒出灰色原生消息 | per-message 顺序、PATCH 合并、终态优先和原生 resend 抑制 |
+| Hermes 运行中不断冒出 Working、上下文提示、skill loading 等灰色提示 | `system.notice` 卡片化：当前任务内进入“思考与工具”，任务外用独立小卡片 |
+| 飞书话题里卡片发出来了，但思考/工具不更新，系统提示还在外面重复出现 | 话题事件按 `reply_to_message_id` 回到原卡片，系统提示被 sidecar 接管后不再原生重复发送 |
+| Hermes 请求授权、让用户选择选项，或 slash 命令需要确认时，需要手工输入编号 | Agent 任务内选项留在当前卡片，独立 slash 命令使用独立命令卡片；不可用时退回编号文本 |
+| 长表格/长代码块被飞书渲染成 raw markdown | Markdown-aware split，重复表头和完整 code fence |
+| 多机器人、多群聊、多 profile 难确认路由 | `bindings.chats`、profile-aware session key、`/health.routing` 诊断 |
+| sidecar 或 hook 出问题难定位 | `doctor`、runtime import 检查、`/health` metrics、fail-closed installer、restore/uninstall |
+
+## V3.8.9 飞书话题卡片连续更新补丁
+
+V3.8.9 修复飞书/Lark 话题回复场景：创建话题后与 bot 对话，首张卡片能出现，但后续 `answer.delta`、`thinking.delta`、`tool.updated` 或 `system.notice` 可能因为 Hermes 内部流式 `message_id` 变化而没有更新同一张卡片，系统提示还可能同时出现在卡片 timeline 和外部灰色消息里。
+
+- **话题内同一张卡持续更新**：sidecar 会用 `reply_to_message_id` 把后续 topic 事件映射回当前运行中的卡片 session。
+- **系统提示不再重复外溢**：session-scoped `system.notice` 成功进入卡片后返回 `applied: true`；如果卡片投递短暂超时，已识别的 Hermes 系统提示也会被抑制，不再继续发送原生灰色文本。
+- **适配 Hermes v0.18.x Relay 元数据**：hook runtime 会把 Relay `source.message_id` 保留下来作为话题原消息锚点。
+
+![飞书话题内卡片连续更新与思考工具 timeline 展示](assets/feishu-topic-card-showcase-v389.png)
+
+上图为真实飞书话题验证：话题回复面板里的卡片能持续更新，思考与工具 timeline、最终答案和 footer 统计保持在同一张卡片内；上下文窗口、自我改进等系统提示会进入卡片或独立小卡片，不再额外溢出成外部灰色消息。
+
+完整发布说明见 [V3.8.9 release notes](release-notes-v3.8.9.md)。
+
+## V3.8.8 Hermes 原生系统提示卡片化
+
+V3.8.8 把 Hermes 原生灰色运行提示统一收束到飞书卡片体验里：`Working` 长任务心跳、上下文窗口/压缩提示、自动 session reset、skill 加载和 self-improvement review 会被识别为 `system.notice`。如果当前任务卡片仍可更新，提示会进入“思考与工具”区域；如果没有可用任务卡片，则发送一张紧凑的独立提示卡片。
+
+- **少一些灰色散落消息**：上下文窗口、压缩、session reset、skill loading、自我改进 review 等提示优先卡片化。
+- **长任务心跳会更新同一条记录**：`Working — iteration ...` 这类 heartbeat 会复用同一个 `notice_id`，避免 timeline 里刷出多条重复提示。
+- **保持 fail-open**：sidecar 不可用、提示无法识别或卡片发送失败时，Hermes 原生文本路径继续可用，不阻断任务。
+
+完整发布说明见 [V3.8.8 release notes](release-notes-v3.8.8.md)。
+
+## V3.8.7 新版 Hermes 首事件兼容补丁
+
+V3.8.7 修复 issue #75：部分新版 Hermes 流式事件可能不再先发送 `message.started`，而是直接从 `answer.delta`、`thinking.delta`、`tool.updated` 或 `message.completed` 开始。旧版 sidecar 因为没有现成 session，会把这些首事件全部计为 `events_ignored`，导致飞书里没有初始卡片。现在这些消息事件也可以创建 session 并立即发送首张 Feishu/Lark 卡片。
+
+- **不再依赖 `message.started`**：首个 answer/thinking/tool/completed 事件都会触发卡片创建。
+- **保留既有链路**：已有 `message.started`、interaction、cron completion 和终态诊断逻辑保持兼容。
+- **与 V3.8.6 叠加**：Docker/source-stripped Hermes 缺 `VERSION` 的 Gateway anchor 兜底继续有效。
+
+完整发布说明见 [V3.8.7 release notes](release-notes-v3.8.7.md)。
+
+## V3.8.6 Docker / Hermes v0.18.0 兼容补丁
+
+V3.8.6 修复 issue #70 的 Docker 容器安装场景：Hermes v0.18.0 / `v2026.7.1` 上游发布包可能没有顶层 `VERSION` 文件，容器镜像也常常不保留 `.git` 元数据。现在 `doctor --explain`、`install` 和 `setup` 会在缺少版本文件时继续读取 `gateway/run.py` 的真实代码 anchor，只要 anchor 可验证，就按 `gateway_run_013_plus` 安装，不再误报 `Hermes VERSION missing, unknown, or invalid`。
+
+- **Hermes v0.18.0**：`v2026.7.1` / `0.18.0` / `v0.18.0` 已加入兼容矩阵，继续使用 `gateway_run_013_plus`。
+- **Docker 无 VERSION 兜底**：诊断会显示 `version_source: gateway anchors`、`version: unknown` 和推断出的 `hook_strategy`。
+- **显式坏版本仍 fail-closed**：只有缺失版本元数据才走 anchor 兜底；如果 `VERSION` 文件内容非法，仍会拒绝安装。
+
+完整发布说明见 [V3.8.6 release notes](release-notes-v3.8.6.md)。
+
+## V3.8.5 命令结果反馈卡片补丁
+
+V3.8.5 补齐 V3.8.4 的“始终允许/无需确认”路径：当 Hermes 直接执行 `/new`、`/reset`、`/clear`、`/undo`、`/stop` 或直接 `/model <model>` 后，执行结果也会以 Feishu/Lark interactive card 回复，而不是退回灰色原生文本。`/model` 切换后的反馈继续稳定留在绿色卡片里，`/update` 仍保持 Hermes 后台升级命令，不弹交互卡片。
+
+- **直通结果卡片化**：patcher 会把当前 `event` 传给 hook runtime，Feishu adapter `send()` 能识别独立 slash command 的返回结果。
+- **交互更新更干净**：按钮/下拉点击后只依赖 Feishu callback response 更新原卡片，不再额外调用飞书不支持的 interactive `message.update`。
+- **升级兼容**：重新运行 `install` 会把 V3.8.4 的旧 command-card hook block 升级为 V3.8.5 的 `event=event` 形式。
+
+完整发布说明见 [V3.8.5 release notes](release-notes-v3.8.5.md)；上一版 WebSocket 原生命令卡片说明见 [V3.8.4 release notes](release-notes-v3.8.4.md)。
+
+## V3.8.4 Feishu WebSocket 命令卡片热修
+
+V3.8.4 修正 V3.8.3 在本地/private sidecar 场景下只能退回灰色文本的问题：`/new`、`/reset`、`/undo` 这类确认命令现在会直接复用 Hermes Feishu adapter 的 WebSocket card action 通道发送原生 interactive card；`/model` 也会用同一套原生卡片完成选择。正在运行的 Agent 流式卡片仍只承接 approval、clarify、对话选项和思考/工具 timeline，不和独立命令混在一起。
+
+- **WebSocket 原生确认卡片**：插件动态补上 Feishu adapter 的 `send_slash_confirm(...)`，按钮点击由 `_on_card_action_trigger` 进入 `tools.slash_confirm.resolve(...)`。
+- **WebSocket 原生模型选择卡片**：当 Hermes 请求 Feishu adapter 的 `send_model_picker(...)` 时，插件会补上 Feishu-only picker，选择模型后回写同一张命令卡片。
+- **不重复弹选择卡**：WebSocket 原生卡片可用时会跳过 sidecar 预交互，`/new` 不再同时出现 sidecar 选项卡和原生按钮卡。
+- **`/update` 不弹卡片**：`/update` 仍按 Hermes 后台升级命令处理，不做交互按钮卡片，避免把升级流程误当成用户确认。
+- **安全 fallback**：Feishu 原生卡片不可用、sidecar 不可用、卡片应用失败、超时或完成态更新失败时，继续交给 Hermes 原生文本路径，避免命令卡死。
+
+完整发布说明见 [V3.8.4 release notes](release-notes-v3.8.4.md)；上一版独立命令卡片基础说明见 [V3.8.3 release notes](release-notes-v3.8.3.md)。
+
+## V3.8.2 卡片 timeline 阅读体验补丁
+
+V3.8.2 聚焦飞书卡片折叠区的真实阅读体验：工具调用前的自然语言预分析会先停留在正文区，直到下一段预分析或完成态再归档到“思考与工具”；完成态会剥离已经归档过的中间说明，只把最终答案留在主内容区。
+
+- **pre-tool answer 延迟折叠**：上一段预分析不会一闪而过，只有下一段预分析或终态到来时才移入折叠 timeline。
+- **完成态正文更干净**：若最终答案包含已经归档的 preface，terminal card 会自动去重，避免“分析过程 + 最终答案”一起挤在正文。
+- **timeline 层级更清楚**：思考条目保持小字号主层级，工具详情使用更小字号和弱化灰度，长命令不再抢主回答注意力。
+- **raw thinking 保持隐藏**：底层 `thinking.delta` 仍只作为内部流式状态，不混入正文和折叠区；折叠区只展示用户可读的 pre-tool answer。
+
+完整发布说明见 [V3.8.2 release notes](release-notes-v3.8.2.md)。
+
+## V3.8.1 高频流式与飞书内诊断补丁
+
+V3.8.1 修复 issue #74：在 Hermes Agent 0.17.0+、thinking model、长上下文和 token-by-token 高频 delta 场景下，hook 会先在 Hermes Gateway 进程内合并 `thinking.delta` / `answer.delta`，再发送到 sidecar，降低 stream-reader 线程上的对象构造、锁竞争和 HTTP 调度压力，避免启用插件后触发 `Stream stale for 180s`。
+
+- **Gateway-side delta 合并**：新增 `HERMES_FEISHU_CARD_DELTA_COALESCE_MS`、`HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS`、`HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING`，默认无需配置。
+- **终态前主动 flush**：`message.completed` / `message.failed` 前会先 flush 同一消息的 pending delta，避免最后卡片缺少尾部内容。
+- **飞书内只读诊断命令**：支持 `/hfc help`、`/hfc status`、`/hfc doctor`、`/hfc monitor`，结果以飞书卡片回复，不会执行写操作。
+- **诊断信息脱敏**：`/messages/{message_id}/summary` 和 `/hfc` 卡片只展示 hash 后的 chat/message/thread 上下文。
+
+完整发布说明见 [V3.8.1 release notes](release-notes-v3.8.1.md)。
+
+## V3.8.0 卡片体验与流式稳定性升级
+
+V3.8.0 聚焦真实飞书阅读体验：最终答案固定在最重要的主内容区，reasoning / tool timeline 收进辅助区域；长表格、代码块、工具 burst 和终态事件堆积时，卡片会先合并并 drain 待更新内容，再写入最终态。
+
+- **主回答更清楚**：最终答案不被长思考和工具列表挤到卡片底部，工具过程进入辅助 timeline。
+- **减少重复展示**：启用辅助 timeline 时，底部不再额外渲染一份“工具调用 N 次”摘要。
+- **流式终态更稳**：terminal card 渲染前 drain pending updates，避免最后一张卡被旧的中间状态覆盖。
+- **诊断更准**：`doctor` 的 Hermes runtime import 检查会在 Hermes 项目根目录执行，避免当前仓库路径导致误判。
+- **Docker 同步发布**：V3.8.0 发布时同步了 Docker 安装示例，容器内安装仍使用 `install-docker.sh`。
+
+完整发布说明见 [V3.8.0 release notes](release-notes-v3.8.0.md)。
+
+## V3.6.6 中断去重与安装诊断补丁
+
+V3.6.6 修复 issues #67 和 #68：`message.completed` 会基于 sidecar 返回的 `applied` 结果判断卡片链路是否真正接管，terminal 事件不再等待慢 Feishu PATCH 才响应 Hermes，避免中断或更新堆积后同时出现流式卡片和灰色原生答复；`doctor --explain` / `install` 在 `--hermes-dir` 指错时会读取 `hermes -V` 的 `Project:` 路径，并直接提示正确的 Hermes 目录。
+
+完整发布说明见 [V3.6.6 release notes](release-notes-v3.6.6.md)。
+
+## V3.7.0 Docker 容器适配
+
+V3.7.0 在已有 Hermes 容器中补齐安装与升级路径（issue #70）。`install-docker.sh` 会按容器默认路径执行更新。
+
+完整发布说明见 [V3.7.0 release notes](release-notes-v3.7.0.md)。
+
+## V3.6.5 流式终态稳定性补丁
+
+V3.6.5 修复 issues #64 和 #65：Feishu thread / 话题场景下，`message.started` 现在会使用和 streaming callbacks 一致的 reply anchor 作为 card session `message_id`，避免 `events_applied=0`；DeepSeek 等一次性返回最终答案的模型，即使没有任何 `thinking.delta` / `answer.delta`，也会从 `message.completed` / `agent_result.final_response` 回填最终内容并完成同一张卡片。
+
+完整发布说明见 [V3.6.5 release notes](release-notes-v3.6.5.md)。
+
+## V3.6.4 话题回复与定时投递补丁
+
+V3.6.4 修复 issues #61 和 #62：用户在飞书 thread / 话题里发消息时，初始 streaming card 会使用飞书 reply API 发回同一 thread，并继续用同一张卡片做后续 PATCH 更新；cron job 配置 `deliver: "feishu:oc_xxx"` 时也能从 `deliver` 字段解析 chat id，避免定时任务退回普通文本。
+
+完整发布说明见 [V3.6.4 release notes](release-notes-v3.6.4.md)。
+
+## V3.6.3 Hermes v0.17 兼容与交互补丁
+
+V3.6.3 修复 issues #56-#59：Hermes v0.17.0+ / `v2026.6.19+` 将真实 streaming callback 移到 `_run_agent_inner` 后，patcher 会优先在 `_run_agent_inner` 注入 `tool.updated`、`answer.delta`、`thinking.delta`、clarify 和 approval hook，避免卡片停在“思考中”。
+
+localhost/private sidecar 默认使用 `card.interaction_mode: auto`，sidecar-owned choices 会降级成卡片内编号选项，并立即交还 Hermes 原生文本交互流程。V3.8.5 的 `/new`、`/reset`、`/model` 独立命令不依赖公网 HTTP 回调，而是直接复用 Feishu/Lark WebSocket 长连接 card action；命令执行结果也会保持卡片反馈。
+
+这一版还隔离了非飞书平台事件，安装插件后不会影响 Telegram 原生消息；Windows `HERMES_HOME=C:\Users\...\AppData\Local\hermes\profiles\thinking` 也能正确解析 profile。
+
+完整发布说明见 [V3.6.3 release notes](release-notes-v3.6.3.md)。
+
+## V3.6.2 安装可靠性补丁
+
+V3.6.2 修复 issue #53：`setup` / `install` 不只把插件装进当前用户 Python，还会检测 Hermes Gateway 实际运行的 venv Python（例如 `~/.hermes/hermes-agent/venv/bin/python`），并在打 hook 前把同一版本的 `hermes-feishu-streaming-card` 安装进去。
+
+`doctor --explain` / `doctor --json` 新增 `runtime_import` 检查，会明确告诉你 Hermes runtime 是否能 import `hermes_feishu_card.hook_runtime`。hook import/emit 失败也不再完全静默，仍保持 fail-open，但会在 Hermes stderr 写入 `[hermes-feishu-card] hook failed: ...` 诊断 warning。
+
+完整发布说明见 [V3.6.2 release notes](release-notes-v3.6.2.md)。
+
+## V3.6.1 兼容补丁
+
+V3.6.1 修复 issue #47：Hermes `VERSION` 文件写成 `0.15.1` 这类无 `v` 前缀语义版本时，`doctor --explain` 不再误报 unsupported。`0.15.x` / `v0.15.x` 会继续按新版 Hermes 走 `gateway_run_013_plus`，前提是 `gateway/run.py` 的必要 anchor 仍存在。
+
+完整发布说明见 [V3.6.1 release notes](release-notes-v3.6.1.md)。
+
+## V3.6.0 运维增强
+
+V3.6.0 面向真实线上使用后的排障和维护场景：当 Hermes 升级、hook 状态异常、媒体/文件消息进入会话，或一个 sidecar 服务多个 profile/bot 时，用户可以更快判断“哪里坏了、能不能自动修、该验证哪条路由”。
+
+- **诊断可读可机器解析**：`doctor --explain` 给人工排障摘要，`doctor --json` 输出 config、sidecar、Hermes、streaming、install_state 和 recommendations。
+- **安装状态可自救**：新增 `repair --hermes-dir ... --yes` 和 `setup --repair`，只修复可验证的 manifest/backup 状态，遇到用户改动会拒绝覆盖。
+- **媒体/文件更安全**：识别 Hermes 结构化 `attachments` / `files` / `media_files` / image/audio/video 对象，卡片保留摘要，同时不抑制 Hermes 原生媒体/文件投递路径。
+- **多 Profile 更好排障**：`smoke-feishu-card --profile-id`、`bots test --profile-id`、CLI `status` 和 `/health.routing.profiles` 都能按 profile 展示路由状态。
+- **兼容矩阵更明确**：自动化覆盖 Hermes `v2026.4.23`、`v2026.5.7`、`v2026.5.16+`、`v2026.5.29`、`0.13.x`、`0.14.x`、`0.15.x` 和带/不带 `v` 前缀语义版本的 hook strategy。
+
+完整发布说明见 [V3.6.0 release notes](release-notes-v3.6.0.md)，历史路线见 [docs/roadmap-v3.6.0.md](roadmap-v3.6.0.md)。
+
+## V3.6.0 解决了什么
+
+| 场景 | V3.6.0 的变化 |
+|------|---------------|
+| 用户只知道“卡片没回来”，不知道 hook、sidecar 还是 Hermes anchor 出问题 | `doctor --explain` 给出分区诊断和下一步建议 |
+| manifest/backup 丢失导致 restore/install 拒绝，但当前 patch 其实可验证 | `repair` 自动重建缺失状态文件，无法验证时保持拒绝 |
+| 图片、文件、音频、视频进入 Hermes locals 后卡片里看不到上下文 | 卡片显示附件摘要，原生媒体/文件发送路径继续保留 |
+| 多 profile / 多 bot 下不知道消息走了哪个机器人 | `status` 和 `/health.routing.profiles` 展示 bot 数、群聊绑定、last_route、last_route_error |
+| 升级 Hermes 后不确定用新版还是旧版 hook strategy | 测试和文档明确各 Hermes key release 对应的 `gateway_run_013_plus` / `legacy_gateway_run`，并覆盖 `0.15.x` |
+
+## V3.5.x 功能基线
+
+**交互能力**
+
+- 新增飞书按钮交互闭环：`interaction.requested` 渲染按钮，`/card/actions` 记录选择，Hermes hook 轮询 `/interactions/{interaction_id}` 后继续执行。
+- 授权/选项按钮采用飞书 JSON 2.0 `button + behaviors.callback`，避免旧式 action 容器在飞书端更新失败。
+- approval / clarify hook 透传 Hermes event loop，交互请求和流式 delta 共用同一条 message send lock，减少事件乱序。
+
+**流式稳定性**
+
+- 修复 issue #41：多条回复和新版 Hermes streaming flow 继续走卡片更新，最终回答不再从第二条开始退回原生 text。
+- 修复 issue #39：`message.completed.answer` 为空时不再清空已通过 `answer.delta` 展示的内容，避免 DeepSeek V4 Pro 工具调用后卡片最终无内容。
+- 修复 issue #31：同一张飞书卡片 PATCH 串行化，避免旧快照后到覆盖新内容。
+- 修复 issue #25：Hermes v2026.5.7 的 `event_message_id` 作为显式 `message_id` 使用，保证 `message.started` 和 `message.completed` 落在同一张 fallback 卡片。
+- 同一消息的 HTTP 事件发送按 message id 加锁；多线程 Hermes callback 产生的 sequence 不会互相踩踏。
+- `answer.delta` / `thinking.delta` 保留原始边界空格，避免中文、英文、代码片段被拼坏。
+- `thinking.delta(mode=append_block)` 以完整思考片段追加，修复思考过程句子漏字、截断和粘连。
+- sidecar 事件快速 ACK，卡片 PATCH 合并更新，刷新间隔降到 `0.2s`，终态事件在后台优先补齐最终卡片。
+- queued follow-up 完成后抑制原生 resend，避免“卡片已完成但下面又冒出一大段灰色原生消息”。
+
+**长内容与渲染**
+
+- 长 Markdown 表格超过 `MAIN_CONTENT_CHUNK_CHARS` 后重复表头分块，仍保持合法表格。
+- fenced code block 超长后拆成多个完整 fenced block，避免飞书显示半截代码围栏。
+- 保留 V3.3.0 的飞书 5 表格限制保护，超限时自动截断并提示。
+
+**兼容与安装**
+
+- Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x、`v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` 使用 `gateway_run_013_plus`。
+- 旧版本 Hermes（`v2026.4.23` 到 `v2026.4.x` / `0.12.x`）继续使用 `legacy_gateway_run`。
+- `doctor` 输出 `version_source`、`version`、`hook_strategy`、`compatibility`、anchor/anchors 和 `reason`，便于安装前确认。
+- 升级插件后必须重新安装 hook：运行 `install --hermes-dir ... --yes`，让 Hermes 使用匹配当前版本的 hook。
+- 处理 PR #42：cron 卡片路由优先使用 `job['deliver']` 和 scheduler 解析出的 Feishu target。
+- 多 profile / multi bot 体验补齐：issue #23、per-bot/profile title、cron final cards、attachment summaries + native media delivery、reply card context。
+- V3.6.0 进一步补齐 profile 定向 smoke、routing profile diagnostics、structured attachment summaries 和 safe repair。
+
+**配置与运行安全**
+
+- `--config` 指向的配置文件同目录存在 `.env` 时，会自动读取 `FEISHU_APP_ID`、`FEISHU_APP_SECRET`、`HERMES_FEISHU_CARD_HOST`、`HERMES_FEISHU_CARD_PORT`。
+- 真实进程环境变量优先级高于同目录 `.env`。
+- 多 Profile 模式下继续要求每个 profile 显式配置 Feishu 凭据，顶层环境变量不会覆盖 profile 凭据。
+- 无凭据时 sidecar 使用 no-op client，只做本地状态，不会向真实飞书发卡；`/health.routing.bot_count` 可用于确认是否加载到真实 bot。
+
+## 一行安装
+
+macOS / Linux：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/baileyh8/hermes-feishu-streaming-card/main/install.sh | bash
+```
+
+Windows PowerShell：
+
+```powershell
+irm https://raw.githubusercontent.com/baileyh8/hermes-feishu-streaming-card/main/install.ps1 | iex
+```
+
+安装脚本会自动安装/升级插件、读取或提示填写飞书凭据、写入 `~/.hermes/.env`，并调用整合安装器：
+
+```bash
+python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --config ~/.hermes/config.yaml --yes
+```
+
+安装完成后可以检查 sidecar 状态：
+
+```bash
+python3 -m hermes_feishu_card.cli status --config ~/.hermes/config.yaml
+```
+
+常用环境变量：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `HFC_VERSION` | `latest` | 指定安装版本，例如 `v3.8.9`、`v3.6.6` 或 `main` |
+| `HERMES_DIR` | `~/.hermes/hermes-agent` | Hermes Agent Gateway 目录 |
+| `HFC_CONFIG` | `~/.hermes/config.yaml` | sidecar 配置路径 |
+| `HFC_ENV_FILE` | `HFC_CONFIG` 同目录 `.env` | 飞书凭据保存位置 |
+| `HFC_SKIP_START` | `0` | 设为 `1` 时只安装 hook，不启动 sidecar |
+| `HFC_NO_PROMPT` | `0` | 设为 `1` 时禁止交互式输入，适合自动化安装 |
+
+高频流式调优变量默认无需配置，只有在超高频 thinking/burst 场景下才需要调整：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MS` | `250` | Gateway runtime 内合并 delta 的最大等待时间；设为 `0` 可关闭 |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_CHARS` | `600` | pending delta 累积到该字符数后立即 flush |
+| `HERMES_FEISHU_CARD_DELTA_COALESCE_MAX_PENDING` | `128` | 同时保留的 pending delta session 上限 |
+
+## Docker 容器内安装 / 更新
+
+如果 Hermes 运行在已有 Docker 容器里，优先使用 `install-docker.sh`。它默认读取：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `HERMES_DIR` | `/opt/hermes` | 容器内 Hermes Agent Gateway 目录 |
+| `HFC_CONFIG` | `/opt/data/config.yaml` | sidecar 配置路径 |
+| `HFC_ENV_FILE` | `/opt/data/.env` | 飞书凭据文件 |
+| `HFC_VERSION` | `latest`（脚本）/ `v3.8.9`（Compose 示例） | 指定安装 tag 或分支 |
+| `HFC_PYTHON` | 自动检测 Hermes venv | 显式指定容器内 Python |
+
+示例：
+
+```bash
+export FEISHU_APP_ID=cli_xxx
+export FEISHU_APP_SECRET=xxx
+export HFC_VERSION=v3.8.9
+bash install-docker.sh
+```
+
+`docker-compose.example.yml` 只是适配示例，不是官方镜像。它展示 `/opt/hermes`、`/opt/data` 挂载和非交互安装方式。
+
+也可以从 Release 下载 `hermes-feishu-card-<version>-macos.tar.gz`、`hermes-feishu-card-<version>-linux.tar.gz` 或 `hermes-feishu-card-<version>-windows.zip`，解压后运行包内的 `install.sh` / `install.ps1`。完整安装包说明见 [README-install.md](../README-install.md)。
+
+## 手动安装
+
+```bash
+git clone https://github.com/baileyh8/hermes-feishu-streaming-card.git
+cd hermes-feishu-streaming-card
+pip install -e ".[test]"
+
+export FEISHU_APP_ID=cli_xxx
+export FEISHU_APP_SECRET=xxx
+
+python3 -m hermes_feishu_card.cli setup --hermes-dir ~/.hermes/hermes-agent --yes
+```
+
+`setup` 是整合安装器：自动生成配置、检查 Hermes 版本和代码 anchor、把插件安装到 Hermes Gateway 实际运行的 venv Python、安装 hook、启动 sidecar 并做健康检查。它支持 `v2026.4.23` 起的旧版 Hermes，也支持 Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 与 `v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` 新版 anchor；Hermes `VERSION` 可带或不带 `v` 前缀。V3.8.6 起，Docker/source-stripped 环境缺少 `VERSION` 和 `.git` 时也可用 `gateway/run.py` anchor 兜底识别。
+
+如果你使用 Hermes 默认目录，也可以把凭据放在 `~/.hermes/.env`：
+
+```bash
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+FEISHU_CONNECTION_MODE=websocket
+FEISHU_HOME_CHANNEL=oc_xxx
+```
+
+之后使用：
+
+```bash
+python3 -m hermes_feishu_card.cli start --config ~/.hermes/config.yaml
+```
+
+V3.6.2 会继续自动读取 `~/.hermes/config.yaml` 同目录的 `~/.hermes/.env`。更宽泛的 `.env` 搜索路径会作为独立小项评估，不和 venv 安装修复混在同一版里。
+
+## 升级
+
+从 V3.2.x/V3.3.0/V3.4.x/V3.5.x/V3.6.x/V3.7.x/V3.8.0/V3.8.1/V3.8.2/V3.8.3/V3.8.4/V3.8.5/V3.8.6/V3.8.7/V3.8.8 升级到 V3.8.9 向后兼容，**单 Profile 配置无需任何修改**。如果 Hermes 使用自己的 venv，升级后请重新跑 `setup` 或 `install`，让插件同时进入 Hermes runtime Python 并刷新 hook。V3.8.9 保留 V3.8.8 的原生系统提示卡片化、V3.8.7 的新版 Hermes 首事件兼容和 V3.8.6 的 Docker/Hermes v0.18.0 兼容补丁，并修复飞书/Lark 话题内卡片 timeline 不更新与系统提示重复外溢；建议升级后执行一次 `doctor --explain`，并在普通会话和话题里各发送一次普通问题、`/new`、`/model` 或触发一次长任务/上下文提示验证状态。
+
+```bash
+# 1. 停止 sidecar
+python3 -m hermes_feishu_card.cli stop --config ~/.hermes_feishu_card/config.yaml
+
+# 2. 更新代码
+cd /path/to/hermes-feishu-streaming-card
+git checkout v3.8.9
+pip install -e ".[test]" --upgrade
+
+# 3. 诊断 Hermes hook strategy 与 anchors
+python3 -m hermes_feishu_card.cli doctor \
+  --config ~/.hermes_feishu_card/config.yaml \
+  --hermes-dir ~/.hermes/hermes-agent
+
+# 4. 重新安装 hook
+python3 -m hermes_feishu_card.cli install --hermes-dir ~/.hermes/hermes-agent --yes
+
+# 5. 启动 sidecar
+python3 -m hermes_feishu_card.cli start --config ~/.hermes_feishu_card/config.yaml
+```
+
+`doctor` 会优先从 `VERSION` 或 Git tag `v2026.4.23+` 判断 Hermes 支持状态。Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 与 `v2026.5.16+` / `v2026.6.19+` / `v2026.7.1+` 应命中 `gateway_run_013_plus`；旧版本 Hermes 应命中 `legacy_gateway_run`。如果 Docker 镜像缺少 `VERSION` 和 `.git` 元数据，V3.8.6 会用 `gateway/run.py` anchor 兜底，输出 `version_source: gateway anchors`。若 `doctor --explain` 提示可自动修复，先执行 `repair --hermes-dir ... --yes` 再重新安装 hook。
+
+## 核心功能
+
+- **飞书流式卡片**：`message.started`、`thinking.delta`、`answer.delta`、`tool.updated`、`message.completed`、`message.failed` 汇聚到同一张卡片。
+- **授权/选项交互**：Hermes approval、clarify choices 和独立 slash 命令优先显示为飞书按钮卡片；不可用时显示编号/文本 fallback，并交还 Hermes 原生文本选择流程。
+- **多 bot 与群聊绑定**：`bots.items` 注册多个飞书机器人，`bindings.chats` 按 `chat_id` 路由，`group_rules` 预留群聊策略。
+- **多 Profile 进程内隔离**：一个 sidecar 服务多个 Hermes profile，使用 `profile_id:message_id` 隔离 session。
+- **Profile / Bot 卡片标题**：全局、profile、bot 均可设置标题，bot 级优先。
+- **Cron 最终卡片与回复上下文**：cron 任务可发送最终卡片，reply card context 保留必要上下文。
+- **附件摘要与原生媒体投递**：卡片内展示 attachment summaries，hook 不抑制 Hermes 原生媒体/文件投递路径。
+- **DeepSeek 思维链兼容**：过滤 `<think>`/`</think>` 与 `<thinking>`/`</thinking>` 标签。
+- **工具调用跟踪**：累计工具调用次数和每个工具的当前状态。
+- **运行统计 footer**：显示耗时、模型、token、上下文占比；非终态卡片显示旋转生成中状态。
+- **故障隔离**：sidecar 不可用时 hook fail-open，Hermes 原生文本继续运行。
+- **安全安装/恢复**：安装器 fail-closed，`restore`/`uninstall` 检测文件改动后拒绝覆盖。
+
+## 配置
+
+复制 `config.yaml.example` 到本地使用，不要提交真实凭据。
+
+**单 Profile 最小配置**
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8765
+feishu:
+  app_id: ""
+  app_secret: ""
+card:
+  title: Hermes Agent
+  footer_fields: [duration, model, input_tokens, output_tokens, context]
+```
+
+**单 Profile + 多 Bot / 群聊**
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8765
+feishu:
+  app_id: ""
+  app_secret: ""          # fallback
+bots:
+  default: default
+  items:
+    sales:
+      app_id: "cli_sales_xxx"
+      app_secret: "xxx"
+    support:
+      app_id: "cli_support_yyy"
+      app_secret: "yyy"
+bindings:
+  fallback_bot: default
+  chats:
+    oc_5cc6a25d8815790fa890dd0226005e83: sales
+  group_rules:
+    enabled: false
+card:
+  title: Hermes Agent
+  footer_fields: [duration, model, input_tokens, output_tokens, context]
+```
+
+**多 Profile**
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8765
+profiles:
+  engineering:
+    feishu:
+      app_id: "cli_eng_xxx"
+      app_secret: "xxx"
+    bots:
+      default: default
+      items:
+        default:
+          app_id: "cli_eng_xxx"
+          app_secret: "xxx"
+    bindings:
+      fallback_bot: default
+      chats: {}
+  sales:
+    feishu:
+      app_id: "cli_sales_xxx"
+      app_secret: "xxx"
+    bots:
+      default: default
+      items:
+        default:
+          app_id: "cli_sales_xxx"
+          app_secret: "xxx"
+    bindings:
+      fallback_bot: default
+      chats: {}
+card:
+  title: Hermes Agent
+  footer_fields: [duration, model, input_tokens, output_tokens, context]
+```
+
+多 Profile 模式下，`FEISHU_APP_ID` / `FEISHU_APP_SECRET` 不会覆盖 profile 内的 `feishu` 配置。`footer_fields` 支持 `duration`、`model`、`input_tokens`、`output_tokens`、`context`。
+
+## 飞书应用配置
+
+```bash
+export FEISHU_APP_ID=cli_xxx
+export FEISHU_APP_SECRET=xxx
+
+# 真实飞书 smoke 测试
+python3 -m hermes_feishu_card.cli smoke-feishu-card \
+  --config config.yaml.example \
+  --chat-id oc_xxx
+```
+
+如果凭据未配置，sidecar 会使用 no-op client；这适合本地单元测试，但不会向真实飞书发卡。真实联调前请检查：
+
+```bash
+python3 -m hermes_feishu_card.cli status --config ~/.hermes/config.yaml
+```
+
+确认 `/health.routing.bot_count` 大于 0，且 `last_route_error` 为空。
+
+## Hermes Gateway 流式配置
+
+确保 Hermes `config.yaml` 中启用流式编辑：
+
+```yaml
+streaming:
+  enabled: true
+  transport: edit
+```
+
+不要设置 `display.platforms.feishu.streaming: false`。也不要把 `display.show_reasoning` 当成本插件的必需开关；它可能在最终回复中追加 reasoning 代码块，反而干扰卡片流式体验。若模型只返回最终答案、没有 thinking 增量，卡片会直接显示最终答案。
+
+## CLI 命令
+
+| 命令 | 说明 |
+|------|------|
+| `setup --hermes-dir ... --yes` | 一键安装：配置、检测、hook、sidecar、健康检查 |
+| `doctor --config ... --hermes-dir ...` | 诊断 Hermes 版本、runtime import、`hook_strategy`、`compatibility`、anchors 和原因；支持 `--explain` / `--json` |
+| `install --hermes-dir ... --yes` | 安装插件到 Hermes runtime venv，并安装 hook 到 Hermes |
+| `repair --hermes-dir ... --yes` | 修复可验证的 hook manifest/backup 状态，不覆盖用户改动 |
+| `restore --hermes-dir ... --yes` | 恢复原始 Hermes 文件 |
+| `uninstall --hermes-dir ... --yes` | 卸载并恢复 |
+| `start --config ...` | 启动 sidecar |
+| `stop --config ...` | 停止 sidecar；校验 PID/token 与 `/health` 的 `process_pid/process_token_hash` 后才停止 |
+| `status --config ...` | 查看 sidecar 状态、routing、profile diagnostics 与 metrics |
+| `smoke-feishu-card --profile-id ... --chat-id ...` | 按指定 profile 发送真实飞书 smoke 卡片 |
+| `bots list|show|add|remove --config ...` | 管理飞书 Bot 注册 |
+| `bots test --profile-id ... --chat-id ...` | 按指定 profile/bot 做真实飞书 bot smoke |
+| `bots bind-chat|unbind-chat --config ...` | 管理 `bindings.chats` 群聊绑定 |
+
+## 架构
+
+```text
+Hermes Gateway
+  └─ minimal hook in gateway/run.py
+       └─ hermes_feishu_card.hook_runtime
+            └─ HTTP POST /events ——→  sidecar server
+                                      ├─ CardSession 状态机
+                                      ├─ render_card() 卡片渲染
+                                      ├─ Feishu CardKit HTTP client 已实现
+                                      ├─ tenant token / send / update
+                                      ├─ 节流、合并、重试、锁、诊断
+                                      └─ /health 指标
+```
+
+Hermes hook 将事件 fail-open 转发给 sidecar。sidecar 持有完整会话状态和飞书边界，可独立测试、重启、诊断。历史实现集中归档在 `legacy/`（`installer_v2.py`、`gateway_run_patch.py`、`patch_feishu.py` 等），不是 active runtime；当前主线以 `hermes_feishu_card/` 为准。迁移说明见 [docs/migration.md](migration.md)。
+
+## 常见问题
+
+- **卡片没有思考/不流式**：检查 `streaming.enabled: true` 与 `streaming.transport: edit`，确认模型确实输出 `thinking.delta`。
+- **真实飞书没有卡片**：检查凭据是否进入 sidecar；没有凭据时是 no-op client。V3.6.2 会读取 config 同目录 `.env`，真实环境变量仍优先。
+- **hook 已安装但 Hermes 卡片完全不工作**：跑 `doctor --explain`，查看 `Runtime import` 是否为 `ok`。如果 Hermes venv 不能 import `hook_runtime`，重新执行 `setup` 或 `install --hermes-dir ... --yes`。
+- **卡片停在“思考中”**：看 `/health.diagnostics.last_terminal_event` 和 `feishu_update_failures`，确认终态事件是否到达、飞书 PATCH 是否成功。
+- **出现灰色原生文本**：通常说明 sidecar 未成功接收或更新终态；V3.5.x 已补 queued follow-up suppression 和终态优先更新。
+- **思考过程漏字/截断**：V3.5.x 已用 ordered send、append_block、PATCH 合并与终态优先修复；若仍出现，先检查 `/health.metrics.feishu_update_failures`。
+- **长表格/代码显示成 raw markdown**：V3.5.x 会结构化拆分；如果仍异常，减少单个表格列宽或代码块长度。
+- **重复卡片**：检查 `/health` metrics（`events_received`、`events_applied`、`feishu_send_successes`）。多 Profile 下 session key 为 `profile_id:message_id`。
+- **多 Profile 路由不确定**：跑 `status --config ...`，查看 `routing.last_route`、`profile.<id>.events`、`profile.<id>.last_profile_source`，再用 `smoke-feishu-card --profile-id ...` 或 `bots test --profile-id ...` 定向验证。
+- **Hermes 0.13.0+/0.14.0/0.15.x/0.17.x/0.18.x 升级后无卡片**：先跑 `doctor --config ... --hermes-dir ...`，确认 `hook_strategy` 为 `gateway_run_013_plus`，再按需重新安装 hook。
+- **恢复失败**：`restore`/`uninstall` 检测到文件改动会拒绝覆盖，先跑 `doctor --explain` 看 manifest/backup/run.py 状态；若提示可自动修复，执行 `repair --hermes-dir ... --yes`，否则先备份再人工确认差异。
+- **只想验证本地 sidecar**：可以用 no-op client 跑测试；真实飞书 smoke 需要真实 App ID/Secret 和 chat id。
+
+## 版本历史
+
+| 版本 | 日期 | 主要变更 |
+|------|------|---------|
+| [v3.8.9](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.9) | 2026-07 | 飞书/Lark 话题内卡片连续更新：后续流式事件和 `system.notice` 通过 `reply_to_message_id` 回到原卡片，避免 timeline 停住和灰色提示重复 |
+| [v3.8.8](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.8) | 2026-07 | Hermes 原生系统提示卡片化：Working 心跳、上下文窗口/压缩提示、session reset、skill loading、自我改进 review 进入卡片或独立小卡片 |
+| [v3.8.7](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.7) | 2026-07 | issue #75，新版 Hermes 缺少 `message.started` 时，`answer.delta` / `thinking.delta` / `tool.updated` / `message.completed` 首事件也会创建卡片 |
+| [v3.8.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.6) | 2026-07 | issue #70，Docker/source-stripped Hermes 缺少 `VERSION` 时用 Gateway anchor 兜底，补齐 Hermes v0.18.0 / `v2026.7.1` 兼容 |
+| [v3.8.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.5) | 2026-07 | 始终允许 `/new` 等直通命令的执行结果也保持 Feishu/Lark 卡片反馈，移除无效 interactive direct update |
+| [v3.8.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.4) | 2026-07 | Feishu/Lark WebSocket 长连接 slash/model 原生命令卡片，修复 V3.8.3 本地 sidecar 只显示灰色文本 fallback 的问题 |
+| [v3.8.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.3) | 2026-07 | 独立 slash 命令卡片，`/new`/`/reset`/`/undo` 确认、`/model` 选择卡片、`/update` 非交互边界和文本 fallback |
+| [v3.8.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.2) | 2026-07 | 卡片 timeline 阅读体验补丁，pre-tool answer 延迟归档、终态正文去重、思考/工具折叠区层级区分、真实折叠/展开截图更新 |
+| [v3.8.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.1) | 2026-07 | issue #74，高频 delta Gateway-side 合并、终态前 flush、飞书内 `/hfc` 只读诊断命令、summary/诊断上下文 hash 脱敏 |
+| [v3.8.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.8.0) | 2026-07 | 卡片主回答与辅助 timeline 分离、工具摘要去重、terminal drain、Hermes runtime import 诊断修正、Docker 示例同步 |
+| [v3.7.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.7.0) | 2026-06 | issue #70，补齐现有 Hermes Docker 容器内安装与更新路径 |
+| [v3.6.6](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.6) | 2026-06 | issues #67/#68，中断/慢 PATCH 场景避免卡片和原生答复双发，doctor/install 提示 `hermes -V` 的真实 Project 目录 |
+| [v3.6.5](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.5) | 2026-06 | issues #64/#65，Feishu thread `message_id` 归一化、DeepSeek completed-only 最终答案回填并更新同一卡片 |
+| [v3.6.4](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.4) | 2026-06 | issues #61/#62，飞书 thread 卡片回复到原话题、cron `deliver: "feishu:oc_xxx"` 解析为卡片投递 |
+| [v3.6.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.3) | 2026-06 | issues #56-#59，Hermes v0.17 `_run_agent_inner` hook、localhost 交互 text fallback、Telegram 隔离、Windows profile path |
+| [v3.6.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.2) | 2026-06 | issue #53，安装到 Hermes runtime venv、doctor runtime import 检查、hook 失败 warning 诊断 |
+| [v3.6.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.1) | 2026-06 | issue #47，支持 Hermes `0.15.x` 和无 `v` 前缀 VERSION，避免 `doctor --explain` 误报 unsupported |
+| [v3.6.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.6.0) | 2026-06 | `doctor --json/--explain`、安全 `repair`、结构化媒体/文件摘要、多 profile 定向 smoke、routing profile diagnostics、Hermes 兼容矩阵 |
+| [v3.5.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.2) | 2026-06 | 跨平台一行安装、Release 安装包、macOS `.env` 安全解析、uv/PEP 668 Python 安装适配、Windows installer CI 解析验证 |
+| [v3.5.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.1) | 2026-06 | 流式更新排序与合并、飞书 JSON 2.0 按钮修复、queued follow-up 原生消息抑制、`.env` 凭据回退、README 首页重整 |
+| [v3.5.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.5.0) | 2026-06 | 飞书按钮交互闭环、issue #41、PR #42、长表格/代码块结构拆分、thinking 漏字修复 |
+| [v3.4.3](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.3) | 2026-05 | issue #39、Markdown 结构化切分、Hermes v0.14.0 / v2026.5.16+ 验证 |
+| [v3.4.2](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.2) | 2026-05 | issue #31，避免并发 PATCH 和 sequence 竞争导致内容回退/漏字 |
+| [v3.4.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.1) | 2026-05 | issue #25，Hermes v2026.5.7 fallback message id 生命周期一致 |
+| [v3.4.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.4.0) | 2026-05 | Hermes 0.13.0+ 兼容、旧版本 strategy、issue #23、多 profile/multi bot、附件与回复上下文 |
+| [v3.3.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.3.0) | 2026-05 | 多 Profile、DeepSeek 兼容、表格保护、Footer 动画、平台判断修复 |
+| [v3.2.1](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.1) | 2026-04 | Accept-Encoding 修复 |
+| [v3.2.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.2.0) | 2026-04 | 多 Bot 路由、群聊绑定、Bot CLI、路由诊断 |
+| [v3.1.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.1.0) | 2026-04 | Sidecar 架构、流式卡片、健康端点、安装向导 |
+| [v3.0.0](https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v3.0.0) | 2026-04 | Sidecar-only 初始发布 |
+
+完整更新日志：[CHANGELOG.md](../CHANGELOG.md)。
+
+## 测试与验收
+
+```bash
+python3 -m pytest -q
+```
+
+本版本自动化覆盖配置加载、hook patch、Hermes runtime event、sidecar session、飞书按钮 callback、长表格/代码块切分、queued follow-up completion、cron deliver precedence 和文档约束。
+
+已完成的人工/集成验收包括：真实 Feishu E2E 主链路、真实 Hermes Gateway E2E、真实飞书应用卡片验证、16k 长卡压力测试、`doctor -> install -> restore` 闭环、多 Profile 路由、DeepSeek 标签过滤。Feishu CardKit HTTP client 已实现，并通过 mock Feishu server 和真实飞书 smoke 验证。
+
+## 文档
+
+- 项目维护 Wiki：[docs/wiki](wiki/README.md)
+- 架构说明：[中文](architecture.md) / [English](architecture.en.md)
+- 事件协议：[中文](event-protocol.md) / [English](event-protocol.en.md)
+- 安装安全：[中文](installer-safety.md) / [English](installer-safety.en.md)
+- 迁移说明：[中文](migration.md) / [English](migration.en.md)
+- 端到端验证：[中文](e2e-verification.md) / [English](e2e-verification.en.md)
+- 发布准备：[中文](release-readiness.md) / [English](release-readiness.en.md)
+- 测试说明：[中文](testing.md) / [English](testing.en.md)
+
+## 贡献者
+
+感谢以下贡献者对项目的改进：
+
+- [gischuck](https://github.com/gischuck) — [PR #12](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/12) Accept-Encoding 修复（V3.2.1 brotli 兼容）
+- [gischuck](https://github.com/gischuck) — [PR #76](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/76) 思考与工具 timeline 体验建议与实现探索（V3.8.x）
+- [fengs2021](https://github.com/fengs2021) — [PR #17](https://github.com/baileyh8/hermes-feishu-streaming-card/pull/17) 锁架构优化与更新间隔改进（V3.3.0）
+
+## 安全说明
+
+不要把 App Secret、tenant token、真实 chat_id 提交到仓库。效果图仅用于展示卡片效果，生产凭据保存在本机配置或环境变量中。
+
+## License
+
+MIT License，详见 [LICENSE](../LICENSE)。

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,44 @@
+# Hermes Feishu Streaming Card Wiki
+
+这个目录是项目维护 wiki。README 面向用户介绍能力，`docs/release-notes-*` 记录版本变化；这里沉淀长期有效的维护知识、运行链路和验收清单。
+
+## 一句话理解
+
+`hermes-feishu-streaming-card` 是 Hermes Agent Gateway 的 Feishu/Lark sidecar 插件：Hermes 进程只安装最小 hook，真实卡片状态、Feishu 发送/更新、交互回调、诊断和发布资产都由本仓库维护。
+
+## 阅读路径
+
+1. [维护指南](maintenance-guide.md)
+   - 适合改代码前阅读，说明 hot files、风险边界和测试矩阵。
+2. [事件流和卡片生命周期](event-flow.md)
+   - 适合排查卡片不更新、重复灰色消息、topic/thread 锚点问题。
+3. [真实飞书验收清单](feishu-acceptance.md)
+   - 适合每个 UX/兼容性版本发布前人工验证。
+4. [发布手册](release-playbook.md)
+   - 适合发版前按步骤核对版本号、测试、tag、release assets。
+
+## 当前核心能力
+
+- 普通会话流式卡片：`message.started` / `answer.delta` / `thinking.delta` / `tool.updated` / `message.completed` 聚合到同一张卡片。
+- 新版 Hermes 兼容：首事件缺少 `message.started` 时也能创建初始卡片。
+- Feishu/Lark 话题体验：后续事件通过 `reply_to_message_id` 回到原卡片，避免 topic timeline 停住。
+- 系统提示卡片化：`Working`、上下文窗口/压缩、session reset、skill loading、自我改进 review 等归一为 `system.notice`。
+- 独立命令卡片：`/new`、`/reset`、`/undo`、`/model` 走 Feishu interactive card；`/update` 保持 Hermes 后台升级语义。
+- 安装与诊断：`install/setup/doctor/repair/restore/uninstall` 覆盖本机、Hermes venv、Docker/source-stripped Hermes。
+
+## 文档分层
+
+| 层级 | 位置 | 用途 |
+|---|---|---|
+| 产品说明 | `README.md` / `README.en.md` | 面向第一次访问仓库的人，讲项目价值、安装和展示图 |
+| 详细使用手册 | `docs/user-guide.md` / `docs/user-guide.en.md` | 承接 README 迁出的配置、升级、CLI、版本史和排障细节 |
+| 长期维护 wiki | `docs/wiki/` | 面向维护者和 Agent，讲如何安全改动和验证 |
+| 版本说明 | `CHANGELOG.md` + `docs/release-notes-*` | 面向版本使用者，记录每个版本变化 |
+| 测试说明 | `docs/testing.md` | 面向开发者，列出测试命令和覆盖范围 |
+| 架构说明 | `docs/architecture.md` | 面向实现理解，说明 sidecar-only 结构 |
+
+## 与 Obsidian LLM Wiki 的关系
+
+仓库内 wiki 是公开、可随项目发布的维护资料；Bailey 的 Obsidian LLM Wiki 是长期检索层，会保存项目总览、维护规则和跨项目复用经验。
+
+当本目录新增稳定知识时，同步到 Bailey 的 Obsidian LLM Wiki 镜像；仓库文档不记录本机绝对路径。

--- a/docs/wiki/event-flow.md
+++ b/docs/wiki/event-flow.md
@@ -1,0 +1,112 @@
+# 事件流和卡片生命周期
+
+## 总览
+
+```text
+Hermes Gateway
+  -> patched gateway/run.py hook block
+  -> hermes_feishu_card.hook_runtime
+  -> sidecar /events
+  -> CardSession / reply index / route lookup
+  -> Feishu/Lark send or update card
+```
+
+Hermes 进程内的 hook 只负责提取和转发。sidecar 负责会话状态、卡片渲染、Feishu API、重试、诊断和 metrics。
+
+## 普通消息生命周期
+
+1. `message.started`
+   - 创建或定位 session。
+   - 发送首张 Feishu/Lark interactive card。
+2. `thinking.delta` / `answer.delta`
+   - 更新思考或正文。
+   - 高频 delta 在 runtime 或 sidecar 层合并。
+3. `tool.updated`
+   - 更新工具调用 timeline。
+   - terminal 事件前 flush pending delta。
+4. `message.completed`
+   - 渲染终态卡片。
+   - 标记 session completed。
+   - 抑制 Hermes 原生重复答复。
+
+## 新版 Hermes 首事件兼容
+
+部分 Hermes 版本可能不先发送 `message.started`。如果首个事件是：
+
+- `answer.delta`
+- `thinking.delta`
+- `tool.updated`
+- `message.completed`
+
+sidecar 仍应创建 session 并发送初始卡片，不能把整条流计入 `events_ignored`。
+
+## Feishu topic / thread 锚点
+
+话题场景里，用户原消息、topic thread 和 Hermes 内部 stream id 可能不是同一个值。
+
+关键规则：
+
+- 首张卡片通常锚定用户 topic message id。
+- 后续事件可能只带 Hermes 内部 streaming `message_id`。
+- hook runtime 必须保存 Relay `source.message_id`。
+- sidecar 创建新 session 前先用 `reply_to_message_id` 查已有 active card。
+- 找到后继续 PATCH 原卡片，不新建重复卡片。
+
+这条规则解决：
+
+- 话题右侧面板卡片出现但 timeline 不更新。
+- 主会话卡片更新、topic 卡片停住。
+- `system.notice` 同时进入卡片 timeline 又在外面出现灰色消息。
+
+## `system.notice`
+
+Hermes 原生运行提示会被归一为 `system.notice`：
+
+- `Working — ...`
+- context window / auto-compaction 提示
+- automatic session reset
+- skill loading
+- self-improvement review
+- context compression
+
+处理规则：
+
+1. 如果当前 session 可用，notice 进入辅助 timeline。
+2. 如果没有当前 session，发送独立小卡片。
+3. 已识别 notice 如果卡片投递超时，也不再退回原生灰色文本。
+4. 未识别 notice 保持 Hermes 原生路径，避免吞掉重要未知提示。
+
+## 独立 slash command 卡片
+
+独立命令不混入正在运行的 Agent 卡片：
+
+- `/new`
+- `/reset`
+- `/clear`
+- `/undo`
+- `/stop`
+- `/model`
+
+这些命令在 Feishu/Lark WebSocket 长连接环境中优先走原生 interactive card。按钮或下拉选择通过 Hermes 原 handler 回写结果。
+
+特殊情况：
+
+- `/update` 是 Hermes 后台升级命令，不渲染交互命令卡片。
+- sidecar 或 command card 不可用时，允许回到 Hermes 原生文本 fallback。
+
+## `/health` 观测指标
+
+排查时先看：
+
+- `events_received`
+- `events_applied`
+- `events_ignored`
+- `feishu_send_successes`
+- `feishu_update_successes`
+- `feishu_update_failures`
+- `last_update_error`
+- `last_route_error`
+- `reply_index.entries`
+
+如果 Feishu UI 出现灰色重复文本，同时 `/health` 显示卡片成功更新，应优先查 hook runtime 的 native fallback suppression。
+

--- a/docs/wiki/feishu-acceptance.md
+++ b/docs/wiki/feishu-acceptance.md
@@ -1,0 +1,114 @@
+# 真实飞书验收清单
+
+自动化测试不能完全证明 Feishu/Lark 客户端体验。涉及卡片 UX、topic、系统提示、命令卡片的版本，发布前需要真实飞书 smoke。
+
+## 准备
+
+- 本机 Hermes Gateway 正常运行。
+- sidecar 已启动：`python -m hermes_feishu_card.cli status --config ~/.hermes_feishu_card/config.yaml`
+- `doctor --explain` 通过，且 `Runtime import` 指向当前版本。
+- 飞书 bot 已在目标会话可用。
+- 不在仓库、issue 或日志中暴露 App Secret、tenant token、真实 chat id。
+
+## 普通会话
+
+提示词：
+
+```text
+查一下广州明天天气
+```
+
+验收：
+
+- 首张卡片出现。
+- 正文持续更新。
+- 工具调用进入“思考与工具”。
+- 完成后只有一张最终卡片，没有额外灰色最终答案。
+
+## Feishu topic / thread
+
+在飞书会话中创建或打开话题，在话题回复框里发送：
+
+```text
+请验证当前 Hermes 飞书卡片插件是否已经支持话题内卡片连续更新。不要直接回答，先说明你会从哪些证据判断；然后依次检查本地版本、CHANGELOG、测试用例和运行状态；每次工具调用前先给一句阶段性判断。
+```
+
+验收：
+
+- 右侧话题面板中出现卡片。
+- 后续工具和答案持续更新同一张卡片。
+- `思考与工具` 折叠区可展开，并显示工具 timeline。
+- 完成态仍在话题面板内。
+- 没有重复外溢的灰色 `system.notice`。
+
+## 系统提示 suppression
+
+提示词：
+
+```text
+V3.8.9 notice suppress smoke: please run terminal command date, then reply exactly topic smoke ok
+```
+
+验收：
+
+- 卡片完成并回复 `topic smoke ok`。
+- 如果触发 `Codex gpt-5.5 caps context...` 等上下文提示，不应额外出现在卡片外灰色消息里。
+- Gateway 日志允许出现 `system notice native fallback suppressed`，表示已识别并抑制原生 fallback。
+
+## Slash command cards
+
+发送：
+
+```text
+/new
+```
+
+验收：
+
+- 出现独立确认卡片。
+- 点击“允许一次”或“始终允许”后有状态反馈。
+- 允许后的 reset 结果以卡片反馈，不退回灰色文本。
+
+发送：
+
+```text
+/model
+```
+
+验收：
+
+- 出现模型选择卡片。
+- 使用下拉或选项选择模型。
+- 结果卡片显示模型已更新。
+- 再问“现在是什么模型”，模型应与选择一致。
+
+## 长内容和 Markdown
+
+提示词：
+
+```text
+生成一个包含 20 行、4 列的 Markdown 表格，并在后面附一个 80 行 Python 代码块。要求保持表格和代码块结构完整。
+```
+
+验收：
+
+- 长表格没有被飞书渲染成 raw markdown。
+- code fence 完整，没有半截围栏。
+- 卡片完成后没有重复灰色全文。
+
+## 记录方式
+
+验收完成后可记录到 release notes 或 issue comment：
+
+```text
+真实飞书验收：
+- 普通会话：通过
+- 话题回复：通过
+- system.notice suppression：通过
+- /new：通过
+- /model：通过
+- 长 Markdown：通过
+```
+
+截图入库前需要遮挡私人头像、姓名、chat id、群名和不适合公开的上下文。
+

--- a/docs/wiki/maintenance-guide.md
+++ b/docs/wiki/maintenance-guide.md
@@ -1,0 +1,78 @@
+# 维护指南
+
+## 改动前先判断范围
+
+这个项目的风险主要来自三类边界：
+
+- Hermes Gateway 内部变量和事件结构会变。
+- Feishu/Lark 卡片 API 与 WebSocket 交互路径有多条 fallback。
+- sidecar 状态是进程内内存，不能依赖持久化恢复。
+
+小文档改动可以直接做；涉及 `hook_runtime.py`、`server.py`、`patcher.py`、安装器或 release 流程时，先读 `AGENTS.md` 的 hot files 和测试矩阵。
+
+## Hot files
+
+### `hermes_feishu_card/hook_runtime.py`
+
+职责：
+
+- 从 Hermes runtime `locals()` 里抽取事件信息。
+- 向 sidecar 发送 `message.*`、`tool.updated`、`system.notice` 等事件。
+- monkeypatch Feishu adapter 的 `send`、`edit_message`、slash confirm、model picker。
+- 处理新版 Hermes 缺少 `message.started` 的首事件场景。
+
+高风险点：
+
+- 字段名必须贴合 Hermes 变量：`source`、`event`、`response`、`agent_result`、`event_message_id` 等。
+- Feishu topic 场景必须保留 `source.message_id` 和 `reply_to_message_id`。
+- 已识别 `system.notice` 不能在卡片投递超时后再次退回灰色原生文本。
+- `/update` 不进入命令卡片，保持 Hermes 后台升级。
+
+### `hermes_feishu_card/server.py`
+
+职责：
+
+- 管理 `CardSession`。
+- 根据 `message_id`、`reply_to_message_id` 和 profile/bot 信息路由到卡片。
+- 合并高频 delta，安排 Feishu PATCH。
+- 处理 terminal drain、终态优先更新、metrics 和 `/health`。
+
+高风险点：
+
+- topic 后续事件使用不同内部 `message_id` 时，必须先查 reply anchor。
+- terminal 事件前要 flush pending delta，避免尾部文本丢失。
+- 卡片已完成时不能让 Hermes 原生 resend 泄漏成灰色消息。
+
+### `hermes_feishu_card/install/patcher.py`
+
+职责：
+
+- 唯一允许修改 Hermes `gateway/run.py` 的代码。
+- AST 定位 Gateway 函数并插入 marker-wrapped hook blocks。
+- 创建 manifest、backup，支持 restore/uninstall/repair。
+
+高风险点：
+
+- patch 必须幂等、可移除、可检测 corrupt markers。
+- Hermes source-stripped Docker 目录缺少 `VERSION` 时，只能在 gateway anchors 可验证时兜底。
+- 新 hook block 必须有 patcher 单测和 remove/restore 覆盖。
+
+## 常见改动对应测试
+
+| 改动 | 先跑 | 发布前还要跑 |
+|---|---|---|
+| runtime event 抽取、topic、notice | `python -m pytest tests/unit/test_hook_runtime.py tests/integration/test_server.py -q` | `python -m pytest -q` |
+| patcher / install hook | `python -m pytest tests/unit/test_patcher.py tests/integration/test_cli_install.py -q` | `python -m pytest -q` |
+| renderer / timeline / Markdown | `python -m pytest tests/unit/test_render.py tests/unit/test_session.py -q` | `python -m pytest -q` |
+| CLI / doctor / install scripts | `python -m pytest tests/integration/test_cli.py tests/unit/test_install_scripts.py -q` | `python -m pytest -q` |
+| README / release notes / TODO | `python -m pytest tests/unit/test_docs.py -q` | `git diff --check` |
+| version bump | `python -m pytest tests/unit/test_package_metadata.py tests/unit/test_docs.py -q` | `python -m pytest -q` |
+
+## 维护原则
+
+- 先加失败测试，再修复复杂 bug。
+- 不直接改 Hermes 本体；通过 patcher 和 install 命令验证。
+- 保持 hook fail-open，但对已识别且已接管的 Feishu 卡片消息要抑制重复原生文本。
+- 真实 Feishu 凭据、chat id、token 不进入仓库。
+- 截图入库前脱敏；优先展示项目能力，不展示私人内容。
+

--- a/docs/wiki/release-playbook.md
+++ b/docs/wiki/release-playbook.md
@@ -1,0 +1,95 @@
+# 发布手册
+
+## 何时发版本
+
+适合发补丁版本：
+
+- 修复明确 issue 或真实 Feishu bug。
+- 增加 Hermes 兼容性。
+- 修复 installer/doctor/Docker 影响安装的问题。
+- README/文档和安装包需要同步公开。
+
+适合攒到小版本：
+
+- 多个相关 UX 改进。
+- 新诊断命令或新安装流程。
+- 涉及截图、README 首页和 release assets 的体验升级。
+
+## 发版前
+
+1. 确认版本号
+   - `pyproject.toml`
+   - `hermes_feishu_card/__init__.py`
+   - `tests/unit/test_package_metadata.py`
+2. 更新文档
+   - `CHANGELOG.md`
+   - `docs/release-notes-vX.Y.Z.md`
+   - `README.md`
+   - `README.en.md`
+   - `TODO.md`
+   - 受影响的 `docs/wiki/` 页面
+3. 更新安装包默认值
+   - `docker-compose.example.yml`
+   - `README-install.md`
+   - 必要时 `install.sh` / `install.ps1`
+4. 真实 Feishu 验收
+   - 按 [真实飞书验收清单](feishu-acceptance.md) 选择相关 smoke。
+
+## 必跑验证
+
+```bash
+python -m pytest -q
+git diff --check
+```
+
+如果使用 `uv run --extra test pytest -q`，测试后删除临时 `uv.lock`，除非项目明确决定开始提交 lockfile。
+
+## 提交和 tag
+
+```bash
+git status --short
+git add <release files>
+git commit -m "Release vX.Y.Z <summary>"
+git tag -a vX.Y.Z -m "Release vX.Y.Z <summary>"
+git push origin main
+git push origin vX.Y.Z
+```
+
+`vX.Y.Z` 必须是 annotated tag。
+
+## GitHub Release
+
+如果 tag push 触发 `.github/workflows/release-assets.yml`，workflow 会创建 release 并上传：
+
+- `hermes-feishu-card-vX.Y.Z-macos.tar.gz`
+- `hermes-feishu-card-vX.Y.Z-linux.tar.gz`
+- `hermes-feishu-card-vX.Y.Z-windows.zip`
+- `hermes-feishu-card-vX.Y.Z-checksums.txt`
+
+随后用自定义 notes 覆盖自动 body：
+
+```bash
+gh release edit vX.Y.Z \
+  --repo baileyh8/hermes-feishu-streaming-card \
+  --title "vX.Y.Z" \
+  --notes-file docs/release-notes-vX.Y.Z.md
+```
+
+最后确认：
+
+```bash
+gh release view vX.Y.Z --repo baileyh8/hermes-feishu-streaming-card
+gh run list --workflow release-assets.yml --limit 3
+```
+
+## Issue 回复
+
+能确认解决的 issue，回复应包含：
+
+- 修复版本和 release 链接。
+- 修复范围。
+- 测试命令。
+- 如果需要用户再验证，列出最小验证步骤。
+
+不要把未验证的问题写成已解决。
+

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -10,13 +10,9 @@ def read_doc(path: str) -> str:
 
 def test_readme_documents_sidecar_only_and_supported_hermes_version():
     readme = read_doc("README.md")
+    guide = read_doc("docs/user-guide.md")
 
     assert readme.startswith("# Hermes 飞书流式卡片插件\n")
-    assert "V3.6.6" in readme
-    assert "V3.6.5" in readme
-    assert "V3.6.4" in readme
-    assert "V3.6.3" in readme
-    assert "V3.6.2" in readme
     assert "[English](README.en.md)" in readme
     assert "img.shields.io/github/stars/baileyh8/hermes-feishu-streaming-card" in readme
     assert "img.shields.io/github/v/release/baileyh8/hermes-feishu-streaming-card" in readme
@@ -26,9 +22,11 @@ def test_readme_documents_sidecar_only_and_supported_hermes_version():
     assert "img.shields.io/badge/Runtime-Sidecar--only" in readme
     assert "docs/assets/readme-cover.png" in readme
     assert "docs/assets/feishu-card-showcase-v385.png" in readme
+    assert "docs/assets/feishu-topic-card-showcase-v389.png" in readme
+    assert "docs/user-guide.md" in readme
     assert "PR #76" in readme
-    assert "项目亮点" in readme
-    assert "解决的真实痛点" in readme
+    assert "你能看到什么" in readme
+    assert "适用场景" in readme
     assert "Hermes Agent Gateway 的飞书/Lark 回复变成一张持续更新的交互式卡片" in readme
     assert "/hfc status" in readme
     assert "HERMES_FEISHU_CARD_DELTA_COALESCE_MS" in readme
@@ -41,87 +39,98 @@ def test_readme_documents_sidecar_only_and_supported_hermes_version():
     assert "thinking.delta" in readme
     assert "v2026.4.23" in readme
     assert "Git tag `v2026.4.23+`" in readme
+    assert len(readme.splitlines()) <= 260
     assert (ROOT / "docs/assets/readme-cover.png").exists()
     assert (ROOT / "docs/assets/feishu-card-showcase-v385.png").exists()
     assert (ROOT / "docs/assets/feishu-weather-card.png").exists()
-    assert "V3.2" in readme
+    assert "V3.6.6" in guide
+    assert "V3.6.5" in guide
+    assert "V3.6.4" in guide
+    assert "V3.6.3" in guide
+    assert "V3.6.2" in guide
+    assert "V3.2" in guide
     assert "多 bot" in readme
     assert "群聊" in readme
     assert "bindings.chats" in readme
-    assert "group_rules" in readme
+    assert "group_rules" in guide
 
 
 def test_readme_documents_v340_hermes_compatibility():
     readme = read_doc("README.md")
+    guide = read_doc("docs/user-guide.md")
+    docs = readme + "\n" + guide
 
-    assert "V3.6.0" in readme
-    assert "issue #41" in readme
-    assert "PR #42" in readme
-    assert "授权/选项按钮" in readme
-    assert "issue #39" in readme
-    assert "v0.14.0" in readme
-    assert "0.15.x" in readme
-    assert "v2026.5.16+" in readme
-    assert "issue #31" in readme
-    assert "issue #25" in readme
-    assert "Hermes 0.13.0" in readme
-    assert "旧版本" in readme
-    assert "hook_strategy" in readme
-    assert "gateway_run_013_plus" in readme
-    assert "legacy_gateway_run" in readme
-    assert "compatibility" in readme
-    assert "anchor" in readme or "anchors" in readme
-    assert "重新安装 hook" in readme
-    assert "install --hermes-dir" in readme
-    assert "issue #23" in readme
-    assert "多 profile / multi bot" in readme
-    assert "per-bot/profile title" in readme
-    assert "cron final cards" in readme
-    assert "attachment summaries + native media delivery" in readme
-    assert "routing profile diagnostics" in readme
-    assert "safe repair" in readme
-    assert "reply card context" in readme
+    assert "V3.6.0" in docs
+    assert "issue #41" in docs
+    assert "PR #42" in docs
+    assert "授权/选项按钮" in docs
+    assert "issue #39" in docs
+    assert "v0.14.0" in docs
+    assert "0.15.x" in docs
+    assert "v2026.5.16+" in docs
+    assert "issue #31" in docs
+    assert "issue #25" in docs
+    assert "Hermes 0.13.0" in docs
+    assert "旧版本" in docs
+    assert "hook_strategy" in docs
+    assert "gateway_run_013_plus" in docs
+    assert "legacy_gateway_run" in docs
+    assert "compatibility" in docs
+    assert "anchor" in docs or "anchors" in docs
+    assert "重新安装 hook" in docs
+    assert "install --hermes-dir" in docs
+    assert "issue #23" in docs
+    assert "多 profile / multi bot" in docs
+    assert "per-bot/profile title" in docs
+    assert "cron final cards" in docs
+    assert "attachment summaries + native media delivery" in docs
+    assert "routing profile diagnostics" in docs
+    assert "safe repair" in docs
+    assert "reply card context" in docs
 
 
 def test_english_readme_documents_v340_hermes_compatibility():
     readme = read_doc("README.en.md")
+    guide = read_doc("docs/user-guide.en.md")
+    docs = readme + "\n" + guide
 
-    assert "V3.6.6" in readme
-    assert "V3.6.5" in readme
-    assert "V3.6.4" in readme
-    assert "V3.6.3" in readme
-    assert "V3.6.2" in readme
-    assert "issue #41" in readme
-    assert "PR #42" in readme
-    assert "Approval/choice interactions" in readme
-    assert "issue #39" in readme
-    assert "v0.14.0" in readme
-    assert "0.15.x" in readme
-    assert "v2026.5.16+" in readme
-    assert "issue #31" in readme
-    assert "issue #25" in readme
-    assert "Hermes 0.13.0" in readme
-    assert "older Hermes" in readme
-    assert "hook_strategy" in readme
-    assert "gateway_run_013_plus" in readme
-    assert "legacy_gateway_run" in readme
-    assert "compatibility" in readme
-    assert "anchor" in readme or "anchors" in readme
-    assert "Reinstall the hook" in readme
-    assert "install --hermes-dir" in readme
-    assert "issue #23" in readme
-    assert "Multi-profile / multi-bot" in readme
-    assert "per-bot/profile title" in readme
-    assert "cron final cards" in readme
-    assert "attachment summaries + native media delivery" in readme
-    assert "routing profile diagnostics" in readme
-    assert "safe `repair`" in readme
-    assert "reply card context" in readme
+    assert "V3.6.6" in guide
+    assert "V3.6.5" in guide
+    assert "V3.6.4" in guide
+    assert "V3.6.3" in guide
+    assert "V3.6.2" in guide
+    assert "issue #41" in docs
+    assert "PR #42" in docs
+    assert "Approval/choice interactions" in docs
+    assert "issue #39" in docs
+    assert "v0.14.0" in docs
+    assert "0.15.x" in docs
+    assert "v2026.5.16+" in docs
+    assert "issue #31" in docs
+    assert "issue #25" in docs
+    assert "Hermes 0.13.0" in docs
+    assert "older Hermes" in docs
+    assert "hook_strategy" in docs
+    assert "gateway_run_013_plus" in docs
+    assert "legacy_gateway_run" in docs
+    assert "compatibility" in docs
+    assert "anchor" in docs or "anchors" in docs
+    assert "Reinstall the hook" in docs
+    assert "install --hermes-dir" in docs
+    assert "issue #23" in docs
+    assert "Multi-profile / multi-bot" in docs
+    assert "per-bot/profile title" in docs
+    assert "cron final cards" in docs
+    assert "attachment summaries + native media delivery" in docs
+    assert "routing profile diagnostics" in docs
+    assert "safe `repair`" in docs
+    assert "reply card context" in docs
 
 
 def test_readme_documents_one_line_install_and_release_packages():
     readme = read_doc("README.md")
     english_readme = read_doc("README.en.md")
+    guide = read_doc("docs/user-guide.md")
     install_doc = read_doc("README-install.md")
     workflow = read_doc(".github/workflows/release-assets.yml")
 
@@ -139,25 +148,25 @@ def test_readme_documents_one_line_install_and_release_packages():
     assert "docs/release-notes-v3.8.7.md" in readme
     assert "docs/release-notes-v3.8.6.md" in readme
     assert "docs/release-notes-v3.8.5.md" in readme
-    assert "docs/release-notes-v3.8.4.md" in readme
-    assert "docs/release-notes-v3.8.3.md" in readme
-    assert "docs/release-notes-v3.8.2.md" in readme
-    assert "docs/release-notes-v3.8.1.md" in readme
-    assert "docs/release-notes-v3.8.0.md" in readme
-    assert "docs/release-notes-v3.6.6.md" in readme
-    assert "docs/release-notes-v3.6.5.md" in readme
-    assert "docs/release-notes-v3.6.4.md" in readme
-    assert "docs/release-notes-v3.6.3.md" in readme
-    assert "docs/release-notes-v3.6.2.md" in readme
-    assert "docs/release-notes-v3.6.1.md" in readme
-    assert "docs/release-notes-v3.6.0.md" in readme or "v3.6.0" in readme
-    assert "docs/release-notes-v3.5.2.md" in readme or "v3.5.2" in readme
-    assert "docs/roadmap-v3.6.0.md" in readme
-    assert "hermes-feishu-card-<version>-macos.tar.gz" in readme
-    assert "hermes-feishu-card-<version>-linux.tar.gz" in readme
-    assert "hermes-feishu-card-<version>-windows.zip" in readme
+    assert "release-notes-v3.8.4.md" in guide
+    assert "release-notes-v3.8.3.md" in guide
+    assert "release-notes-v3.8.2.md" in guide
+    assert "release-notes-v3.8.1.md" in guide
+    assert "release-notes-v3.8.0.md" in guide
+    assert "release-notes-v3.6.6.md" in guide
+    assert "release-notes-v3.6.5.md" in guide
+    assert "release-notes-v3.6.4.md" in guide
+    assert "release-notes-v3.6.3.md" in guide
+    assert "release-notes-v3.6.2.md" in guide
+    assert "release-notes-v3.6.1.md" in guide
+    assert "release-notes-v3.6.0.md" in guide or "v3.6.0" in guide
+    assert "release-notes-v3.5.2.md" in guide or "v3.5.2" in guide
+    assert "roadmap-v3.6.0.md" in guide
+    assert "hermes-feishu-card-<version>-macos.tar.gz" in guide
+    assert "hermes-feishu-card-<version>-linux.tar.gz" in guide
+    assert "hermes-feishu-card-<version>-windows.zip" in guide
 
-    assert "One-Line Install" in english_readme
+    assert "Quick Install" in english_readme
     assert "README-install.md" in english_readme
     assert "bash install.sh" in install_doc
     assert "install.ps1" in install_doc
@@ -325,21 +334,21 @@ def test_english_readme_and_docs_are_linked():
     assert "Hermes Feishu Streaming Card turns Hermes Agent Gateway replies" in english_readme
     assert "/hfc status" in english_readme
     assert "HERMES_FEISHU_CARD_DELTA_COALESCE_MS" in english_readme
-    assert "Project Highlights" in english_readme
-    assert "Pain Points Solved" in english_readme
+    assert "What You Get" in english_readme
+    assert "Problems Solved" in english_readme
     assert "img.shields.io/github/stars/baileyh8/hermes-feishu-streaming-card" in english_readme
     assert "docs/assets/readme-cover.png" in english_readme
     assert "docs/assets/feishu-card-showcase-v385.png" in english_readme
     assert "PR #76" in english_readme
     assert "setup --hermes-dir" in english_readme
-    assert "Hermes Gateway Streaming And Thinking" in english_readme
+    assert "Hermes Streaming Config" in english_readme
     assert "streaming.enabled" in english_readme
     assert "display.platforms.feishu.streaming" in english_readme
     assert "Do not treat `display.show_reasoning`" in english_readme
     assert "thinking.delta" in english_readme
     assert "Multi-bot" in english_readme
     assert "group chat" in english_readme
-    assert "pytest" in english_readme
+    assert "pytest" in read_doc("docs/testing.en.md")
     assert "425 passed" not in readme
     assert "398 passed" not in readme
     assert "425 passed" not in english_readme
@@ -382,17 +391,19 @@ def test_event_protocol_documents_card_status_labels():
 
 def test_docs_describe_event_forwarding_and_real_e2e_completion():
     readme = read_doc("README.md")
+    guide = read_doc("docs/user-guide.md")
     architecture = read_doc("docs/architecture.md")
     todo = read_doc("TODO.md")
     docs = "\n".join(
         [
             readme,
+            guide,
             architecture,
             todo,
         ]
     )
 
-    assert "真实 Feishu E2E 主链路" in readme
+    assert "真实 Feishu E2E 主链路" in docs
     assert "Hermes hook 到 sidecar `/events` 的 fail-open 转发链路已经落地" in architecture
     assert "Feishu CardKit HTTP client 已实现" in docs
     assert "真实 Hermes Gateway E2E" in docs


### PR DESCRIPTION
## Summary

- Streamline the Chinese and English README files into short project entry pages.
- Move the previous long README content into docs/user-guide.md and docs/user-guide.en.md.
- Add a maintainer wiki under docs/wiki covering maintenance rules, event flow, Feishu acceptance checks, and release playbook.
- Keep AGENTS.md concise and route durable reference material into docs/wiki.
- Update documentation tests so they validate the new README/user-guide split instead of forcing all details into README.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_docs.py -q`
- `git diff --check`
- Local Markdown link check for README and user-guide files

## Notes

This is documentation-only. No runtime code, package version, tag, or release was changed.