### PR TITLE
fix: cron delivery modes short-circuit platform fallback chain

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -3216,6 +3216,12 @@ def _deliver_platform(value: Any) -> str:
         return ""
     if ":" in text:
         return text.split(":", 1)[0].strip()
+    # "origin"/"all"/"local" are delivery modes, not platform names.
+    # Without this guard they short-circuit the platform fallback chain
+    # in build_cron_event and cause every deliver=origin cron to
+    # silently lose card delivery.
+    if text in {"origin", "all", "local"}:
+        return ""
     return text
 
 


### PR DESCRIPTION
## Problem

When a cron job has `deliver: origin` (the auto-detect default), `_deliver_platform("origin")` returns the literal string `"origin"`. This is truthy, so the platform fallback chain in `build_cron_event`:

```python
platform = str(
    deliver_platform          # <-- "origin" stops here
    or _first_target_platform(...)
    or origin.get("platform") # <-- should be "feishu"
    or os.environ.get(...)
    or "feishu"
)
```

gets short-circuited at the first step. The result: `platform = "origin"`, which fails the check `if platform != "feishu" or not chat_id: return None`, and the cron card is **silently discarded** with no log or error.

## Fix

Recognize `"origin"`, `"all"`, and `"local"` as delivery modes rather than platform names in `_deliver_platform()`. Return empty string for these values so the fallback chain proceeds normally.

## Impact

- 2 lines inserted, 0 lines deleted, 0 lines modified
- All cron jobs with implicit `deliver: origin` will now correctly fall through to card delivery
- Zero performance impact — the check runs once per cron delivery