### PR TITLE
fix: keep Hermes runtime package version in sync

### DIFF
--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import yaml
 
+from hermes_feishu_card import __version__ as PACKAGE_VERSION
 from hermes_feishu_card.config import load_config
 from hermes_feishu_card.bots import BotRegistry, RoutingContext
 from hermes_feishu_card.diagnostics import (
@@ -995,8 +996,13 @@ def _detect_hermes_runtime_python(hermes_root: Path | str) -> Path | None:
 
 def _check_runtime_hook_import(runtime_python: Path) -> dict[str, Any]:
     code = (
-        "import hermes_feishu_card.hook_runtime as hook_runtime; "
-        "print(getattr(hook_runtime, '__file__', ''))"
+        "import json; "
+        "import hermes_feishu_card as package; "
+        "import hermes_feishu_card.hook_runtime; "
+        "print(json.dumps({"
+        "'version': getattr(package, '__version__', ''), "
+        "'location': getattr(package, '__file__', '')"
+        "}))"
     )
     cwd = _hermes_runtime_cwd(runtime_python)
     try:
@@ -1026,12 +1032,24 @@ def _check_runtime_hook_import(runtime_python: Path) -> dict[str, Any]:
             ),
         }
     if result.returncode == 0:
-        location = result.stdout.strip()
+        try:
+            metadata = json.loads(result.stdout.strip().splitlines()[-1])
+        except (IndexError, json.JSONDecodeError):
+            return {
+                "checked": True,
+                "status": "failed",
+                "python": str(runtime_python),
+                "message": "Hermes runtime returned invalid package metadata.",
+            }
+        version = str(metadata.get("version", "")).strip()
+        location = str(metadata.get("location", "")).strip()
         suffix = f" from {location}" if location else ""
         return {
             "checked": True,
             "status": "ok",
             "python": str(runtime_python),
+            "version": version,
+            "location": location,
             "message": f"Hermes runtime can import hook_runtime{suffix}.",
         }
     detail = _summarize_process_output(result)
@@ -1057,9 +1075,11 @@ def _ensure_hermes_runtime_package(detection: HermesDetection) -> None:
         print("runtime package: skipped (Hermes venv Python not found)")
         return
     report = _check_runtime_hook_import(runtime_python)
-    if report["status"] == "ok":
-        print(f"runtime package: import ok ({runtime_python})")
+    if report["status"] == "ok" and report.get("version") == PACKAGE_VERSION:
+        print(f"runtime package: {PACKAGE_VERSION} import ok ({runtime_python})")
         return
+
+    previous_version = report.get("version") if report["status"] == "ok" else None
 
     spec = _runtime_install_spec()
     if not spec:
@@ -1088,7 +1108,20 @@ def _ensure_hermes_runtime_package(detection: HermesDetection) -> None:
     report = _check_runtime_hook_import(runtime_python)
     if report["status"] != "ok":
         raise ValueError(report["message"])
