### PR TITLE
fix: abandon stale card sessions on interrupt to prevent stuck "生成中"

### DIFF
--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -663,6 +663,12 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 metrics.events_ignored += 1
                 return web.json_response({"ok": True, "applied": False}), None
     if event.event == "message.started" and session is None:
+        # Abandon stale sessions for the same conversation — covers the case
+        # where a new message arrives with its own explicit message_id (e.g.
+        # after /stop or a generation-bump interrupt).
+        _abandon_stale_sessions_for_chat(
+            request.app, event.chat_id, session_key, event,
+        )
         session = CardSession(
             conversation_id=event.conversation_id,
             message_id=event.message_id,
@@ -710,6 +716,14 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
 
     if session is None:
         if event.event in SESSION_CREATING_EVENTS:
+            # Abandon stale sessions for the same conversation when a new
+            # session is being created.  This handles the interrupt scenario:
+            # the gateway interrupts a running turn and starts a new one
+            # without sending message.completed for the old turn — the old
+            # card would be stuck at "生成中" forever.
+            _abandon_stale_sessions_for_chat(
+                request.app, event.chat_id, session_key, event,
+            )
             session = CardSession(
                 conversation_id=event.conversation_id,
                 message_id=event.message_id,
@@ -794,6 +808,16 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
     applied = session.apply(event)
     if applied:
         _register_session_aliases(request.app, incoming_event, session_key)
+    # When a terminal event arrives for a session already completed (e.g. by
+    # _abandon_stale_sessions_for_chat), the apply() returns False but the
+    # session IS handled — report applied=True so the gateway hook suppresses
+    # the native text message (avoiding duplicate delivery).
+    if (
+        not applied
+        and event.event in TERMINAL_EVENTS
+        and session.status in {"completed", "failed"}
+    ):
+        applied = True
     if applied and event.event.startswith("interaction."):
         _store_interaction_result(request.app, session)
     if event.event in TERMINAL_EVENTS:
@@ -1222,6 +1246,81 @@ def _reset_session_for_new_turn(app: web.Application, session_key: str) -> None:
     controller = controllers.pop(session_key, None)
     if controller is not None:
         controller.close()
+
+
+def _abandon_stale_sessions_for_chat(
+    app: web.Application,
+    chat_id: str,
+    new_session_key: str,
+    event: "SidecarEvent",
+) -> None:
+    """Mark stale active sessions for the same chat+conversation as completed.
+
+    When the gateway interrupts a running turn and starts a new one (e.g. user
+    sends a new message mid-turn), no message.completed is sent for the old turn.
+    The old card stays stuck at "生成中" forever.  This function finds such
+    orphaned sessions and marks them completed so their cards render properly.
+
+    Only abandons sessions that share the same chat_id AND conversation_id AND
+    profile_id prefix (to avoid cross-profile or cross-thread interference),
+    and skips the new session itself.
+    """
+    sessions: Dict[str, CardSession] = app[SESSIONS_KEY]
+    feishu_message_ids: Dict[str, str] = app[FEISHU_MESSAGE_IDS_KEY]
+    message_bot_ids: Dict[str, str] = app[MESSAGE_BOT_IDS_KEY]
+
+    # Extract profile_id prefix from new_session_key (format: "profile:msg_id")
+    new_profile = new_session_key.split(":", 1)[0] if ":" in new_session_key else ""
+    new_conversation_id = event.conversation_id
+
+    stale_keys = []
+    for key, sess in sessions.items():
+        if key == new_session_key:
+            continue
+        if sess.chat_id != chat_id:
+            continue
+        if sess.conversation_id != new_conversation_id:
+            continue
+        if sess.status in {"completed", "failed"}:
+            continue
+        # Match profile prefix
+        key_profile = key.split(":", 1)[0] if ":" in key else ""
+        if key_profile != new_profile:
+            continue
+        stale_keys.append(key)
+
+    for key in stale_keys:
+        sess = sessions.get(key)
+        if sess is None:
+            continue
+        sess.status = "completed"
+        logger.info(
+            "Abandoning stale session %s (chat=%s, ans=%d chars) "
+            "— new session %s is taking over",
+            key, chat_id, len(sess.answer_text), new_session_key,
+        )
+        # Schedule a background card update to render the final state
+        feishu_msg_id = feishu_message_ids.get(key)
+        bot_id = message_bot_ids.get(key)
+        if feishu_msg_id is not None:
+            from hermes_feishu_card.render import render_card
+            card_config = app[SESSION_CARD_CONFIGS_KEY].get(key, app[BASE_CARD_CONFIG_KEY])
+            footer_fields = card_config.get("footer_fields", app[FOOTER_FIELDS_KEY])
+            if isinstance(footer_fields, list):
+                footer_fields = list(footer_fields)
+            elif footer_fields is not None:
+                footer_fields = app[FOOTER_FIELDS_KEY]
+            title = card_config.get("title", app[CARD_TITLE_KEY])
+            if not isinstance(title, str):
+                title = app[CARD_TITLE_KEY]
+            card = render_card(
+                sess,
+                footer_fields=footer_fields,
+                title=title,
+            )
+            asyncio.create_task(
+                _update_card_for_app(app, feishu_msg_id, card, bot_id)
+            )
 
 
 def _flush_controller_for_session(

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -2218,3 +2218,162 @@ async def test_session_key_explicit_empty_profile_uses_default_composite_key():
         data={"profile_id": ""},
     )
     assert _session_key(event) == "default:m"
+
+
+# --- Tests for _abandon_stale_sessions_for_chat (interrupt scenario, #92) ---
+
+
+async def test_interrupt_abandons_stale_session_via_session_creating_event(client):
+    """When a new session is created via SESSION_CREATING_EVENTS (e.g. answer.delta
+    after an interrupt with no message.started), the old active session for the
+    same chat+conversation should be marked completed and its card updated."""
+    test_client, feishu_client = client
+
+    # First turn: message.started + some streaming
+    msg1 = {"conversation_id": "conv-1", "message_id": "msg-turn-1"}
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg1))
+    await test_client.post(
+        "/events",
+        json=event_payload("answer.delta", 1, {"text": "正在回答第一个问题"}, **msg1),
+    )
+    await wait_for_card_update(feishu_client, "正在回答第一个问题")
+
+    # Interrupt: a new turn arrives via SESSION_CREATING_EVENTS (answer.delta with
+    # a different message_id but same conversation_id — simulates the gateway
+    # interrupt fallback path where event_message_id changes).
+    msg2 = {"conversation_id": "conv-1", "message_id": "msg-turn-2"}
+    resp = await test_client.post(
+        "/events",
+        json=event_payload("answer.delta", 0, {"text": "新的回答"}, **msg2),
+    )
+    assert resp.status == 200
+
+    # The old card should have been updated to completed state.
+    # Two cards were sent (one for each session).
+    assert len(feishu_client.sent) == 2
+
+    # The old card (feishu-message-1) should have a final update showing completed
+    updates_for_old = [
+        card for mid, card in feishu_client.updated if mid == "feishu-message-1"
+    ]
+    # At least 2 updates: the streaming delta + the abandon completion
+    assert len(updates_for_old) >= 2
+    # The last update should contain the completed marker (subtitle)
+    last_card = str(updates_for_old[-1])
+    assert "已完成" in last_card
+
+
+async def test_interrupt_abandons_stale_session_via_message_started(client):
+    """When a new message.started arrives with a different message_id but same
+    conversation, the old active session should be abandoned."""
+    test_client, feishu_client = client
+
+    msg1 = {"conversation_id": "conv-1", "message_id": "msg-first"}
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg1))
+    await test_client.post(
+        "/events",
+        json=event_payload("answer.delta", 1, {"text": "第一轮内容"}, **msg1),
+    )
+    await wait_for_card_update(feishu_client, "第一轮内容")
+
+    # New turn with different message_id, same conversation
+    msg2 = {"conversation_id": "conv-1", "message_id": "msg-second"}
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg2))
+
+    # Two cards sent (old + new)
+    assert len(feishu_client.sent) == 2
+
+    # Old card should have been updated with completed state
+    updates_for_old = [
+        card for mid, card in feishu_client.updated if mid == "feishu-message-1"
+    ]
+    assert len(updates_for_old) >= 2
+    assert "已完成" in str(updates_for_old[-1])
+
+
+async def test_interrupt_does_not_abandon_different_conversation(client):
+    """Sessions in different conversations (e.g. different topic group threads)
+    should NOT be abandoned when a new session is created."""
+    test_client, feishu_client = client
+
+    # Two different conversations in the same chat
+    msg1 = {"conversation_id": "thread-A", "message_id": "msg-thread-a"}
+    msg2 = {"conversation_id": "thread-B", "message_id": "msg-thread-b"}
+
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg1))
+    await test_client.post(
+        "/events",
+        json=event_payload("answer.delta", 1, {"text": "Thread A 内容"}, **msg1),
+    )
+    await wait_for_card_update(feishu_client, "Thread A 内容")
+    updates_before = len(feishu_client.updated)
+
+    # New session in a DIFFERENT conversation — should NOT abandon thread-A
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg2))
+
+    # Give any background tasks a chance to run
+    await asyncio.sleep(0.05)
+
+    # Old card (feishu-message-1) should NOT have gotten an abandon update
+    updates_after = feishu_client.updated[updates_before:]
+    old_card_updates = [card for mid, card in updates_after if mid == "feishu-message-1"]
+    assert len(old_card_updates) == 0, (
+        "Session in different conversation should not be abandoned"
+    )
+
+async def test_terminal_event_on_abandoned_session_returns_applied_true(client):
+    """When message.completed arrives for a session that was already abandoned
+    (status=completed), the sidecar should return applied=True so the gateway
+    hook suppresses the native plain-text delivery."""
+    test_client, feishu_client = client
+
+    msg1 = {"conversation_id": "conv-1", "message_id": "msg-original"}
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg1))
+    await test_client.post(
+        "/events",
+        json=event_payload("answer.delta", 1, {"text": "部分回答"}, **msg1),
+    )
+    await wait_for_card_update(feishu_client, "部分回答")
+
+    # Trigger abandon by creating a new session in the same conversation
+    msg2 = {"conversation_id": "conv-1", "message_id": "msg-followup"}
+    await test_client.post(
+        "/events",
+        json=event_payload("answer.delta", 0, {"text": "新回答"}, **msg2),
+    )
+
+    # Now send message.completed for the OLD session — should report applied=True
+    response = await test_client.post(
+        "/events",
+        json=event_payload("message.completed", 2, {"answer": "最终答案"}, **msg1),
+    )
+    result = await response.json()
+    assert result["ok"] is True
+    assert result["applied"] is True
+
+
+async def test_interrupt_abandon_does_not_affect_completed_sessions(client):
+    """Sessions that are already completed should not be re-abandoned or cause
+    extra card updates when a new session is created."""
+    test_client, feishu_client = client
+
+    msg1 = {"conversation_id": "conv-1", "message_id": "msg-done"}
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg1))
+    await test_client.post(
+        "/events",
+        json=event_payload("message.completed", 1, {"answer": "完成了"}, **msg1),
+    )
+    await wait_for_card_update(feishu_client, "完成了")
+    updates_after_complete = len(feishu_client.updated)
+
+    # New session in same conversation — should not touch the completed one
+    msg2 = {"conversation_id": "conv-1", "message_id": "msg-new-turn"}
+    await test_client.post("/events", json=event_payload("message.started", 0, **msg2))
+
+    # No extra card updates should happen for the old completed session
+    await asyncio.sleep(0.05)
+    new_updates = feishu_client.updated[updates_after_complete:]
+    for mid, _ in new_updates:
+        assert mid != "feishu-message-1", (
+            "Already-completed session should not get extra updates on abandon"
+        )


