### PR TITLE
docs: finalize v3.10.0 release state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 
 详细路线见 [docs/superpowers/specs/2026-06-30-v3-8-design.md](docs/superpowers/specs/2026-06-30-v3-8-design.md) 和 [docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md](docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md)。
 
-### V3.10.0：原生会话恢复与轻量视觉增强（待发布）
+### V3.10.0：原生会话恢复与轻量视觉增强（已发布）
 
 - [x] Issue #94 / @colinaaa：裸 `/resume` 使用原生 `select_static` 会话选择器，带参数命令保持 Hermes 原行为。
 - [x] 选择回调即时 ACK，后台复用 original Hermes resume handler；权限、continuation、agent release 和 override cleanup 不重复实现。
@@ -15,7 +15,7 @@
 - [x] V3.9.1 相关 issue/PR 与 2026-07-11 旧队列已完成证据化回复和关闭，仅 #94 留待 V3.10.0 发布收口。
 - [x] Python 3.9 / 3.12 release gate 均为 `1216 passed, 3 skipped`，`git diff --check` 通过。
 - [x] 真实 Feishu 私聊、群聊发起者和 topic 原线程 smoke 通过；换操作者拒绝因测试群仅一位真人，保留自动化回归证据。
-- [ ] 完成 tag、Release 与资产验证。
+- [x] `v3.10.0` tag、GitHub Release 与 macOS/Linux/Windows/checksums 四个资产验证通过。
 
 ### V3.9.1：可靠性热修（已发布）
 

--- a/docs/release-notes-v3.10.0.md
+++ b/docs/release-notes-v3.10.0.md
@@ -1,5 +1,7 @@
 # Hermes Feishu Streaming Card V3.10.0
 
+Released on 2026-07-11. The `release-assets` workflow completed successfully and published all four platform/checksum assets.
+
 V3.10.0 adds one focused interaction improvement and one restrained visual improvement: bare `/resume` becomes a native Feishu/Lark picker, and recognized model names gain sanitized semantic color in the existing footer. The normal streaming-card footer/layout and element order remain unchanged.
 
 ## Native `/resume` Picker (#94)

--- a/docs/release-readiness.en.md
+++ b/docs/release-readiness.en.md
@@ -103,6 +103,7 @@ Acceptance also exposed an upstream Hermes `cron run` status-reporting bug: a su
 - Python 3.9 / 3.12 full automation: **passed (`1216 passed, 3 skipped`)**.
 - Real Feishu: private chat, group initiator, topic same-thread update, and footer passed; changed-operator rejection is covered by automation.
 - Verify macOS, Linux, Windows, and checksums assets after tagging.
+- `v3.10.0`: **released on 2026-07-11** with all four assets verified.
 
 The `v3.9.0` release-assets workflow publishes four assets: the macOS tarball, Linux tarball, Windows zip, and checksums file: `hermes-feishu-card-v3.9.0-macos.tar.gz`, `hermes-feishu-card-v3.9.0-linux.tar.gz`, `hermes-feishu-card-v3.9.0-windows.zip`, and `hermes-feishu-card-v3.9.0-checksums.txt`.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -103,6 +103,7 @@ python3 -m hermes_feishu_card.cli restore --hermes-dir ~/.hermes/hermes-agent --
 - Python 3.9 / 3.12 全量自动化：**已通过（`1216 passed, 3 skipped`）**。
 - 真实 Feishu：私聊、群聊发起者、topic 原线程更新和 footer 已通过；换人拒绝由自动化覆盖。
 - tag 后验证 macOS、Linux、Windows 与 checksums 四个 assets。
+- `v3.10.0`：**已发布（2026-07-11）**，四个 assets 验证通过。
 
 `v3.9.0` tag 的 release-assets workflow 会发布 4 个 assets：macOS tarball、Linux tarball、Windows zip 和 checksums 文件，分别为 `hermes-feishu-card-v3.9.0-macos.tar.gz`、`hermes-feishu-card-v3.9.0-linux.tar.gz`、`hermes-feishu-card-v3.9.0-windows.zip`、`hermes-feishu-card-v3.9.0-checksums.txt`。
 


### PR DESCRIPTION
## Summary
- mark v3.10.0 as released
- record successful release-assets workflow and four verified assets
- preserve real Feishu acceptance boundaries and contributor credits

## Validation
- `40 passed` docs/package metadata
- `git diff --check`