### PR TITLE
fix installer pip warning output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.2.0.html).
 
+## Unreleased
+
+### Fixed
+- issue #79: `install.sh` and `install-docker.sh` now suppress pip's root-user warning by default and keep recoverable `externally-managed-environment` output from looking like a fatal install failure.
+- Docker installs now retry PEP 668 externally managed Python environments with `--break-system-packages`, matching the macOS/Linux installer behavior.
+
+### Tests
+- Added installer regression coverage for pip root-user warning suppression and Debian/Ubuntu externally managed Python retry output.
+
 ## V3.8.9 — 2026-07-04
 
 See also: [docs/release-notes-v3.8.9.md](docs/release-notes-v3.8.9.md)

--- a/README-install.md
+++ b/README-install.md
@@ -57,6 +57,12 @@ Hermes emits later stream events with a different internal `message_id`. Tool
 timeline updates and `system.notice` messages resolve through the original reply
 anchor instead of freezing the topic card or leaking duplicate gray messages.
 
+Current installers default `PIP_ROOT_USER_ACTION=ignore` so Debian/Ubuntu root
+installs do not print pip's root-user warning. If Python reports
+`externally-managed-environment`, `install.sh` and `install-docker.sh` retry with
+`--break-system-packages` and print a concise recovery message after the package
+install succeeds.
+
 ## macOS / Linux
 
 ```bash

--- a/install-docker.sh
+++ b/install-docker.sh
@@ -101,6 +101,7 @@ require_credentials() {
 
 install_package() {
   local python_bin="$1"
+  export PIP_ROOT_USER_ACTION="${PIP_ROOT_USER_ACTION:-ignore}"
   "$python_bin" -m pip --version >/dev/null 2>&1 || "$python_bin" -m ensurepip --upgrade >/dev/null
   local tag
   tag="$(resolve_version)"
@@ -114,7 +115,31 @@ install_package() {
   else
     log "installing $REPO@$tag into $python_bin"
   fi
-  "$python_bin" -m pip install --upgrade "$spec"
+  local pip_log
+  pip_log="$(mktemp)"
+  if "$python_bin" -m pip install --upgrade "$spec" >"$pip_log" 2>&1; then
+    cat "$pip_log"
+    rm -f "$pip_log"
+    return
+  fi
+  local pip_status
+  pip_status=$?
+  if grep -q "externally-managed-environment" "$pip_log"; then
+    log "Python environment is externally managed; retrying with --break-system-packages"
+    if "$python_bin" -m pip install --upgrade --break-system-packages "$spec" >"$pip_log" 2>&1; then
+      cat "$pip_log"
+      log "pip warning handled safely; package install completed"
+      rm -f "$pip_log"
+      return
+    fi
+    pip_status=$?
+    cat "$pip_log" >&2
+    rm -f "$pip_log"
+    return "$pip_status"
+  fi
+  cat "$pip_log" >&2
+  rm -f "$pip_log"
+  return "$pip_status"
 }
 
 run_doctor() {

--- a/install.sh
+++ b/install.sh
@@ -126,6 +126,7 @@ prompt_credentials() {
 
 install_package() {
   have "$PYTHON_BIN" || fail "$PYTHON_BIN was not found. Install Python 3.9+ first."
+  export PIP_ROOT_USER_ACTION="${PIP_ROOT_USER_ACTION:-ignore}"
   "$PYTHON_BIN" -m pip --version >/dev/null 2>&1 || "$PYTHON_BIN" -m ensurepip --upgrade >/dev/null
   local tag
   tag="$(resolve_version)"
@@ -147,14 +148,22 @@ install_package() {
     rm -f "$pip_log"
     return
   fi
-  local pip_status=$?
-  cat "$pip_log" >&2
+  local pip_status
+  pip_status=$?
   if grep -q "externally-managed-environment" "$pip_log"; then
     log "Python environment is externally managed; retrying with --break-system-packages"
+    if "$PYTHON_BIN" -m pip "${pip_args[@]}" --break-system-packages "$spec" >"$pip_log" 2>&1; then
+      cat "$pip_log"
+      log "pip warning handled safely; package install completed"
+      rm -f "$pip_log"
+      return
+    fi
+    pip_status=$?
+    cat "$pip_log" >&2
     rm -f "$pip_log"
-    "$PYTHON_BIN" -m pip "${pip_args[@]}" --break-system-packages "$spec"
-    return
+    return "$pip_status"
   fi
+  cat "$pip_log" >&2
   rm -f "$pip_log"
   return "$pip_status"
 }

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -141,9 +141,74 @@ exit 0
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert "retrying with --break-system-packages" in result.stdout
+    assert "error: externally-managed-environment" not in (
+        result.stderr + result.stdout
+    )
+    assert "pip warning handled safely; package install completed" in result.stdout
     assert "--break-system-packages" in (tmp_path / "python.log").read_text(
         encoding="utf-8"
     )
+
+
+def test_install_sh_suppresses_pip_root_user_warning(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "FEISHU_APP_ID=cli_dotenv\nFEISHU_APP_SECRET=dotenv_secret\n",
+        encoding="utf-8",
+    )
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_PYTHON_LOG"
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  if [ "${PIP_ROOT_USER_ACTION:-}" != "ignore" ]; then
+    echo "WARNING: Running pip as the 'root' user can result in broken permissions" >&2
+  fi
+  echo "install ok"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "hermes_feishu_card.cli" ]; then
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_PYTHON_LOG": str(tmp_path / "python.log"),
+            "HERMES_DIR": str(tmp_path / "hermes-agent"),
+            "HFC_CONFIG": str(tmp_path / "config.yaml"),
+            "HFC_ENV_FILE": str(env_file),
+            "HFC_NO_PROMPT": "1",
+            "HFC_SKIP_START": "1",
+            "HFC_VERSION": "main",
+            "PYTHON": str(fake_python),
+        }
+    )
+    env.pop("FEISHU_APP_ID", None)
+    env.pop("FEISHU_APP_SECRET", None)
+    env.pop("PIP_ROOT_USER_ACTION", None)
+
+    result = subprocess.run(
+        ["bash", "install.sh"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "install ok" in result.stdout
+    assert "Running pip as the 'root' user" not in result.stderr + result.stdout
 
 
 def make_fake_docker_python(path: Path) -> Path:
@@ -434,6 +499,79 @@ def test_install_docker_sh_uses_latest_without_pin(tmp_path):
     assert f"{spec}@" not in log
     assert "@v" not in log
     assert "@main" not in log
+
+
+def test_install_docker_sh_retries_externally_managed_python(tmp_path):
+    hermes_dir = tmp_path / "opt" / "hermes"
+    data_dir = tmp_path / "opt" / "data"
+    (hermes_dir / "gateway").mkdir(parents=True)
+    (hermes_dir / "gateway" / "run.py").write_text("# gateway\n", encoding="utf-8")
+    env_file = data_dir / ".env"
+    data_dir.mkdir(parents=True)
+    env_file.write_text(
+        "FEISHU_APP_ID=cli_docker\nFEISHU_APP_SECRET=docker_secret\n",
+        encoding="utf-8",
+    )
+    fake_python = hermes_dir / "venv" / "bin" / "python"
+    fake_python.parent.mkdir(parents=True, exist_ok=True)
+    fake_python.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_PYTHON_LOG"
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  if [ "${PIP_ROOT_USER_ACTION:-}" != "ignore" ]; then
+    echo "WARNING: Running pip as the 'root' user can result in broken permissions" >&2
+  fi
+  case "$*" in
+    *--break-system-packages*) echo "install ok"; exit 0 ;;
+    *) echo "error: externally-managed-environment" >&2; exit 1 ;;
+  esac
+fi
+if [ "$1" = "-m" ] && [ "$2" = "hermes_feishu_card.cli" ]; then
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_PYTHON_LOG": str(tmp_path / "python.log"),
+            "HERMES_DIR": str(hermes_dir),
+            "HFC_CONFIG": str(data_dir / "config.yaml"),
+            "HFC_ENV_FILE": str(env_file),
+            "HFC_VERSION": "main",
+            "HFC_SKIP_START": "1",
+        }
+    )
+    env.pop("FEISHU_APP_ID", None)
+    env.pop("FEISHU_APP_SECRET", None)
+    env.pop("PIP_ROOT_USER_ACTION", None)
+
+    result = subprocess.run(
+        ["bash", "install-docker.sh"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    combined = result.stderr + result.stdout
+    assert "retrying with --break-system-packages" in result.stdout
+    assert "error: externally-managed-environment" not in combined
+    assert "Running pip as the 'root' user" not in combined
+    assert "pip warning handled safely; package install completed" in result.stdout
+    assert "--break-system-packages" in (tmp_path / "python.log").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_install_docker_sh_fails_without_hermes_venv_python(tmp_path):


### PR DESCRIPTION
## Summary
- suppress pip root-user warnings in `install.sh` and `install-docker.sh` by defaulting `PIP_ROOT_USER_ACTION=ignore`
- keep recoverable `externally-managed-environment` output from looking fatal, then retry with `--break-system-packages`
- document the Debian/Ubuntu root/PEP 668 installer behavior and add changelog coverage

## Why
Closes #79. Debian/Ubuntu root installs could finish successfully while still showing scary pip warnings, which made new users think the install failed.

## Tests
- `.venv/bin/python -m pytest tests/unit/test_install_scripts.py -q`
- `.venv/bin/python -m pytest tests/unit/test_docs.py -q`
- `.venv/bin/python -m pytest tests/integration/test_cli.py tests/unit/test_install_scripts.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
