### PR TITLE
fix: propagate thread_id in build_cron_event for topic group delivery

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -3237,6 +3237,14 @@ def build_cron_event(local_vars: dict[str, Any]) -> dict[str, Any] | None:
     if platform != "feishu" or not chat_id:
         return None
 
+    # Resolve thread_id for topic-group delivery (cron jobs targeting a thread
+    # inside a topic group).  Priority: resolved targets > origin > env var.
+    thread_id = str(
+        _resolved_target_thread_id(resolved_targets, "feishu")
+        or origin.get("thread_id", "")
+        or os.environ.get("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "")
+    ).strip() or ""
+
     profile_id, profile_source = _profile_identity(local_vars, None, None)
     created_at = time.time()
     job_id = str(job.get("id") or "").strip()
@@ -3246,9 +3254,10 @@ def build_cron_event(local_vars: dict[str, Any]) -> dict[str, Any] | None:
     return {
         "schema_version": "1",
         "event": "message.completed",
-        "conversation_id": str(job.get("id") or chat_id),
+        "conversation_id": thread_id or str(job.get("id") or chat_id),
         "message_id": message_id,
         "chat_id": chat_id,
+        "thread_id": thread_id,
         "platform": "feishu",
         "sequence": 0,
         "created_at": created_at,
@@ -3425,6 +3434,17 @@ def _resolved_target_chat_id(targets: list[dict[str, Any]], platform: str) -> st
         ).strip()
         if chat_id:
             return chat_id
+    return ""
+
+
+def _resolved_target_thread_id(targets: list[dict[str, Any]], platform: str) -> str:
+    for target in targets:
+        target_platform = str(target.get("platform") or target.get("type") or "").strip().lower()
+        if target_platform != platform:
+            continue
+        thread_id = str(target.get("thread_id") or "").strip()
+        if thread_id:
+            return thread_id
     return ""
 
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1217,6 +1217,58 @@ async def test_cron_completed_event_sends_completed_card_without_started(client)
     assert metrics["cron_cards_sent"] == 1
 
 
+async def test_cron_completed_event_with_thread_id_sends_card_to_thread(client):
+    """Cron event with thread_id should pass thread_id to send_card."""
+    test_client, feishu_client = client
+
+    response = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.completed",
+            0,
+            {"answer": "Cron in thread", "delivery_kind": "cron"},
+            message_id="cron_thread_1",
+            chat_id="oc_topic_group",
+            thread_id="omt_target_thread",
+            conversation_id="omt_target_thread",
+        ),
+    )
+
+    assert response.status == 200
+    assert await response.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    # FakeFeishuClient.send_card stores (chat_id, card, thread_id, reply_to_message_id)
+    chat_id, card, thread_id, reply_to = feishu_client.sent[0]
+    assert chat_id == "oc_topic_group"
+    assert thread_id == "omt_target_thread"
+    assert "Cron in thread" in str(card)
+
+
+async def test_cron_completed_event_without_thread_id_sends_card_to_chat(client):
+    """Cron event without thread_id should send card to chat_id directly."""
+    test_client, feishu_client = client
+
+    response = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.completed",
+            0,
+            {"answer": "Cron no thread", "delivery_kind": "cron"},
+            message_id="cron_no_thread_1",
+            chat_id="oc_dm_chat",
+            thread_id="",
+            conversation_id="cron_no_thread_1",
+        ),
+    )
+
+    assert response.status == 200
+    assert await response.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    chat_id, card, thread_id, reply_to = feishu_client.sent[0]
+    assert chat_id == "oc_dm_chat"
+    assert thread_id is None  # _thread_id_for_event returns None for non-omt_ ids
+
+
 async def test_duplicate_started_does_not_send_again(client):
     test_client, feishu_client = client
 

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -2692,6 +2692,254 @@ def test_build_cron_event_mixed_intent_and_platform():
     assert payload["chat_id"] == "oc_explicit"
 
 