### PR DESCRIPTION
## Summary

Fixes #92.

When the Hermes gateway interrupts a running turn (user sends a new message mid-turn), no `message.completed` is sent for the interrupted turn. The old card stays stuck showing "⠴ 生成中" forever because its sidecar session never reaches terminal state.

## Root Cause

The gateway interrupt flow:
1. User message A → `message.started` → sidecar creates Card A
2. User sends message B → gateway interrupts agent
3. Gateway recursively calls `_run_agent(event_message_id=None)` for the follow-up
4. Follow-up streaming uses a new fallback message_id → sidecar creates Card B via `SESSION_CREATING_EVENTS`
5. Card B completes normally, **Card A never receives `message.completed`** → stuck

## Fix

Two changes in `server.py`:

### 1. `_abandon_stale_sessions_for_chat()`

When a new session is created (via `message.started` or `SESSION_CREATING_EVENTS`), check for existing active sessions with the same `chat_id + conversation_id + profile_id`. If found, mark them as "completed" and push a final card update.

Uses `conversation_id` matching to avoid falsely abandoning parallel sessions in topic groups (different threads have different `conversation_id`).

### 2. Return `applied: True` for terminal events on already-completed sessions

When `message.completed` arrives for a session already in "completed" state (abandoned by the fix above), return `{ok: true, applied: true}` so `should_suppress_native_response` correctly suppresses the native delivery — preventing duplicate plain-text messages.

## Testing

5 new integration tests added:
- `test_interrupt_abandons_stale_session_via_session_creating_event` — core interrupt scenario
- `test_interrupt_abandons_stale_session_via_message_started` — new turn with explicit message_id
- `test_interrupt_does_not_abandon_different_conversation` — topic group isolation
- `test_terminal_event_on_abandoned_session_returns_applied_true` — suppress correctness
- `test_interrupt_abandon_does_not_affect_completed_sessions` — no spurious updates

All 76 integration tests pass (71 existing + 5 new).

Verified end-to-end on a real Feishu DM deployment with interrupt mode enabled.