-    print(f"runtime package: installed into {runtime_python}")
+    if report.get("version") != PACKAGE_VERSION:
+        actual = report.get("version") or "unknown"
+        raise ValueError(
+            "Hermes runtime package version mismatch after install: "
+            f"expected {PACKAGE_VERSION}, got {actual} from "
+            f"{report.get('location') or runtime_python}."
+        )
+    if previous_version:
+        print(
+            f"runtime package: upgraded {previous_version} -> {PACKAGE_VERSION} "
+            f"in {runtime_python}"
+        )
+    else:
+        print(f"runtime package: installed into {runtime_python}")
 
 
 def _run_runtime_pip(

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_feishu_card import __version__ as PACKAGE_VERSION
 from hermes_feishu_card import cli
 from hermes_feishu_card.install import patcher
 
@@ -109,7 +110,7 @@ set -euo pipefail
 printf '%s\\n' "$*" >> {str(runtime_log)!r}
 if [ "$1" = "-c" ]; then
   if [ -f {str(marker)!r} ]; then
-    echo "hook-runtime-ok"
+    printf '%s\\n' '{{"version":"{PACKAGE_VERSION}","location":"/runtime/hermes_feishu_card/__init__.py"}}'
     exit 0
   fi
   echo "No module named hermes_feishu_card" >&2
@@ -138,6 +139,84 @@ exit 0
     assert "install ok" in result.stdout.lower()
 
 
+def test_install_upgrades_importable_outdated_runtime_package(tmp_path, monkeypatch):
+    hermes_dir = copy_hermes(tmp_path)
+    venv_bin = hermes_dir / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    runtime_python = venv_bin / "python"
+    upgraded = tmp_path / "runtime-upgraded"
+    runtime_log = tmp_path / "runtime-python.log"
+    runtime_python.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> {str(runtime_log)!r}
+if [ "$1" = "-c" ]; then
+  if [ -f {str(upgraded)!r} ]; then
+    printf '%s\\n' '{{"version":"{PACKAGE_VERSION}","location":"/runtime/hermes_feishu_card/__init__.py"}}'
+  else
+    printf '%s\\n' '{{"version":"3.6.3","location":"/runtime/hermes_feishu_card/__init__.py"}}'
+  fi
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  touch {str(upgraded)!r}
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    runtime_python.chmod(0o755)
+    monkeypatch.setenv(
+        "HFC_INSTALL_SPEC", f"git+https://example.test/pkg.git@v{PACKAGE_VERSION}"
+    )
+
+    result = run_cli("install", "--hermes-dir", str(hermes_dir), "--yes")
+
+    assert result.returncode == 0, result.stderr
+    assert upgraded.exists()
+    assert (
+        f"-m pip install --upgrade git+https://example.test/pkg.git@v{PACKAGE_VERSION}"
+        in runtime_log.read_text(encoding="utf-8")
+    )
+    assert f"runtime package: upgraded 3.6.3 -> {PACKAGE_VERSION}" in result.stdout
+
+
+def test_install_skips_matching_runtime_package(tmp_path, monkeypatch):
+    hermes_dir = copy_hermes(tmp_path)
+    venv_bin = hermes_dir / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    runtime_python = venv_bin / "python"
+    runtime_log = tmp_path / "runtime-python.log"
+    runtime_python.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> {str(runtime_log)!r}
+if [ "$1" = "-c" ]; then
+  printf '%s\\n' '{{"version":"{PACKAGE_VERSION}","location":"/runtime/hermes_feishu_card/__init__.py"}}'
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  echo "unexpected install" >&2
+  exit 90
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    runtime_python.chmod(0o755)
+    monkeypatch.delenv("HFC_INSTALL_SPEC", raising=False)
+
+    result = run_cli("install", "--hermes-dir", str(hermes_dir), "--yes")
+
+    assert result.returncode == 0, result.stderr
+    assert "-m pip install" not in runtime_log.read_text(encoding="utf-8")
+    assert f"runtime package: {PACKAGE_VERSION} import ok" in result.stdout
+
+
 def test_install_does_not_accept_project_cwd_runtime_import_false_positive(
     tmp_path, monkeypatch
 ):
@@ -153,7 +232,7 @@ set -euo pipefail
 printf 'cwd=%s args=%s\\n' "$PWD" "$*" >> {str(runtime_log)!r}
 if [ "$1" = "-c" ]; then
   if [ -f {str(marker)!r} ]; then
-    echo "hook-runtime-ok"
+    printf '%s\\n' '{{"version":"{PACKAGE_VERSION}","location":"/runtime/hermes_feishu_card/__init__.py"}}'
     exit 0
   fi
   if [ "$PWD" != {str(hermes_dir)!r} ]; then


### PR DESCRIPTION
## Summary
- inspect the installed package version inside the Hermes Gateway venv
- upgrade an importable but outdated runtime package instead of treating import success as sufficient
- verify the runtime version and module location again after installation
- keep matching-version installs idempotent

## Tests
- `.venv/bin/python -m pytest tests/integration/test_cli_install.py tests/unit/test_patcher.py -q` (139 passed)
- `.venv/bin/python -m pytest -q` (1277 passed, 3 skipped)
- `git diff --check`

Addresses #115.