### PR TITLE
fix(session): guard _prepare_completed_answer from archiving full answer as reasoning

### DIFF
--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -229,14 +229,28 @@ class CardSession:
             return final
 
         if self._answer_archive_index is not None:
+            stripped = _strip_preface_prefix(final, preface)
+            # Guard: if final merely extends preface by a tiny suffix (e.g.
+            # trailing punctuation), the preface IS the answer — don't
+            # archive it into reasoning.  (#96)
+            if final.startswith(preface) and (
+                stripped == final or len(stripped) <= max(20, len(final) // 5)
+            ):
+                self._answer_archive_index = None
+                return final
             self._archive_current_answer_to_reasoning()
-            return _strip_preface_prefix(final, preface)
+            return stripped
 
         if self._has_seen_tool_event and final.startswith(preface):
             stripped = _strip_preface_prefix(final, preface)
-            if stripped != final:
+            # Only archive the preface when the remaining stripped content is
+            # substantial — i.e. the preface was a short intro and the real
+            # answer follows.  If stripped is tiny relative to final, the
+            # "preface" IS the answer and should not be archived.  (#96)
+            if stripped != final and len(stripped) > max(20, len(final) // 5):
                 self._archive_current_answer_to_reasoning()
                 return stripped
+            return final
 
         if self._has_seen_tool_event:
             self._archive_current_answer_to_reasoning()

--- a/tests/unit/test_prepare_completed_answer_issue96.py
+++ b/tests/unit/test_prepare_completed_answer_issue96.py
@@ -1,0 +1,188 @@
+"""Tests for _prepare_completed_answer length guard — issue #96.
+
+When tools fire and the streamed answer_text is already the near-complete
+final answer, a minor trailing difference (extra period, whitespace) must
+NOT cause the full answer to be archived into the reasoning timeline.
+"""
+
+from hermes_feishu_card.events import SidecarEvent
+from hermes_feishu_card.session import CardSession
+
+
+def _event(name, sequence, data):
+    payload = {
+        "schema_version": "1",
+        "event": name,
+        "conversation_id": "chat-1",
+        "message_id": "msg-1",
+        "chat_id": "oc_abc",
+        "platform": "feishu",
+        "sequence": sequence,
+        "created_at": 1777017600.0 + sequence,
+        "data": data,
+    }
+    return SidecarEvent.from_dict(payload)
+
+
+def _session_with_tool_and_answer(answer_text: str) -> CardSession:
+    """Create a session that has seen a tool event and streamed answer_text."""
+    session = CardSession(conversation_id="chat-1", message_id="msg-1", chat_id="oc_abc")
+    # Stream some answer text
+    session.apply(_event("answer.delta", 1, {"text": answer_text}))
+    # Fire a tool event so _has_seen_tool_event is True
+    session.apply(_event("tool.updated", 2, {"tool_id": "t1", "name": "search", "status": "completed"}))
+    return session
+
+
+class TestBugScenarioTrailingPunctuation:
+    """#96: trailing punctuation causes incorrect archival."""
+
+    def test_trailing_period_does_not_archive(self):
+        """Full answer streamed, completed has same + trailing '。' → no archival."""
+        full_answer = "根据搜索结果，今天的天气是晴天，温度在25度左右，适合户外活动"
+        session = _session_with_tool_and_answer(full_answer)
+
+        # message.completed arrives with same text + trailing period
+        session.apply(_event("message.completed", 3, {"answer": full_answer + "。"}))
+
+        assert session.status == "completed"
+        # The answer should contain the full text, NOT be truncated to just "。"
+        assert len(session.answer_text) > 10
+        # The visible answer must still be the full answer (possibly with period)
+        assert full_answer in session.answer_text or session.answer_text == full_answer + "。"
+
+    def test_trailing_english_period_does_not_archive(self):
+        """Same but with English period."""
+        full_answer = "Based on the search results, the weather today is sunny with temperatures around 25C"
+        session = _session_with_tool_and_answer(full_answer)
+
+        session.apply(_event("message.completed", 3, {"answer": full_answer + "."}))
+
+        assert session.status == "completed"
+        assert len(session.answer_text) > 10
+
+
+class TestBugScenarioWhitespaceDifference:
+    """#96: minor whitespace/normalization difference causes incorrect archival."""
+
+    def test_trailing_whitespace_does_not_archive(self):
+        """Completed answer has trailing spaces → no archival."""
+        full_answer = "这是一个完整的回答，包含了所有需要的信息和详细的解释"
+        session = _session_with_tool_and_answer(full_answer)
+
+        session.apply(_event("message.completed", 3, {"answer": full_answer + "  "}))
+
+        assert session.status == "completed"
+        assert len(session.answer_text) > 10
+
+    def test_trailing_newline_does_not_archive(self):
+        """Completed answer has trailing newline → no archival."""
+        full_answer = "The complete answer with all details about the topic"
+        session = _session_with_tool_and_answer(full_answer)
+
+        session.apply(_event("message.completed", 3, {"answer": full_answer + "\n"}))
+
+        assert session.status == "completed"
+        assert len(session.answer_text) > 10
+
+
+class TestLegitimateArchival:
+    """Short preface before tool, long final after → should still archive."""
+
+    def test_short_preface_long_final_archives(self):
+        """'Let me check...' streamed before tool, then long final answer."""
+        preface = "Let me check"
+        long_answer = preface + " — here are the detailed results from my search that contain a lot of important information about the topic you asked about."
+        session = _session_with_tool_and_answer(preface)
+
+        session.apply(_event("message.completed", 3, {"answer": long_answer}))
+
+        assert session.status == "completed"
+        # The short preface should be archived; answer shows the long content
+        # after stripping
+        assert "Let me check" not in session.answer_text or len(session.answer_text) > len(preface) + 30
+
+    def test_chinese_preface_long_final_archives(self):
+        """Short Chinese preface, then long final."""
+        preface = "让我查一下"
+        # Make the remaining content substantial (>20 chars and >20% of final)
+        long_suffix = "，根据我的搜索结果，这个问题的答案是：人工智能在过去十年中取得了巨大进步，深度学习技术使得许多previously不可能的应用成为了现实。"
+        long_answer = preface + long_suffix
+        session = _session_with_tool_and_answer(preface)
+
+        session.apply(_event("message.completed", 3, {"answer": long_answer}))
+
+        assert session.status == "completed"
+        # The answer should be the stripped version (without the preface)
+        assert session.answer_text != preface
+
+
+class TestEqualPrefaceAndFinal:
+    """No archival needed when preface equals final."""
+
+    def test_equal_text_no_archival(self):
+        """When streamed answer == completed answer, no archival."""
+        answer = "完全相同的回答内容不需要任何处理"
+        session = _session_with_tool_and_answer(answer)
+
+        session.apply(_event("message.completed", 3, {"answer": answer}))
+
+        assert session.status == "completed"
+        assert session.answer_text == answer
+
+
+class TestNoToolEvents:
+    """Without tool events, should never archive via startswith path."""
+
+    def test_no_tool_no_archive(self):
+        """No tools fired — startswith archival path should not trigger."""
+        session = CardSession(conversation_id="chat-1", message_id="msg-1", chat_id="oc_abc")
+        full_answer = "这是一个没有工具调用的回答"
+        session.apply(_event("answer.delta", 1, {"text": full_answer}))
+        # No tool event!
+
+        session.apply(_event("message.completed", 2, {"answer": full_answer + "。"}))
+
+        assert session.status == "completed"
+        # Answer should be fully preserved
+        assert len(session.answer_text) > 5
+
+
+class TestThresholdBoundary:
+    """Edge case: stripped exactly at threshold boundary."""
+
+    def test_stripped_at_exact_threshold_does_not_archive(self):
+        """len(stripped) == max(20, len(final)//5) → should NOT archive (need >)."""
+        # We need: len(stripped) == max(20, len(final) // 5)
+        # Let's make final long enough that len(final)//5 > 20
+        # If final is 125 chars, then len(final)//5 = 25
+        # So we need stripped to be exactly 25 chars
+        # preface = final[:-25], stripped = final[-25:]  (25 chars)
+        stripped_part = "a" * 25  # exactly 25 chars
+        preface_part = "b" * 100  # 100 chars → final = 125 chars, final//5 = 25
+        final_text = preface_part + stripped_part  # 125 chars total
+
+        session = _session_with_tool_and_answer(preface_part)
+
+        session.apply(_event("message.completed", 3, {"answer": final_text}))
+
+        assert session.status == "completed"
+        # At exactly threshold (25 == 25), condition is NOT satisfied (need >)
+        # so it should NOT archive via this path — falls through to the
+        # unconditional tool archive below
+        # The key point: it doesn't incorrectly strip to just the 25-char suffix
+
+    def test_stripped_one_above_threshold_archives(self):
+        """len(stripped) == max(20, len(final)//5) + 1 → should archive."""
+        # final = 125 chars, threshold = 25, stripped = 26 chars
+        stripped_part = "a" * 26  # 26 chars — just above threshold
+        preface_part = "b" * 99  # 99 chars → final = 125, final//5 = 25
+        final_text = preface_part + stripped_part
+
+        session = _session_with_tool_and_answer(preface_part)
+
+        session.apply(_event("message.completed", 3, {"answer": final_text}))
+
+        assert session.status == "completed"
+        # With 26 > 25, archival should trigger and answer becomes stripped_part
+        assert session.answer_text == stripped_part


### PR DESCRIPTION
## Summary

Fixes #96.

When a session has tool calls and the streamed `answer_text` already contains the near-complete final answer, `_prepare_completed_answer()` incorrectly archives the entire answer body into the reasoning timeline. This leaves only a few trailing characters (e.g. "。" or "康。") visible as the card body text, while the full correct answer is hidden in the collapsed thinking panel.

## Root Cause

The condition at line 235-239 checks `final.startswith(preface)` and archives `preface` whenever `stripped != final`. But when the answer was fully streamed via `answer.delta` events and `message.completed` arrives with the same text plus minor trailing differences (extra period, whitespace normalization), this condition triggers incorrectly — the "preface" IS the answer, not a short thinking-aloud prefix.

## Fix

Add a length guard: only archive when `stripped` (the remaining content after removing preface) is substantial — at least 20 chars AND more than 20% of the final answer length. This preserves the legitimate use case (short "Let me check..." prefix archived, long real answer shown) while preventing the bug (full answer incorrectly treated as prefix).

## Test Plan

```bash
python -m pytest tests/ -q
```

Added test cases covering:
- Bug reproduction: trailing punctuation/whitespace causes incorrect archival
- Legitimate archival: short preface + substantial final content
- Edge cases: equal text, no tool events, boundary thresholds