### PR TITLE
docs: finalize v4.0.0 release state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 
 详细路线见 [docs/superpowers/specs/2026-06-30-v3-8-design.md](docs/superpowers/specs/2026-06-30-v3-8-design.md) 和 [docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md](docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md)。
 
-### V4.0.0：实时双轨 Agent 卡片（候选）
+### V4.0.0：实时双轨 Agent 卡片（已发布）
 
 - [x] 运行态 Header title 保留用户配置名，subtitle 将 Hermes 工具名与最新非空 `tool.updated.detail` 整理为确定性动作摘要，工具间隙保留上一条。
 - [x] 正文显示公开 `thinking.delta` 阶段输出，`answer.delta` 开始后主回答优先。
@@ -14,7 +14,7 @@
 - [x] 运行、等待、失败 Footer 只显示状态，完成态显示最终统计。
 - [x] preview 单行化、长度限制和敏感参数脱敏；无 preview 时兼容旧布局。
 - [x] 真实飞书私聊/群聊、四状态截图与本地发布包 smoke 通过；`/model` Provider、返回、切换和同卡回写通过。
-- [ ] tag 后验证 V4.0.0 macOS、Linux、Windows 与 checksums 四个 Release assets。
+- [x] `v4.0.0` tag、GitHub Release、macOS/Linux/Windows/checksums 四个 assets 与公共 tag 安装验证通过。
 
 ### V3.10.0：原生会话恢复与轻量视觉增强（已发布）
 

--- a/docs/release-readiness.en.md
+++ b/docs/release-readiness.en.md
@@ -103,7 +103,7 @@ Acceptance also exposed an upstream Hermes `cron run` status-reporting bug: a su
 - Focused interaction/installer/render matrix: **passed (`416 passed`)**.
 - Python 3.9 / 3.12 full automation: **passed (`1216 passed, 3 skipped`)**.
 - Real Feishu: private chat, group initiator, topic same-thread update, and footer passed; changed-operator rejection is covered by automation.
-- Verify macOS, Linux, Windows, and checksums assets after tagging.
+- `v4.0.0`: **released on 2026-07-12**. The release-assets workflow succeeded; the macOS, Linux, Windows, and checksums assets were complete and checksum-verified; installation from the public tag reported version `4.0.0` and the CLI started successfully.
 - `v3.10.0`: **released on 2026-07-11** with all four assets verified.
 
 ## V4.0.0 Release Gates

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -103,7 +103,7 @@ python3 -m hermes_feishu_card.cli restore --hermes-dir ~/.hermes/hermes-agent --
 - 聚焦 interaction/installer/render 矩阵：**已通过（`416 passed`）**。
 - Python 3.9 / 3.12 全量自动化：**已通过（`1216 passed, 3 skipped`）**。
 - 真实 Feishu：私聊、群聊发起者、topic 原线程更新和 footer 已通过；换人拒绝由自动化覆盖。
-- tag 后验证 macOS、Linux、Windows 与 checksums 四个 assets。
+- `v4.0.0`：**已发布（2026-07-12）**。release-assets workflow 成功；macOS、Linux、Windows 与 checksums 四个 assets 完整且 checksum 通过；从公开 tag 安装后版本为 `4.0.0`，CLI 可启动。
 - `v3.10.0`：**已发布（2026-07-11）**，四个 assets 验证通过。
 
 ## V4.0.0 发布门禁


### PR DESCRIPTION
## Summary

- mark V4.0.0 as released in the roadmap
- record successful release-assets workflow and checksum verification
- record clean public-tag installation and CLI smoke

## Verification

- `46 passed`
- `git diff --check`
- release: https://github.com/baileyh8/hermes-feishu-streaming-card/releases/tag/v4.0.0
