### PR TITLE
docs: finalize v3.9.1 release state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 
 详细路线见 [docs/superpowers/specs/2026-06-30-v3-8-design.md](docs/superpowers/specs/2026-06-30-v3-8-design.md) 和 [docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md](docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md)。
 
-### V3.9.1：可靠性热修（待发布）
+### V3.9.1：可靠性热修（已发布）
 
 - [x] Issue #96 / PR #97 / @colinaaa：完成事件携带有效 suffix 时保留完整最终答案，同时保持原生重复 reply suppression。
 - [x] Issue #92 / PR #93 / @colinaaa：打断旧任务时先 drain 更新队列，再串行写入 abandoned 终态，迟到 PATCH 不再覆盖终态。
@@ -16,7 +16,8 @@
 - [x] source-stripped Hermes 的诊断文案明确显示 metadata 缺失，不伪造版本号。
 - [x] 普通流式卡 footer/layout 保持不变。
 - [x] Python 3.9 / 3.12 release gate 均为 `1198 passed, 3 skipped`，`git diff --check` 通过。
-- [ ] 完成 tag、GitHub Release、资产校验和 issue/PR 回复。
+- [x] v3.9.1 tag、GitHub Release 与四个 release assets 按发布流程完成。
+- [ ] 完成相关 issue/PR 的证据化回复与状态收口。
 
 ### V3.9.0：运维与可靠性基础（已完成自动化与文档）
 

--- a/docs/release-notes-v3.9.1.md
+++ b/docs/release-notes-v3.9.1.md
@@ -1,5 +1,7 @@
 # Hermes Feishu Streaming Card V3.9.1
 
+Released on 2026-07-11. The `v3.9.1` tag triggers the release-assets workflow for the four packages listed below.
+
 V3.9.1 is a focused reliability hotfix. It closes the regressions reported in #82, #92, and #96, incorporates the useful parts of PR #93, PR #97, PR #98, and PR #52, and keeps the established streaming-card footer/layout unchanged.
 
 ## Fixed

--- a/docs/release-readiness.en.md
+++ b/docs/release-readiness.en.md
@@ -2,7 +2,7 @@
 
 [中文](release-readiness.md) | [English](release-readiness.en.md)
 
-Current release candidate: `3.9.1`. It builds on the V3.9.0 operations foundation and fixes completed-answer truncation, interrupted terminal-card ordering, model-picker callback timeouts, loopback proxy interference, and verified marker-only installer damage. V3.9.0 was released on 2026-07-11 and built on the sidecar-only runtime, V3.8.2 timeline, group diagnostics, topic/cron routing, and WebSocket interactions. Normal streaming-card footer/layout is unchanged.
+Current package version: `3.9.1`; it was released on 2026-07-11. It builds on the V3.9.0 operations foundation and fixes completed-answer truncation, interrupted terminal-card ordering, model-picker callback timeouts, loopback proxy interference, and verified marker-only installer damage. V3.9.0 was released on 2026-07-11 and built on the sidecar-only runtime, V3.8.2 timeline, group diagnostics, topic/cron routing, and WebSocket interactions. Normal streaming-card footer/layout is unchanged.
 
 ## Ready
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -2,7 +2,7 @@
 
 [中文](release-readiness.md) | [English](release-readiness.en.md)
 
-当前候选包版本为 `3.9.1`。它在 V3.9.0 运维与可靠性基础上修复完成答案截断、打断任务终态竞争、模型选择 callback 超时、loopback 代理干扰和可验证的 marker-only 安装损坏。V3.9.0 已于 2026-07-11 发布，并建立在 sidecar-only、V3.8.2 timeline、群聊诊断、话题/cron 路由和 WebSocket 交互基础上。普通流式卡的 footer/layout 不变。
+当前包版本为 `3.9.1`，已于 2026-07-11 发布。它在 V3.9.0 运维与可靠性基础上修复完成答案截断、打断任务终态竞争、模型选择 callback 超时、loopback 代理干扰和可验证的 marker-only 安装损坏。V3.9.0 同样已于 2026-07-11 发布，并建立在 sidecar-only、V3.8.2 timeline、群聊诊断、话题/cron 路由和 WebSocket 交互基础上。普通流式卡的 footer/layout 不变。
 
 ## 已具备
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1104,6 +1104,11 @@ def test_v391_documents_reliability_hotfix_and_contributors():
     assert "source-stripped metadata" in release_notes
     assert "callback" in release_notes.lower()
     assert "footer/layout" in release_notes
+    assert "Released on 2026-07-11" in release_notes
+    assert "release-assets workflow" in release_notes
+    assert "（已发布）" in todo
+    assert "已于 2026-07-11 发布" in read_doc("docs/release-readiness.md")
+    assert "was released on 2026-07-11" in read_doc("docs/release-readiness.en.md")
 
     assert "### V3.9.1：可靠性热修" in todo
     assert "v3.9.1" in readme


### PR DESCRIPTION
## Summary
- mark v3.9.1 as released in the tagged documentation
- record the release-assets workflow and four packages
- keep issue/PR response closure tracked separately

## Validation
- docs/package metadata: `39 passed`
- `git diff --check`