### PR TITLE
fix: send a new card for a second message reusing the same message_id (topic groups)

### DIFF
--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -649,8 +649,20 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
 
     if event.event == "message.started":
         if session is not None:
-            metrics.events_ignored += 1
-            return web.json_response({"ok": True, "applied": False}), None
+            if session.status in {"completed", "failed"}:
+                # Feishu topic (thread) groups reuse the same message_id across
+                # consecutive messages in the same thread, so a new turn's
+                # message.started collides with the previous, already-finished
+                # session for that key. Treat it as a fresh turn: discard the
+                # finished session and its delivery bookkeeping so the code below
+                # creates a new session and sends a NEW card (rather than
+                # ignoring the started event and losing the card entirely).
+                _reset_session_for_new_turn(request.app, session_key)
+                session = None
+            else:
+                metrics.events_ignored += 1
+                return web.json_response({"ok": True, "applied": False}), None
+    if event.event == "message.started" and session is None:
         session = CardSession(
             conversation_id=event.conversation_id,
             message_id=event.message_id,
@@ -1191,6 +1203,25 @@ async def _retry_terminal_update(
         await asyncio.sleep(delay)
         if await _update_card_for_app(app, message_id, card, bot_id):
             return
+
+
+def _reset_session_for_new_turn(app: web.Application, session_key: str) -> None:
+    """Discard a finished session and all its per-key bookkeeping.
+
+    Used when a Feishu topic (thread) group reuses the same message_id for a new
+    turn: the previous session for that key is already completed/failed, and we
+    must clear it (and its delivery/config/flush state) so the next
+    message.started sends a brand-new card instead of trying to update the old
+    one or ignoring the event.
+    """
+    app[SESSIONS_KEY].pop(session_key, None)
+    app[FEISHU_MESSAGE_IDS_KEY].pop(session_key, None)
+    app[MESSAGE_BOT_IDS_KEY].pop(session_key, None)
+    app[SESSION_CARD_CONFIGS_KEY].pop(session_key, None)
+    controllers: Dict[str, FlushController] = app[FLUSH_CONTROLLERS_KEY]
+    controller = controllers.pop(session_key, None)
+    if controller is not None:
+        controller.close()
 
 
 def _flush_controller_for_session(

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -741,6 +741,117 @@ async def test_topic_system_notice_with_reply_anchor_updates_existing_card(clien
     assert len(feishu_client.sent) == 1
 
 
+async def test_topic_second_message_reusing_message_id_sends_new_card(client):
+    """Feishu topic groups reuse the same message_id across turns. A second
+    message.started on the same (already-completed) key must send a NEW card,
+    not be ignored, so the second turn is not left card-less."""
+    test_client, feishu_client = client
+
+    # First turn: started -> answer -> completed on message_id om_topic_user.
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": "om_topic_user"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "answer.delta",
+            1,
+            {"reply_to_message_id": "om_topic_user", "text": "first answer"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    completed = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.completed",
+            2,
+            {"reply_to_message_id": "om_topic_user"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    assert completed.status == 200
+    assert len(feishu_client.sent) == 1
+
+    # Second turn in the SAME thread reuses the SAME message_id.
+    started2 = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": "om_topic_user"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    assert started2.status == 200
+    assert await started2.json() == {"ok": True, "applied": True}
+    # A brand-new card must be sent for the second turn.
+    assert len(feishu_client.sent) == 2
+
+    # And the second turn's content must render on the new card.
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "answer.delta",
+            1,
+            {"reply_to_message_id": "om_topic_user", "text": "second answer"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    _mid, card = await wait_for_card_update(feishu_client, "second answer")
+    assert "second answer" in str(card)
+
+
+async def test_topic_second_message_started_while_active_is_ignored(client):
+    """A duplicate message.started while the session is still streaming must
+    still be ignored (no spurious second card)."""
+    test_client, feishu_client = client
+
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": "om_topic_user"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    assert len(feishu_client.sent) == 1
+
+    # Session still active (no completed) -> a second started is a duplicate.
+    dup = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": "om_topic_user"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+    assert dup.status == 200
+    assert await dup.json() == {"ok": True, "applied": False}
+    assert len(feishu_client.sent) == 1
+
+
 async def test_interaction_request_renders_buttons_and_callback_resolves(client):
     test_client, feishu_client = client
 


### PR DESCRIPTION
Fixes #89.

## Summary

Fixes a bug in **Feishu/Lark topic (thread) groups** where the **second and later messages in the same thread show no streaming card** — only the final native text appears. When such a message triggers a `clarify`/approval interaction, it hangs (the interaction card never appears, so it can't be answered).

## Root cause

In topic groups the gateway reuses the **same `message_id`** across consecutive messages in the same thread. The sidecar keys sessions by `profile_id:message_id`, so a new turn's `message.started` resolves to the **same session key** as the previous turn.

After the first turn completes, its `CardSession` stays in the sessions map with `status="completed"`. The second turn's `message.started` then hit this branch:

```python
if event.event == "message.started":
    if session is not None:
        metrics.events_ignored += 1
        return web.json_response({"ok": True, "applied": False}), None  # ← no new card
```

Because a session already existed for the key, the started event was ignored and **no new card was sent**. Subsequent stream events for the second turn were also rejected by `CardSession.apply` (it drops events once `status` is `completed`/`failed`), so the second message fell back to native text. For a `clarify` turn this means the interaction card never renders and the turn hangs.

I confirmed this on a real Feishu topic group with a temporary probe: two consecutive `message.started` events in the same thread carried the **identical `message_id`**, and the second matched the first turn's `completed` session.

## Fix

In the `message.started` branch, distinguish a genuine duplicate from a reused-message_id new turn:

- If the matched session is **already `completed`/`failed`**, treat the event as a **fresh turn**: discard the finished session and all its per-key bookkeeping (`feishu_message_id`, `bot_id`, card config, flush controller) via a new `_reset_session_for_new_turn` helper, then fall through to create a new session and send a **new card**.
- If the matched session is **still streaming**, keep the existing behavior and ignore the duplicate `message.started` (no spurious second card).

Clearing `feishu_message_ids[key]` is what makes the new turn send a fresh card instead of trying to update the previous (now stale) card.

## Testing

- `tests/integration/test_server.py::test_topic_second_message_reusing_message_id_sends_new_card` — first turn started→answer→completed (1 card), then a second `message.started` on the same message_id sends a **second** card and the second turn's answer renders on it.
- `tests/integration/test_server.py::test_topic_second_message_started_while_active_is_ignored` — a duplicate `message.started` while the session is still streaming is still ignored (no second card).
- Full suite green locally (`python -m pytest -q`) against a clean `HERMES_HOME`.
- Verified end-to-end on a real Feishu WebSocket topic group: the second message in a thread now shows its own streaming card.

## Notes

- No behavior change outside topic-group message_id reuse: non-topic chats give each message a unique message_id, so the completed-session branch isn't reached there.
