### PR TITLE
Fix background notifications in Feishu streaming cards

### DIFF
--- a/docs/wiki/event-flow.md
+++ b/docs/wiki/event-flow.md
@@ -107,13 +107,17 @@ Hermes 原生运行提示会被归一为 `system.notice`：
 - skill loading
 - self-improvement review
 - context compression
+- background process running / finished output
+- background task complete / failed output
 
 处理规则：
 
 1. 如果当前 session 可用，notice 进入辅助 timeline。
 2. 如果没有当前 session，发送独立小卡片。
-3. 已识别 notice 如果卡片投递超时，也不再退回原生灰色文本。
-4. 未识别 notice 保持 Hermes 原生路径，避免吞掉重要未知提示。
+3. 同一 background process 使用稳定的 `notice_id` 和独立 message id；running 更新与 finished 终态复用同一张卡。exit code `0` 显示成功，非零显示失败，未知 exit code 显示警告。
+4. Gateway 启动时会在 recovered watcher drain 前安装 adapter wrapper；contextless / recovered watcher 优先沿用 Hermes `metadata.thread_id`，避免独立通知掉出原 topic。
+5. 已识别 notice 如果卡片投递超时，也不再退回原生灰色文本。
+6. 只有严格匹配 Hermes 固定 envelope 和 production process/task id 的后台通知才会被接管；未知或不完整文本保持 Hermes 原生路径，避免吞掉普通回复。
 
 ## 独立 slash command 卡片
 

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -46,6 +46,27 @@ MEDIA_RE = re.compile(r"MEDIA:([^\s\]]+)")
 LOCAL_FILE_RE = re.compile(
     r"(?<![:\w/])(/[^\s`]+\.(?:png|jpg|jpeg|webp|gif|pdf|txt|md|csv|xlsx|docx|mp3|wav|ogg|mp4|mov|webm))"
 )
+BACKGROUND_PROCESS_FINISHED_RE = re.compile(
+    r"\A\[Background process "
+    r"(?P<process_id>proc_[0-9a-f]{12}) "
+    r"finished with exit code (?P<exit_code>-?\d+|None)~ "
+    r"Here's the final output:\n[\s\S]*\]\Z"
+)
+BACKGROUND_PROCESS_RUNNING_RE = re.compile(
+    r"\A\[Background process "
+    r"(?P<process_id>proc_[0-9a-f]{12}) "
+    r"is still running~ New output:\n[\s\S]*\]\Z"
+)
+BACKGROUND_TASK_COMPLETED_RE = re.compile(
+    r"\A✅ Background task complete\n"
+    r'Prompt: "(?:[\s\S]{60}\.\.\.|[\s\S]{0,60})"\n\n'
+    r"[\s\S]*\Z"
+)
+BACKGROUND_TASK_FAILED_RE = re.compile(
+    r"\A❌ Background task "
+    r"(?P<task_id>bg_\d{6}_[0-9a-f]{6}) "
+    r"failed:(?:[ \t\r\n][\s\S]*)?\Z"
+)
 ATTACHMENT_TRAILING_PUNCTUATION = ",.;:)]}，。；：）】}"
 NATIVE_DELIVERY_MARKERS = ("[[as_document]]", "[[audio_as_voice]]")
 NATIVE_DELIVERY_ATTACHMENT_FIELDS = (
@@ -1811,6 +1832,12 @@ def _metadata_reply_to(metadata: dict[str, Any] | None) -> str:
     ).strip()
 
 
+def _metadata_thread_id(metadata: dict[str, Any] | None) -> str:
+    if not isinstance(metadata, dict):
+        return ""
+    return str(metadata.get("thread_id") or "").strip()
+
+
 def _send_result(success: bool, message_id: str | None = None, error: str | None = None):
     return SimpleNamespace(success=success, message_id=message_id, error=error)
 
@@ -2124,10 +2151,14 @@ def _hfc_notice_context_from_source(
     }
 
 
-def _hfc_classify_system_notice(content: Any) -> dict[str, str] | None:
-    text = str(content or "").strip()
-    if not text:
+def _hfc_classify_system_notice(content: Any) -> dict[str, Any] | None:
+    raw_text = str(content or "")
+    if not raw_text.strip():
         return None
+    background_notice = _hfc_classify_background_notice(raw_text)
+    if background_notice is not None:
+        return background_notice
+    text = raw_text.strip()
     lowered = text.lower()
     if text.startswith("⏳") or lowered.startswith("working ") or "working —" in lowered:
         return {
@@ -2170,6 +2201,61 @@ def _hfc_classify_system_notice(content: Any) -> dict[str, str] | None:
             "level": "info",
             "notice_kind": "compression",
             "notice_id": _hfc_content_notice_id("compression", text),
+        }
+    return None
+
+
+def _hfc_classify_background_notice(text: str) -> dict[str, Any] | None:
+    process_finished = BACKGROUND_PROCESS_FINISHED_RE.fullmatch(text)
+    if process_finished is not None:
+        process_id = process_finished.group("process_id")
+        exit_code_text = process_finished.group("exit_code")
+        if exit_code_text == "0":
+            title = "后台进程已完成"
+            level = "success"
+        elif exit_code_text == "None":
+            title = "后台进程已结束"
+            level = "warning"
+        else:
+            title = "后台进程失败"
+            level = "error"
+        return {
+            "title": title,
+            "level": level,
+            "notice_kind": "background-process",
+            "notice_id": f"background-process:{process_id}",
+            "notice_terminal": True,
+        }
+
+    process_running = BACKGROUND_PROCESS_RUNNING_RE.fullmatch(text)
+    if process_running is not None:
+        process_id = process_running.group("process_id")
+        return {
+            "title": "后台进程运行中",
+            "level": "info",
+            "notice_kind": "background-process",
+            "notice_id": f"background-process:{process_id}",
+            "notice_terminal": False,
+        }
+
+    if BACKGROUND_TASK_COMPLETED_RE.fullmatch(text) is not None:
+        return {
+            "title": "后台任务已完成",
+            "level": "success",
+            "notice_kind": "background-task",
+            "notice_id": _hfc_content_notice_id("background-task-completed", text),
+            "notice_terminal": True,
+        }
+
+    task_failed = BACKGROUND_TASK_FAILED_RE.fullmatch(text)
+    if task_failed is not None:
+        task_id = task_failed.group("task_id")
+        return {
+            "title": "后台任务失败",
+            "level": "error",
+            "notice_kind": "background-task",
+            "notice_id": f"background-task:{task_id}",
+            "notice_terminal": True,
         }
     return None
 