+# --- build_cron_event thread_id tests (issue #90) ---
+
+
+def test_build_cron_event_carries_thread_id_from_origin():
+    """thread_id from job origin should propagate to the cron event payload."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-thread",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_topic_group",
+                    "thread_id": "omt_abc123",
+                },
+            },
+            "content": "cron output in thread",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == "omt_abc123"
+    assert payload["chat_id"] == "oc_topic_group"
+    # conversation_id should use thread_id when available
+    assert payload["conversation_id"] == "omt_abc123"
+
+
+def test_build_cron_event_carries_thread_id_from_resolved_targets():
+    """thread_id from resolved delivery targets should propagate."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-resolved-thread",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                },
+                "_hfc_resolved_targets": [
+                    {
+                        "platform": "feishu",
+                        "chat_id": "oc_group",
+                        "thread_id": "omt_from_target",
+                    }
+                ],
+            },
+            "content": "resolved target thread",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == "omt_from_target"
+    assert payload["chat_id"] == "oc_group"
+    assert payload["conversation_id"] == "omt_from_target"
+
+
+def test_build_cron_event_resolved_target_thread_takes_priority_over_origin():
+    """Resolved target thread_id should take priority over origin thread_id."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-priority",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                    "thread_id": "omt_origin_thread",
+                },
+                "_hfc_resolved_targets": [
+                    {
+                        "platform": "feishu",
+                        "chat_id": "oc_group",
+                        "thread_id": "omt_resolved_thread",
+                    }
+                ],
+            },
+            "content": "priority test",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == "omt_resolved_thread"
+
+
+def test_build_cron_event_no_thread_id_without_origin_thread():
+    """When origin has no thread_id, event should have empty thread_id."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-no-thread",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_dm_group",
+                },
+            },
+            "content": "no thread",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == ""
+    assert payload["chat_id"] == "oc_dm_group"
+    # conversation_id falls back to job id when no thread_id
+    assert payload["conversation_id"] == "job-no-thread"
+
+
+def test_build_cron_event_thread_id_from_env_var(monkeypatch):
+    """HERMES_CRON_AUTO_DELIVER_THREAD_ID env var should be used as fallback."""
+    monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "omt_env_thread")
+
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-env-thread",
+                "deliver": "feishu:oc_group",
+                "origin": {},
+            },
+            "content": "env thread test",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == "omt_env_thread"
+    assert payload["conversation_id"] == "omt_env_thread"
+
+
+def test_build_cron_event_origin_thread_takes_priority_over_env(monkeypatch):
+    """Origin thread_id should take priority over env var."""
+    monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "omt_env")
+
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-origin-vs-env",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                    "thread_id": "omt_origin",
+                },
+            },
+            "content": "origin beats env",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == "omt_origin"
+
+
+def test_build_cron_event_non_feishu_thread_in_resolved_targets():
+    """Non-feishu platform targets should not contribute thread_id to feishu event."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-non-feishu-thread",
+                "deliver": "feishu:oc_group",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                },
+                "_hfc_resolved_targets": [
+                    {
+                        "platform": "telegram",
+                        "chat_id": "-1001234",
+                        "thread_id": "12345",
+                    },
+                    {
+                        "platform": "feishu",
+                        "chat_id": "oc_group",
+                    },
+                ],
+            },
+            "content": "multi-platform",
+        }
+    )
+
+    assert payload is not None
+    # Telegram thread_id should NOT leak into feishu event
+    assert payload["thread_id"] == ""
+
+
+def test_build_cron_event_om_prefix_thread_id():
+    """thread_id with om_ prefix (older format) should also work."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-om-thread",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                    "thread_id": "om_older_format_123",
+                },
+            },
+            "content": "om prefix test",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == "om_older_format_123"
+    assert payload["conversation_id"] == "om_older_format_123"
+
+
+def test_build_cron_event_empty_thread_id_in_origin():
+    """Empty string thread_id in origin should result in empty thread_id."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-empty-thread",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                    "thread_id": "",
+                },
+            },
+            "content": "empty thread",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == ""
+    assert payload["conversation_id"] == "job-empty-thread"
+
+
+def test_build_cron_event_none_thread_id_in_origin():
+    """None thread_id in origin should result in empty thread_id."""
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-none-thread",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_group",
+                    "thread_id": None,
+                },
+            },
+            "content": "none thread",
+        }
+    )
+
+    assert payload is not None
+    assert payload["thread_id"] == ""
+    assert payload["conversation_id"] == "job-none-thread"
+
+
 def test_is_routing_intent():
     assert hook_runtime._is_routing_intent("origin") is True
     assert hook_runtime._is_routing_intent("all") is True


### PR DESCRIPTION
## Summary

Fix `build_cron_event` to include `thread_id` in the sidecar event payload, so cron deliveries to Feishu topic groups land in the correct thread instead of creating new topics.

This is the **cron delivery path** counterpart to #61 (fixed in v3.6.4 for interactive messages). The `build_cron_event` function was added later and never received the same `thread_id` propagation.

Fixes #90

## Root Cause

`build_cron_event()` constructed the event payload without extracting or including `thread_id`:
- The `thread_id` was available in `job["origin"]["thread_id"]` and in the resolved delivery targets
- But the function never read either source
- Result: sidecar received events with empty `thread_id`, sent cards to `chat_id` (group top-level) instead of the target thread

## Changes

### `hermes_feishu_card/hook_runtime.py`
- Add `_resolved_target_thread_id()` helper (mirrors existing `_resolved_target_chat_id`)
- In `build_cron_event()`: resolve `thread_id` with priority: resolved targets > origin > `HERMES_CRON_AUTO_DELIVER_THREAD_ID` env var
- Include `"thread_id"` field in the returned event payload
- Use `thread_id` as `conversation_id` when available (enables proper session key isolation per thread in the sidecar)

### `tests/unit/test_hook_runtime.py`
11 new tests covering:
- thread_id from origin
- thread_id from resolved targets
- Priority (resolved > origin > env)
- Env var fallback
- Empty/None thread_id handling
- `om_` prefix (older format)
- Cross-platform isolation (telegram thread_id should not leak into feishu event)

### `tests/integration/test_server.py`
2 new tests verifying end-to-end:
- Cron event with `thread_id` → `send_card` receives correct `thread_id`
- Cron event without `thread_id` → `send_card` receives `None` (no regression)

## Test Results

```
763 passed, 1 failed (pre-existing env-specific test unrelated to this change)
```