@@ -2257,12 +2343,18 @@ def _hfc_notice_post_applied(result: Any) -> bool:
 def _hfc_independent_notice_message_id(
     chat_id: str,
     content: str,
-    notice: dict[str, str],
+    notice: dict[str, Any],
 ) -> str:
+    notice_id = str(notice.get("notice_id") or "").strip()
+    if notice.get("notice_kind") == "background-process" and notice_id:
+        raw = f"{chat_id}:{notice_id}".encode("utf-8")
+        return "notice_" + sha256(raw).hexdigest()[:16]
+    if notice_id.startswith("background-task-completed:"):
+        return "notice_" + secrets.token_hex(8)
     bucket = int(time.time() // 300)
     raw = (
         f"{chat_id}:"
-        f"{notice.get('notice_id', '')}:"
+        f"{notice_id}:"
         f"{content}:"
         f"{bucket}"
     ).encode("utf-8")
@@ -2276,13 +2368,17 @@ def _hfc_build_system_notice_payload(
     reply_to: str | None,
     metadata: dict[str, Any] | None,
     context: dict[str, str],
-    notice: dict[str, str],
+    notice: dict[str, Any],
     notice_scope: str,
     message_id: str,
 ) -> dict[str, Any]:
     reply_id = str(reply_to or "").strip() or _metadata_reply_to(metadata)
-    conversation_id = str(context.get("conversation_id") or chat_id).strip() or chat_id
-    thread_id = str(context.get("thread_id") or "").strip()
+    thread_id = str(
+        context.get("thread_id") or _metadata_thread_id(metadata) or ""
+    ).strip()
+    conversation_id = str(
+        context.get("conversation_id") or thread_id or chat_id
+    ).strip() or chat_id
     source = SimpleNamespace(platform="feishu", chat_id=chat_id, thread_id=thread_id)
     local_vars: dict[str, Any] = {
         "source": source,
@@ -2297,6 +2393,8 @@ def _hfc_build_system_notice_payload(
         "_hfc_notice_scope": notice_scope,
         "delivery_kind": "notice" if notice_scope == "independent" else "chat",
     }
+    if "notice_terminal" in notice:
+        local_vars["_hfc_notice_terminal"] = bool(notice["notice_terminal"])
     if reply_id:
         local_vars["reply_to_message_id"] = reply_id
     payload = build_event("system.notice", local_vars)
@@ -4893,6 +4991,12 @@ def _event_data(
                 "notice_scope": notice_scope,
             }
         )
+        notice_terminal = local_vars.get(
+            "_hfc_notice_terminal",
+            local_vars.get("notice_terminal"),
+        )
+        if isinstance(notice_terminal, bool):
+            data["notice_terminal"] = notice_terminal
         delivery_kind = _first_string(local_vars, ("delivery_kind",))
         if delivery_kind:
             data["delivery_kind"] = delivery_kind

--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -23,6 +23,10 @@ SLASH_CONFIRM_PATCH_BEGIN = "# HERMES_FEISHU_CARD_SLASH_CONFIRM_PATCH_BEGIN"
 SLASH_CONFIRM_PATCH_END = "# HERMES_FEISHU_CARD_SLASH_CONFIRM_PATCH_END"
 COMMAND_CARD_PATCH_BEGIN = "# HERMES_FEISHU_CARD_COMMAND_CARD_PATCH_BEGIN"
 COMMAND_CARD_PATCH_END = "# HERMES_FEISHU_CARD_COMMAND_CARD_PATCH_END"
+COMMAND_CARD_STARTUP_PATCH_BEGIN = (
+    "# HERMES_FEISHU_CARD_COMMAND_CARD_STARTUP_PATCH_BEGIN"
+)
+COMMAND_CARD_STARTUP_PATCH_END = "# HERMES_FEISHU_CARD_COMMAND_CARD_STARTUP_PATCH_END"
 PLATFORM_NOTICE_PATCH_BEGIN = "# HERMES_FEISHU_CARD_PLATFORM_NOTICE_PATCH_BEGIN"
 PLATFORM_NOTICE_PATCH_END = "# HERMES_FEISHU_CARD_PLATFORM_NOTICE_PATCH_END"
 HFC_COMMAND_PATCH_BEGIN = "# HERMES_FEISHU_CARD_HFC_COMMAND_PATCH_BEGIN"
@@ -43,6 +47,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
     content = _apply_queued_complete_patch(content)
     if strategy == "gateway_run_013_plus":
         content = _apply_cron_patch(content)
+        content = _apply_command_card_startup_patch(content)
         content = _apply_command_card_adapter_patch(content)
         content = _apply_hfc_command_patch(content)
         content = _apply_platform_notice_patch(content)
@@ -282,6 +287,39 @@ def _apply_command_card_adapter_patch(content: str) -> str:
     return content
 
 
+def _apply_command_card_startup_patch(content: str) -> str:
+    owned_block = _find_simple_marker_block(
+        content,
+        COMMAND_CARD_STARTUP_PATCH_BEGIN,
+        COMMAND_CARD_STARTUP_PATCH_END,
+        "command card startup patch markers",
+    )
+    if owned_block is not None:
+        lines = content.splitlines(keepends=True)
+        begin_index, end_index = owned_block
+        indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
+        newline = _line_ending(lines[begin_index]) or _detect_newline(content)
+        expected = _render_command_card_startup_hook_block(indent, newline)
+        if lines[begin_index : end_index + 1] == expected:
+            return content
+        return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
+
+    tree = _parse_content(content)
+    func = _find_gateway_runner_method(tree, "start")
+    if func is None:
+        return content
+    drain = _find_recovered_watcher_drain(func)
+    if drain is None or drain.lineno is None:
+        return content
+
+    lines = content.splitlines(keepends=True)
+    insert_at = drain.lineno - 1
+    indent = _line_indent(lines, insert_at)
+    newline = _line_ending(lines[insert_at]) or _detect_newline(content)
+    hook = _render_command_card_startup_hook_block(indent, newline)
+    return "".join(lines[:insert_at] + hook + lines[insert_at:])
+
+
 def _apply_platform_notice_patch(content: str) -> str:
     owned_block = _find_simple_marker_block(
         content,
@@ -354,6 +392,13 @@ def _apply_hfc_command_patch(content: str) -> str:
 def remove_patch(content: str) -> str:
     """Remove the owned Feishu card hook block from patched Hermes content."""
     content = _remove_cron_patch(content)
+    content = _remove_simple_owned_patch(
+        content,
+        COMMAND_CARD_STARTUP_PATCH_BEGIN,
+        COMMAND_CARD_STARTUP_PATCH_END,
+        _render_command_card_startup_hook_block,
+        "command card startup patch markers",
+    )
     content = _remove_simple_owned_patch(
         content,
         COMMAND_CARD_PATCH_BEGIN,
@@ -464,6 +509,7 @@ def remove_patch_lenient(content: str) -> str:
         (THINKING_DELTA_PATCH_BEGIN, THINKING_DELTA_PATCH_END),
         (CLARIFY_PATCH_BEGIN, CLARIFY_PATCH_END),
         (APPROVAL_PATCH_BEGIN, APPROVAL_PATCH_END),
+        (COMMAND_CARD_STARTUP_PATCH_BEGIN, COMMAND_CARD_STARTUP_PATCH_END),
         (COMMAND_CARD_PATCH_BEGIN, COMMAND_CARD_PATCH_END),
         (HFC_COMMAND_PATCH_BEGIN, HFC_COMMAND_PATCH_END),
         (PLATFORM_NOTICE_PATCH_BEGIN, PLATFORM_NOTICE_PATCH_END),
@@ -1011,6 +1057,40 @@ def _find_async_function(tree, name: str):
                 if isinstance(child, ast.AsyncFunctionDef) and child.name == name:
                     return child
 
+    return None
+
+
+def _find_gateway_runner_method(tree, name: str):
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "GatewayRunner":
+            continue
+        for child in node.body:
+            if isinstance(child, ast.AsyncFunctionDef) and child.name == name:
+                return child
+    return None
+
+
+def _find_recovered_watcher_drain(func):
+    for node in func.body:
+        if not isinstance(node, ast.Try):
+            continue
+        has_pending_watchers = any(
+            isinstance(child, ast.Attribute)
+            and child.attr == "pending_watchers"
+            and isinstance(child.value, ast.Name)
+            and child.value.id == "process_registry"
+            for child in ast.walk(node)
+        )
+        has_watcher_call = any(
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "_run_process_watcher"
+            and isinstance(child.func.value, ast.Name)
+            and child.func.value.id == "self"
+            for child in ast.walk(node)
+        )
+        if has_pending_watchers and has_watcher_call:
+            return node
     return None
 
 
@@ -1601,6 +1681,21 @@ def _render_command_card_adapter_hook_block(indent: str, newline: str):
         f"{inner_indent}_hfc_install_command_cards(self, event=event){newline}",
         *_render_hook_exception_handler(indent, newline),
         f"{indent}{COMMAND_CARD_PATCH_END}{newline}",
+    ]
+
+
+def _render_command_card_startup_hook_block(indent: str, newline: str):
+    inner_indent = _child_indent(indent)
+    return [
+        f"{indent}{COMMAND_CARD_STARTUP_PATCH_BEGIN}{newline}",
+        f"{indent}try:{newline}",
+        (
+            f"{inner_indent}from hermes_feishu_card.hook_runtime "
+            f"import install_feishu_command_card_adapter_methods as _hfc_install_command_cards{newline}"
+        ),
+        f"{inner_indent}_hfc_install_command_cards(self){newline}",
+        *_render_hook_exception_handler(indent, newline),
+        f"{indent}{COMMAND_CARD_STARTUP_PATCH_END}{newline}",
     ]
 
 

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -1592,7 +1592,7 @@ async def _events(request: web.Request) -> web.Response:
             cleanup_orphan_message_lock(request.app, lock_key, lock)
     if post_lock_task is not None and _should_await_card_update(event):
         await post_lock_task
-    if event.event in TERMINAL_EVENTS and post_lock_task is None:
+    if _event_is_terminal(event) and post_lock_task is None:
         cleanup_runtime_state(request.app, time.time())
     return response
 
@@ -1961,6 +1961,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
     session = sessions.get(session_key)
     if session is not None:
         event = _event_for_session(incoming_event, session)
+    event_is_terminal = _event_is_terminal(event)
 
     if _skip_native_text_fallback_interaction(request.app, event):
         metrics.events_ignored += 1
@@ -2055,9 +2056,10 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             # the gateway interrupts a running turn and starts a new one
             # without sending message.completed for the old turn — the old
             # card would be stuck at "生成中" forever.
-            await _abandon_stale_sessions_for_chat(
-                request.app, event.chat_id, session_key, event,
-            )
+            if not _is_independent_notice_event(event):
+                await _abandon_stale_sessions_for_chat(
+                    request.app, event.chat_id, session_key, event,
+                )
             session = CardSession(
                 conversation_id=event.conversation_id,
                 message_id=event.message_id,
@@ -2112,7 +2114,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 message_bot_ids[session_key] = route.bot_id
                 if event.event == "interaction.requested":
                     _store_interaction_result(request.app, session)
-                if event.event in TERMINAL_EVENTS:
+                if event_is_terminal:
                     _store_card_summary(request.app, event, session, message_id)
                     request.app[DIAGNOSTICS_KEY]["last_terminal_event"] = {
                         "message_id_hash": _diagnostic_id_hash(event.message_id),
@@ -2155,14 +2157,14 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
     # the native text message (avoiding duplicate delivery).
     terminal_already_handled = (
         not applied
-        and event.event in TERMINAL_EVENTS
+        and event_is_terminal
         and session.status in {"completed", "failed"}
     )
     if terminal_already_handled:
         applied = True
     if applied and event.event.startswith("interaction."):
         _store_interaction_result(request.app, session)
-    if event.event in TERMINAL_EVENTS:
+    if event_is_terminal:
         request.app[DIAGNOSTICS_KEY]["last_terminal_event"] = {
             "message_id_hash": _diagnostic_id_hash(event.message_id),
             "event": event.event,
@@ -2176,9 +2178,9 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
         return web.json_response({"ok": True, "applied": True}), None
     post_lock_task = None
     if applied and feishu_message_id is not None:
-        if event.event in TERMINAL_EVENTS:
+        if event_is_terminal:
             _store_card_summary(request.app, event, session, feishu_message_id)
-        is_terminal = event.event in TERMINAL_EVENTS
+        is_terminal = event_is_terminal
         controller = _flush_controller_for_session(request.app, session_key)
         bot_id = message_bot_ids.get(session_key)
 
@@ -2401,6 +2403,24 @@ def _skip_native_text_fallback_interaction(
     if fallback_policy != "native_text":
         return False
     return _interaction_mode_for_session_key(app, _session_key(event)) == "text"
+
+
+def _is_independent_notice_event(event: SidecarEvent) -> bool:
+    if event.event != "system.notice":
+        return False
+    data = event.data if isinstance(event.data, dict) else {}
+    scope = str(data.get("notice_scope") or "session").strip().lower()
+    delivery_kind = str(data.get("delivery_kind") or "").strip().lower()
+    return scope == "independent" or delivery_kind == "notice"
+
+
+def _event_is_terminal(event: SidecarEvent) -> bool:
+    if event.event in TERMINAL_EVENTS:
+        return True
+    if not _is_independent_notice_event(event):
+        return False
+    terminal = event.data.get("notice_terminal")
+    return not (isinstance(terminal, bool) and terminal is False)
 
 
 def _should_await_card_update(event: SidecarEvent) -> bool:
@@ -2734,6 +2754,8 @@ async def _abandon_stale_sessions_for_chat(
         if sess.conversation_id != new_conversation_id:
             continue
         if sess.status in {"completed", "failed"}:
+            continue
+        if sess.delivery_kind == "notice":
             continue
         # Match profile prefix
         key_profile = key.split(":", 1)[0] if ":" in key else ""

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -126,7 +126,7 @@ class CardSession:
             or event.chat_id != self.chat_id
         ):
             return False
-        is_terminal_event = event.event in {"message.completed", "message.failed"}
+        is_terminal_event = _is_terminal_session_event(event)
         if event.sequence <= self.last_sequence and not is_terminal_event:
             return False
         if self.status in {"completed", "failed"}:
@@ -222,7 +222,11 @@ class CardSession:
                 self.notice_title = title
                 self.notice_level = level
                 self.answer_text = content or title
-                self.status = "completed"
+                self.status = (
+                    "completed"
+                    if _notice_is_terminal(event.data.get("notice_terminal"))
+                    else "running"
+                )
                 self.updated_at = time.time()
                 self.refresh_display_status_source()
                 return True
@@ -510,6 +514,24 @@ def _notice_level(value: Any) -> str:
     if level in {"ok", "done", "green"}:
         return "success"
     return "info"
+
+
+def _notice_is_terminal(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return True
+
+
+def _is_terminal_session_event(event: SidecarEvent) -> bool:
+    if event.event in {"message.completed", "message.failed"}:
+        return True
+    if event.event != "system.notice":
+        return False
+    scope = str(event.data.get("notice_scope") or "session").strip().lower()
+    delivery_kind = str(event.data.get("delivery_kind") or "").strip().lower()
+    return (
+        scope == "independent" or delivery_kind == "notice"
+    ) and _notice_is_terminal(event.data.get("notice_terminal"))
 
 
 def _has_substantial_completed_suffix(final: str, stripped: str) -> bool:

--- a/tests/fixtures/hermes_0_13_plus/gateway/run.py
+++ b/tests/fixtures/hermes_0_13_plus/gateway/run.py
@@ -1,4 +1,18 @@
 class GatewayRunner:
+    async def start(self):
+        await self._finish_startup_restore()
+
+        # Drain any recovered process watchers from the crash-recovery checkpoint.
+        try:
+            from tools.process_registry import process_registry
+
+            watchers = process_registry.pending_watchers
+            process_registry.pending_watchers = []
+            for watcher in watchers:
+                self._run_process_watcher(watcher)
+        except Exception:
+            pass
+
     async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):
         _msg_start_time = 0.0
         agent_result = {

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -777,14 +777,19 @@ def test_install_and_restore_013_plus_fixture(tmp_path):
         Path(__file__).resolve().parents[1] / "fixtures" / "hermes_0_13_plus",
         hermes_dir,
     )
+    original = (hermes_dir / "gateway" / "run.py").read_text(encoding="utf-8")
 
     assert cli.main(["install", "--hermes-dir", str(hermes_dir), "--yes"]) == 0
     patched = (hermes_dir / "gateway" / "run.py").read_text(encoding="utf-8")
     assert "HERMES_FEISHU_CARD_STRATEGY gateway_run_013_plus" in patched
+    assert patcher.COMMAND_CARD_STARTUP_PATCH_BEGIN in patched
+    assert patched.index(patcher.COMMAND_CARD_STARTUP_PATCH_BEGIN) < patched.index(
+        "watchers = process_registry.pending_watchers"
+    )
 
     assert cli.main(["restore", "--hermes-dir", str(hermes_dir), "--yes"]) == 0
     restored = (hermes_dir / "gateway" / "run.py").read_text(encoding="utf-8")
-    assert "HERMES_FEISHU_CARD_PATCH_BEGIN" not in restored
+    assert restored == original
 
 
 def test_install_and_restore_latest_layout_patches_scheduler_cron(tmp_path):

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -4886,6 +4886,194 @@ async def test_independent_system_notice_without_started_sends_notice_card(clien
     assert feishu_client.updated == []
 
 
+async def test_independent_background_process_notice_updates_same_card(client):
+    test_client, feishu_client = client
+    message_id = "notice_background_process_proc_109e6dc419af"
+
+    running_response = await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            100,
+            {
+                "title": "后台进程运行中",
+                "content": "Updating files: 76%",
+                "notice_scope": "independent",
+                "notice_kind": "background-process",
+                "notice_id": "background-process:proc_109e6dc419af",
+                "notice_terminal": False,
+                "level": "info",
+            },
+            message_id=message_id,
+        ),
+    )
+
+    assert running_response.status == 200
+    assert await running_response.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert feishu_client.sent[0][1]["header"]["title"]["content"] == "后台进程运行中"
+    assert feishu_client.updated == []
+
+    completed_response = await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            1,
+            {
+                "title": "后台进程已完成",
+                "content": "Updating files: 100%, done.",
+                "notice_scope": "independent",
+                "notice_kind": "background-process",
+                "notice_id": "background-process:proc_109e6dc419af",
+                "notice_terminal": True,
+                "level": "success",
+            },
+            message_id=message_id,
+        ),
+    )
+
+    assert completed_response.status == 200
+    assert await completed_response.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert len(feishu_client.updated) == 1
+    card = feishu_client.updated[0][1]
+    assert card["header"]["title"]["content"] == "后台进程已完成"
+    assert card["header"]["template"] == "green"
+    assert "Updating files: 100%, done." in str(card)
+
+
+async def test_independent_background_notices_do_not_abandon_active_cards(client):
+    test_client, _feishu_client = client
+    conversation_id = "conversation-background-concurrency"
+
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            conversation_id=conversation_id,
+            message_id="main-turn-1",
+        ),
+    )
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            100,
+            {
+                "title": "后台进程运行中",
+                "content": "process one: 50%",
+                "notice_scope": "independent",
+                "notice_kind": "background-process",
+                "notice_id": "background-process:proc_111111111111",
+                "notice_terminal": False,
+                "level": "info",
+            },
+            conversation_id=conversation_id,
+            message_id="notice-process-one",
+        ),
+    )
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            100,
+            {
+                "title": "后台进程运行中",
+                "content": "process two: 50%",
+                "notice_scope": "independent",
+                "notice_kind": "background-process",
+                "notice_id": "background-process:proc_222222222222",
+                "notice_terminal": False,
+                "level": "info",
+            },
+            conversation_id=conversation_id,
+            message_id="notice-process-two",
+        ),
+    )
+
+    sessions = test_client.app[SESSIONS_KEY]
+    assert sessions["main-turn-1"].status == "thinking"
+    assert sessions["notice-process-one"].status == "running"
+    assert sessions["notice-process-two"].status == "running"
+
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            conversation_id=conversation_id,
+            message_id="main-turn-2",
+        ),
+    )
+
+    assert sessions["main-turn-1"].status == "completed"
+    assert sessions["notice-process-one"].status == "running"
+    assert sessions["notice-process-two"].status == "running"
+
+
+async def test_background_notice_terminal_update_retries_and_cleans_controller(
+    client, monkeypatch
+):
+    test_client, feishu_client = client
+    message_id = "notice-background-terminal-retry"
+
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            100,
+            {
+                "title": "后台进程运行中",
+                "content": "Updating files: 76%",
+                "notice_scope": "independent",
+                "notice_kind": "background-process",
+                "notice_id": "background-process:proc_333333333333",
+                "notice_terminal": False,
+                "level": "info",
+            },
+            message_id=message_id,
+        ),
+    )
+    feishu_client.update_failures_remaining = sidecar_server.UPDATE_MAX_ATTEMPTS
+
+    async def fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(sidecar_server.asyncio, "sleep", fake_sleep)
+    completed = await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            1,
+            {
+                "title": "后台进程已完成",
+                "content": "Updating files: 100%, done.",
+                "notice_scope": "independent",
+                "notice_kind": "background-process",
+                "notice_id": "background-process:proc_333333333333",
+                "notice_terminal": True,
+                "level": "success",
+            },
+            message_id=message_id,
+        ),
+    )
+
+    assert completed.status == 200
+    assert await completed.json() == {"ok": True, "applied": True}
+    await wait_for_card_update(feishu_client, "Updating files: 100%, done.")
+    for _ in range(20):
+        if message_id not in test_client.app[FLUSH_CONTROLLERS_KEY]:
+            break
+        await _REAL_ASYNCIO_SLEEP(0)
+
+    metrics = test_client.app[METRICS_KEY]
+    assert metrics.feishu_update_attempts == sidecar_server.UPDATE_MAX_ATTEMPTS + 1
+    assert metrics.feishu_update_failures == sidecar_server.UPDATE_MAX_ATTEMPTS
+    assert message_id not in test_client.app[FLUSH_CONTROLLERS_KEY]
+    assert metrics.flush_controllers_collected == 1
+
+
 async def test_cron_completed_event_sends_completed_card_without_started(client):
     test_client, feishu_client = client
 

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -1169,6 +1169,273 @@ def test_native_feishu_system_notice_send_suppresses_text_when_card_times_out(mo
     assert adapter.text_sent == []
 
 
+def _install_background_notice_probe(
+    monkeypatch,
+    *,
+    post_result=None,
+    post_error=None,
+):
+    posted = []
+
+    async def fake_post_json_ordered_response(url, payload, timeout):
+        posted.append((url, payload, timeout))
+        if post_error is not None:
+            raise post_error
+        if post_result is not None:
+            return post_result
+        return {"ok": True, "applied": True}
+
+    monkeypatch.setattr(
+        hook_runtime,
+        "_post_json_ordered_response",
+        fake_post_json_ordered_response,
+    )
+
+    class DummyFeishuAdapter:
+        name = "feishu"
+
+        def __init__(self):
+            self._client = object()
+            self.text_sent = []
+
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            self.text_sent.append((chat_id, content, reply_to, metadata))
+            return SimpleNamespace(success=True, message_id="om_native_text")
+
+    adapter = DummyFeishuAdapter()
+    runner = SimpleNamespace(adapters={"feishu": adapter})
+    assert hook_runtime.install_feishu_command_card_adapter_methods(runner) is True
+    return adapter, posted
+
+
+def test_background_process_notice_classification_and_stable_id():
+    running = hook_runtime._hfc_classify_system_notice(
+        "[Background process proc_109e6dc419af is still running~ "
+        "New output:\nUpdating files: 76%]"
+    )
+    completed = hook_runtime._hfc_classify_system_notice(
+        "[Background process proc_109e6dc419af finished with exit code 0~ "
+        "Here's the final output:\nCloning into 'skills'...\n]"
+    )
+    failed = hook_runtime._hfc_classify_system_notice(
+        "[Background process proc_109e6dc419af finished with exit code 17~ "
+        "Here's the final output:\nReading skill failed\n]"
+    )
+    unknown = hook_runtime._hfc_classify_system_notice(
+        "[Background process proc_109e6dc419af finished with exit code None~ "
+        "Here's the final output:\n\n]"
+    )
+    killed = hook_runtime._hfc_classify_system_notice(
+        "[Background process proc_109e6dc419af finished with exit code -9~ "
+        "Here's the final output:\nkilled\n]"
+    )
+    another = hook_runtime._hfc_classify_system_notice(
+        "[Background process proc_aaaaaaaaaaaa finished with exit code 0~ "
+        "Here's the final output:\ndone\n]"
+    )
+
+    assert running == {
+        "title": "后台进程运行中",
+        "level": "info",
+        "notice_kind": "background-process",
+        "notice_id": "background-process:proc_109e6dc419af",
+        "notice_terminal": False,
+    }
+    assert completed == {
+        "title": "后台进程已完成",
+        "level": "success",
+        "notice_kind": "background-process",
+        "notice_id": "background-process:proc_109e6dc419af",
+        "notice_terminal": True,
+    }
+    assert failed == {
+        "title": "后台进程失败",
+        "level": "error",
+        "notice_kind": "background-process",
+        "notice_id": "background-process:proc_109e6dc419af",
+        "notice_terminal": True,
+    }
+    assert unknown == {
+        "title": "后台进程已结束",
+        "level": "warning",
+        "notice_kind": "background-process",
+        "notice_id": "background-process:proc_109e6dc419af",
+        "notice_terminal": True,
+    }
+    assert killed == failed
+    assert another is not None
+    assert another["notice_id"] == "background-process:proc_aaaaaaaaaaaa"
+    independent_ids = {
+        hook_runtime._hfc_independent_notice_message_id(
+            "oc_abc",
+            content,
+            notice,
+        )
+        for content, notice in (
+            ("running", running),
+            ("completed", completed),
+            ("failed", failed),
+            ("unknown", unknown),
+            ("killed", killed),
+        )
+    }
+    assert len(independent_ids) == 1
+
+
+@pytest.mark.parametrize(
+    (
+        "content",
+        "expected_title",
+        "expected_level",
+        "expected_kind",
+        "expected_terminal",
+    ),
+    [
+        (
+            "[Background process proc_111111111111 is still running~ "
+            "New output:\nUpdating files: 76%]",
+            "后台进程运行中",
+            "info",
+            "background-process",
+            False,
+        ),
+        (
+            "[Background process proc_222222222222 finished with exit code 0~ "
+            "Here's the final output:\nCloning into 'skills'...\n]",
+            "后台进程已完成",
+            "success",
+            "background-process",
+            True,
+        ),
+        (
+            "[Background process proc_333333333333 finished with exit code 9~ "
+            "Here's the final output:\nfatal: repository not found\n]",
+            "后台进程失败",
+            "error",
+            "background-process",
+            True,
+        ),
+        (
+            '✅ Background task complete\nPrompt: "Clone repositories"\n\nDone.',
+            "后台任务已完成",
+            "success",
+            "background-task",
+            True,
+        ),
+        (
+            "❌ Background task bg_123456_abcdef failed: provider timeout",
+            "后台任务失败",
+            "error",
+            "background-task",
+            True,
+        ),
+    ],
+)
+def test_background_direct_send_uses_system_notice_card(
+    monkeypatch,
+    content,
+    expected_title,
+    expected_level,
+    expected_kind,
+    expected_terminal,
+):
+    adapter, posted = _install_background_notice_probe(monkeypatch)
+
+    async def run():
+        return await adapter.send(
+            "oc_topic",
+            content,
+            metadata={"thread_id": "omt_topic"},
+        )
+
+    result = asyncio.run(run())
+
+    assert result.success is True
+    assert adapter.text_sent == []
+    assert len(posted) == 1
+    _, payload, timeout = posted[0]
+    assert timeout == hook_runtime.TERMINAL_TIMEOUT_SECONDS
+    assert result.message_id == payload["message_id"]
+    assert payload["event"] == "system.notice"
+    assert payload["conversation_id"] == "omt_topic"
+    assert payload["thread_id"] == "omt_topic"
+    assert payload["data"]["notice_scope"] == "independent"
+    assert payload["data"]["title"] == expected_title
+    assert payload["data"]["level"] == expected_level
+    assert payload["data"]["notice_kind"] == expected_kind
+    assert payload["data"]["notice_terminal"] is expected_terminal
+    assert payload["data"]["notice_id"]
+    assert payload["data"]["content"] == content
+
+
+def test_identical_background_task_results_use_distinct_independent_message_ids(
+    monkeypatch,
+):
+    adapter, posted = _install_background_notice_probe(monkeypatch)
+    content = '✅ Background task complete\nPrompt: "Clone repositories"\n\nDone.'
+
+    async def run():
+        first = await adapter.send("oc_abc", content)
+        second = await adapter.send("oc_abc", content)
+        return first, second
+
+    first, second = asyncio.run(run())
+
+    assert first.success is True
+    assert second.success is True
+    assert first.message_id != second.message_id
+    assert adapter.text_sent == []
+    assert len(posted) == 2
+    first_payload = posted[0][1]
+    second_payload = posted[1][1]
+    assert first_payload["data"]["notice_id"] == second_payload["data"]["notice_id"]
+    assert first_payload["message_id"] != second_payload["message_id"]
+
+
+def test_background_notice_timeout_suppresses_native_text(monkeypatch):
+    adapter, posted = _install_background_notice_probe(
+        monkeypatch,
+        post_error=TimeoutError("timed out"),
+    )
+    content = (
+        "[Background process proc_444444444444 finished with exit code 0~ "
+        "Here's the final output:\ndone\n]"
+    )
+
+    result = asyncio.run(adapter.send("oc_abc", content))
+
+    assert result.success is True
+    assert result.message_id == "notice_suppressed"
+    assert len(posted) == 1
+    assert adapter.text_sent == []
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[Background process proc_abc finished somehow]",
+        "[Background process proc_555555555555 finished with exit code zero~ "
+        "Here's the final output:\ndone\n]",
+        "[Background process proc_555555555555 finished with exit code 0~ "
+        "Here's the final output:\ndone\n] trailing text",
+        "ordinary prefix [Background process proc_555555555555 is still running~ "
+        "New output:\n42%]",
+        "✅ Background task",
+        "✅ Background task complete\nordinary text without a Prompt envelope",
+        "❌ Background task failed without an id",
+    ],
+)
+def test_malformed_background_notice_fails_open(monkeypatch, content):
+    adapter, posted = _install_background_notice_probe(monkeypatch)
+
+    result = asyncio.run(adapter.send("oc_abc", content))
+
+    assert result.success is True
+    assert result.message_id == "om_native_text"
+    assert posted == []
+    assert adapter.text_sent == [("oc_abc", content, None, None)]
+
+
 def test_gateway_platform_notice_posts_sidecar_and_suppresses_native_text(monkeypatch):
     posted = []
 

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -189,6 +189,74 @@ def test_apply_patch_installs_feishu_command_card_adapter_methods():
     assert patcher.remove_patch(patched) == content
 
 
+def test_apply_patch_installs_command_card_adapter_before_recovered_watchers():
+    content = (
+        "class GatewayRunner:\n"
+        "    async def start(self):\n"
+        "        await self._finish_startup_restore()\n"
+        "        try:\n"
+        "            from tools.process_registry import process_registry\n"
+        "            watchers = process_registry.pending_watchers\n"
+        "            process_registry.pending_watchers = []\n"
+        "            for watcher in watchers:\n"
+        "                self._run_process_watcher(watcher)\n"
+        "        except Exception:\n"
+        "            pass\n"
+        "\n"
+        "    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "        response = 'ok'\n"
+        "        _response_time = 1\n"
+        "        agent_result = {}\n"
+        "        return response\n"
+    )
+
+    patched = patcher.apply_patch(content, strategy="gateway_run_013_plus")
+
+    ast.parse(patched)
+    assert patcher.COMMAND_CARD_STARTUP_PATCH_BEGIN in patched
+    assert "_hfc_install_command_cards(self)" in patched
+    assert patched.index(patcher.COMMAND_CARD_STARTUP_PATCH_BEGIN) < patched.index(
+        "watchers = process_registry.pending_watchers"
+    )
+    assert patcher.apply_patch(patched, strategy="gateway_run_013_plus") == patched
+    assert patcher.remove_patch(patched) == content
+
+
+@pytest.mark.parametrize(
+    "runner_name, watcher_call",
+    [
+        ("OtherRunner", "self._run_process_watcher(watcher)"),
+        ("GatewayRunner", "self._record_recovered_watcher(watcher)"),
+    ],
+)
+def test_command_card_startup_patch_requires_gateway_runner_recovered_watcher_drain(
+    runner_name,
+    watcher_call,
+):
+    content = (
+        f"class {runner_name}:\n"
+        "    async def start(self):\n"
+        "        try:\n"
+        "            from tools.process_registry import process_registry\n"
+        "            watchers = process_registry.pending_watchers\n"
+        "            for watcher in watchers:\n"
+        f"                {watcher_call}\n"
+        "        except Exception:\n"
+        "            pass\n"
+        "\n"
+        "    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "        response = 'ok'\n"
+        "        _response_time = 1\n"
+        "        agent_result = {}\n"
+        "        return response\n"
+    )
+
+    patched = patcher.apply_patch(content, strategy="gateway_run_013_plus")
+
+    assert patcher.COMMAND_CARD_STARTUP_PATCH_BEGIN not in patched
+    assert patcher.remove_patch(patched) == content
+
+
 def test_apply_patch_013_plus_intercepts_hfc_command_before_unknown_slash():
     content = (
         "class GatewayRunner:\n"

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -374,6 +374,44 @@ def test_independent_system_notice_becomes_completed_notice_card():
     assert session.timeline.snapshot() == []
 
 
+def test_independent_terminal_notice_applies_after_sequence_resets():
+    session = CardSession(
+        conversation_id="chat-1", message_id="notice-process", chat_id="oc_abc"
+    )
+
+    assert session.apply(
+        event(
+            "system.notice",
+            100,
+            {
+                "title": "后台进程运行中",
+                "content": "Updating files: 76%",
+                "notice_scope": "independent",
+                "notice_terminal": False,
+            },
+            message_id="notice-process",
+        )
+    )
+    assert session.status == "running"
+
+    assert session.apply(
+        event(
+            "system.notice",
+            1,
+            {
+                "title": "后台进程已完成",
+                "content": "Updating files: 100%, done.",
+                "notice_scope": "independent",
+                "notice_terminal": True,
+            },
+            message_id="notice-process",
+        )
+    )
+    assert session.status == "completed"
+    assert session.last_sequence == 100
+    assert session.visible_main_text == "Updating files: 100%, done."
+
+
 def test_answer_delta_takes_over_visible_text_before_completion():
     session = CardSession(conversation_id="chat-1", message_id="msg-1", chat_id="oc_abc")
     assert session.apply(event("thinking.delta", 1, {"text": "思考内容。"}))


### PR DESCRIPTION
## Summary

- route Hermes background process and `/background` completion envelopes through Feishu `system.notice` cards instead of native gray text
- keep background process running/final updates on one card, preserve topic routing, and install the adapter wrapper before recovered watchers drain
- handle concurrent notice cards, Gateway sequence resets, duplicate task output, and terminal retry/controller cleanup safely
- document the background notice lifecycle and extend patcher/install coverage

## Testing

- `.venv/bin/python -m pytest -q` — 1300 passed, 3 skipped
- `.venv/bin/python -m pytest tests/unit/test_docs.py tests/unit/test_package_metadata.py -q` — 51 passed
- current Hermes `gateway/run.py` apply/AST-parse/remove round trip
- `git diff --check`
