### PR TITLE
fix(patcher): emit completion hook before already_sent early return on Hermes 0.18.x

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -39,7 +39,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
     if strategy not in _SUPPORTED_STRATEGIES:
         raise ValueError(f"unsupported patch strategy: {strategy}")
     content = _apply_start_patch(content, strategy=strategy)
-    content = _apply_complete_patch(content)
+    content = _apply_complete_patch(content, strategy=strategy)
     content = _apply_queued_complete_patch(content)
     if strategy == "gateway_run_013_plus":
         content = _apply_cron_patch(content)
@@ -153,14 +153,27 @@ def _apply_start_patch(content: str, *, strategy: str) -> str:
     return "".join(lines[:insert_at] + hook + lines[insert_at:])
 
 
-def _apply_complete_patch(content: str) -> str:
+def _apply_complete_patch(content: str, *, strategy: str = "legacy_gateway_run") -> str:
+    renderer = (
+        _render_complete_hook_block_with_reply_anchor
+        if strategy == "gateway_run_013_plus"
+        else _render_complete_hook_block
+    )
+
     owned_block = _find_owned_complete_block(content)
     if owned_block is not None:
+        # Re-apply from a clean slate so a recognised block migrates to the
+        # current expected location (for example, from after an
+        # `already_sent` early return to before it) and to the current
+        # rendering in one pass.
+        stripped = _remove_complete_patch(content)
+        if stripped != content:
+            return _apply_complete_patch(stripped, strategy=strategy)
         lines = content.splitlines(keepends=True)
         begin_index, end_index = owned_block
         indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
         newline = _line_ending(lines[begin_index]) or _detect_newline(content)
-        expected = _render_complete_hook_block(indent, newline)
+        expected = renderer(indent, newline)
         if lines[begin_index : end_index + 1] == expected:
             return content
         return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
@@ -173,7 +186,7 @@ def _apply_complete_patch(content: str) -> str:
 
     newline = _detect_newline(content)
     insert_at, body_indent = completion_location
-    hook = _render_complete_hook_block(body_indent, newline)
+    hook = renderer(body_indent, newline)
     return "".join(lines[:insert_at] + hook + lines[insert_at:])
 
 
@@ -199,8 +212,12 @@ def _apply_queued_complete_patch(content: str) -> str:
     for index, line in enumerate(lines):
         if _strip_line_ending(line).strip() != target:
             continue
-        previous = lines[index - 1] if index > 0 else ""
-        if "first_response = result.get(" not in previous:
+        # `first_response = result.get(...)` no longer sits on the immediately
+        # preceding line in newer Hermes (a multi-line call to
+        # _stream_confirmed_final_delivery is interleaved), so scan a short
+        # window above the anchor instead of only lines[index - 1].
+        lookback = lines[max(0, index - 12) : index]
+        if not any("first_response = result.get(" in item for item in lookback):
             continue
         indent = _leading_whitespace(_strip_line_ending(line))
         newline = _line_ending(line) or _detect_newline(content)
@@ -612,6 +629,10 @@ def _find_completion_return_location(tree, lines):
     if handler is None:
         return None
 
+    already_sent_location = _find_already_sent_early_return_location(handler, lines)
+    if already_sent_location is not None:
+        return already_sent_location
+
     returns = [
         node
         for node in ast.walk(handler)
@@ -626,6 +647,46 @@ def _find_completion_return_location(tree, lines):
     target = max(returns, key=lambda node: node.lineno)
     insert_at = target.lineno - 1
     return insert_at, _line_indent(lines, insert_at)
+
+
+def _find_already_sent_early_return_location(handler, lines):
+    """Locate the streaming `already_sent` early-return branch, if present.
+
+    Hermes 0.18.x returns None from the handler before the final
+    `return response` when gateway streaming already delivered the text
+    (``if agent_result.get("already_sent") and not agent_result.get("failed"):``).
+    The completion hook must run before that branch or streamed turns never
+    emit ``message.completed``.
+    """
+    candidates = []
+    for node in ast.walk(handler):
+        if not isinstance(node, ast.If) or node.lineno is None:
+            continue
+        try:
+            test_source = ast.unparse(node.test)
+        except Exception:
+            continue
+        if "agent_result.get('already_sent')" not in test_source:
+            continue
+        if "not agent_result.get('failed')" not in test_source:
+            continue
+        if not _branch_returns(node.body):
+            continue
+        candidates.append(node)
+    if not candidates:
+        return None
+
+    target = min(candidates, key=lambda node: node.lineno)
+    insert_at = target.lineno - 1
+    return insert_at, _line_indent(lines, insert_at)
+
+
+def _branch_returns(body) -> bool:
+    for node in body:
+        for child in ast.walk(node):
+            if isinstance(child, ast.Return):
+                return True
+    return False
 
 
 def _find_cron_deliver_body_location(tree, lines):
@@ -857,12 +918,16 @@ def _find_owned_complete_block(content: str):
 
     indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
     newline = _line_ending(lines[begin_index]) or _detect_newline(content)
+    expected_with_anchor = _render_complete_hook_block_with_reply_anchor(indent, newline)
     expected = _render_complete_hook_block(indent, newline)
     v400 = _render_v400_complete_hook_block(indent, newline)
     legacy = _render_legacy_complete_hook_block(indent, newline)
     previous_async = _render_previous_async_complete_hook_block(indent, newline)
     previous_async_without_platform = (
         _render_previous_async_complete_hook_block_without_platform_guard(indent, newline)
+    )
+    expected_with_anchor_silent = _with_silent_exception_handler(
+        expected_with_anchor, indent, newline
     )
     expected_silent = _with_silent_exception_handler(expected, indent, newline)
     v400_silent = _with_silent_exception_handler(v400, indent, newline)
@@ -875,11 +940,13 @@ def _find_owned_complete_block(content: str):
     )
     actual = lines[begin_index : end_index + 1]
     if actual not in (
+        expected_with_anchor,
         expected,
         v400,
         legacy,
         previous_async,
         previous_async_without_platform,
+        expected_with_anchor_silent,
         expected_silent,
         v400_silent,
         legacy_silent,
@@ -1259,6 +1326,39 @@ def _render_complete_hook_block(indent: str, newline: str):
         *_render_hook_exception_handler(indent, newline),
         f"{indent}{COMPLETE_PATCH_END}{newline}",
     ]
+
+
+def _render_complete_hook_block_with_reply_anchor(indent: str, newline: str):
+    """Completion hook for gateway_run_013_plus handlers.
+
+    Derives an explicit message_id from the same reply anchor the started and
+    delta hooks use, so the terminal event always lands on the session that
+    owns the card instead of relying on the ambiguous terminal fallback cache
+    (which can make build_event return None on streamed turns).
+    """
+    inner_indent = _child_indent(indent)
+    deeper_indent = _child_indent(inner_indent)
+    block = list(_render_complete_hook_block(indent, newline))
+    anchor_lines = [
+        f"{inner_indent}_hfc_completed_message_id = None{newline}",
+        f"{inner_indent}try:{newline}",
+        f"{deeper_indent}_hfc_completed_message_id = self._reply_anchor_for_event(event){newline}",
+        f"{inner_indent}except Exception:{newline}",
+        f"{deeper_indent}_hfc_completed_message_id = getattr(event, \"message_id\", None){newline}",
+    ]
+    import_index = next(
+        index
+        for index, line in enumerate(block)
+        if "native_media_only_response as _hfc_media_only" in line
+    )
+    block[import_index + 1 : import_index + 1] = anchor_lines
+    locals_index = next(
+        index for index, line in enumerate(block) if "**locals()," in line
+    )
+    block[locals_index + 1 : locals_index + 1] = [
+        f"{deeper_indent}\"message_id\": _hfc_completed_message_id,{newline}"
+    ]
+    return block
 
 
 def _render_v400_complete_hook_block(indent: str, newline: str):

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -1268,3 +1268,148 @@ def test_legacy_complete_hook_block_has_no_return_none():
     from hermes_feishu_card.install.patcher import _render_legacy_complete_hook_block
     block = "".join(_render_legacy_complete_hook_block("    ", "\n"))
     assert "return None" not in block
+
+
+_ALREADY_SENT_HANDLER = (
+    "class GatewayRunner:\n"
+    "    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+    "        response = 'ok'\n"
+    "        _response_time = 1\n"
+    "        agent_result = {}\n"
+    "        if agent_result.get(\"already_sent\") and not agent_result.get(\"failed\"):\n"
+    "            if response:\n"
+    "                pass\n"
+    "            return None\n"
+    "        return response\n"
+    "\n"
+    "    def _reply_anchor_for_event(self, event):\n"
+    "        return getattr(event, 'reply_to_message_id', None) or event.message_id\n"
+)
+
+
+def test_complete_hook_inserted_before_already_sent_early_return():
+    """Hermes 0.18.x: streamed turns return None from the already_sent branch
+    before the final `return response`, so the completion hook must run first."""
+    patched = patcher.apply_patch(_ALREADY_SENT_HANDLER, strategy="gateway_run_013_plus")
+
+    assert patcher.COMPLETE_PATCH_BEGIN in patched
+    assert patched.index(patcher.COMPLETE_PATCH_BEGIN) < patched.index(
+        'if agent_result.get("already_sent")'
+    )
+    ast.parse(patched)
+
+
+def test_complete_hook_keeps_final_return_location_without_already_sent_branch():
+    content = (
+        "class GatewayRunner:\n"
+        "    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "        response = 'ok'\n"
+        "        _response_time = 1\n"
+        "        agent_result = {}\n"
+        "        return response\n"
+    )
+
+    patched = patcher.apply_patch(content, strategy="gateway_run_013_plus")
+    lines = patched.splitlines()
+    marker_line = next(
+        index for index, line in enumerate(lines) if patcher.COMPLETE_PATCH_END in line
+    )
+
+    assert lines[marker_line + 1].strip() == "return response"
+
+
+def test_013_plus_complete_hook_derives_reply_anchor_message_id():
+    patched = patcher.apply_patch(_ALREADY_SENT_HANDLER, strategy="gateway_run_013_plus")
+    complete_block = patched[
+        patched.index(patcher.COMPLETE_PATCH_BEGIN) : patched.index(
+            patcher.COMPLETE_PATCH_END
+        )
+    ]
+
+    assert (
+        "_hfc_completed_message_id = self._reply_anchor_for_event(event)"
+        in complete_block
+    )
+    assert '"message_id": _hfc_completed_message_id' in complete_block
+
+
+def test_legacy_complete_hook_does_not_reference_reply_anchor():
+    content = (
+        "async def _handle_message_with_agent(message):\n"
+        "    response = await run_agent(message)\n"
+        "    _response_time = 1\n"
+        "    agent_result = {}\n"
+        "    return response\n"
+    )
+
+    patched = patcher.apply_patch(content, strategy="legacy_gateway_run")
+    complete_block = patched[
+        patched.index(patcher.COMPLETE_PATCH_BEGIN) : patched.index(
+            patcher.COMPLETE_PATCH_END
+        )
+    ]
+
+    assert "_reply_anchor_for_event" not in complete_block
+
+
+def test_apply_complete_patch_migrates_stale_block_before_already_sent_branch():
+    """A block installed by an older version after the already_sent branch is
+    dead code on Hermes 0.18.x; re-applying must move it before the branch."""
+    from hermes_feishu_card.install.patcher import _render_complete_hook_block
+
+    stale_block = "".join(_render_complete_hook_block("        ", "\n"))
+    content = (
+        "class GatewayRunner:\n"
+        "    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "        response = 'ok'\n"
+        "        _response_time = 1\n"
+        "        agent_result = {}\n"
+        "        if agent_result.get(\"already_sent\") and not agent_result.get(\"failed\"):\n"
+        "            return None\n"
+        + stale_block
+        + "        return response\n"
+    )
+
+    patched = patcher._apply_complete_patch(content, strategy="gateway_run_013_plus")
+
+    assert patched.count(patcher.COMPLETE_PATCH_BEGIN) == 1
+    assert patched.index(patcher.COMPLETE_PATCH_BEGIN) < patched.index(
+        'if agent_result.get("already_sent")'
+    )
+    ast.parse(patched)
+
+
+def test_queued_complete_patch_tolerates_interleaved_stream_confirmation():
+    """Newer Hermes interleaves a multi-line _stream_confirmed_final_delivery
+    call between the first_response assignment and the anchor line; the patch
+    must not be silently skipped."""
+    content = (
+        "async def _drain_queue(self):\n"
+        "    result = {}\n"
+        "    _previewed = bool(result.get('response_previewed'))\n"
+        "    first_response = result.get('final_response', '')\n"
+        "    _already_streamed = _stream_confirmed_final_delivery(\n"
+        "        _sc,\n"
+        "        first_response,\n"
+        "        previewed=_previewed,\n"
+        "    )\n"
+        "    if first_response and not _already_streamed:\n"
+        "        await adapter.send('chat', first_response)\n"
+    )
+
+    patched = patcher._apply_queued_complete_patch(content)
+
+    assert patcher.QUEUED_COMPLETE_PATCH_BEGIN in patched
+    lines = patched.splitlines()
+    marker_line = next(
+        index
+        for index, line in enumerate(lines)
+        if patcher.QUEUED_COMPLETE_PATCH_BEGIN in line
+    )
+    anchor_line = next(
+        index
+        for index, line in enumerate(lines)
+        if line.strip() == "if first_response and not _already_streamed:"
+    )
+    assert marker_line < anchor_line
+    ast.parse(patched)


### PR DESCRIPTION
Fixes #120

## Problem

On Hermes 0.18.x with gateway streaming enabled, every streamed turn leaves the Feishu card stuck in the generating state and additionally delivers the full native text (duplicate reply), while `setup`/`doctor`/`install` all report success:

1. the handler returns `None` from the `already_sent` branch **before** the final `return response`, so the completion hook (inserted before the last `return response`) is dead code on streamed turns — `message.completed` is never emitted and `should_suppress_native_response` never runs;
2. `_apply_queued_complete_patch` requires `first_response = result.get(` on the line immediately above the anchor, but Hermes 0.18.x interleaves a multi-line `_stream_confirmed_final_delivery(...)` call, so the queued completion hook is **silently** skipped while install reports ok.

## Changes

- **`_find_completion_return_location`** now prefers inserting the completion hook before the `already_sent` early-return branch when the handler has one, detected via AST: an `If` whose test contains `agent_result.get('already_sent')` and `not agent_result.get('failed')` and whose body returns. Handlers without the branch keep the existing last-`return response` placement, so older Hermes versions are unaffected.
- **New `_render_complete_hook_block_with_reply_anchor`** is used for the `gateway_run_013_plus` strategy: it derives an explicit `message_id` via `self._reply_anchor_for_event(event)` (fallback `getattr(event, "message_id", None)`) — the same anchor the started and delta hooks use — instead of relying on the terminal fallback cache, which can be ambiguous on streamed turns and make `build_event` return `None`. The `legacy_gateway_run` rendering is unchanged (those handlers have no `self`/`event`).
- **Upgrade/migration safety**: the previous rendering stays in the owned-block recognition list (plus its silent-handler variant), and `_apply_complete_patch` re-applies a recognised block from a clean slate, so a block installed by an older version at the stale location (after the `already_sent` branch) migrates to the correct position on reinstall. Re-applying is idempotent.
- **`_apply_queued_complete_patch`** scans a short lookback window (12 lines) for the `first_response = result.get(` guard instead of only the immediately preceding line.

## Testing

- `tests/unit/test_patcher.py`: 6 new tests — insertion before the `already_sent` branch, unchanged placement without the branch, reply-anchor derivation for `013_plus`, no anchor reference for `legacy`, stale-block migration, and queued-completion tolerance for the interleaved multi-line call. `67 passed`.
- Full suite: `1281 passed, 3 skipped`; the remaining integration failures (`test_cli_process` ×2, `test_full_capacity_repeated_recheck...`) also fail on a clean `main` checkout in this environment, and `test_operations_callbacks_keep_full_recovery_fingerprint_internal` is flaky on both (passes/fails intermittently on unmodified `main`).
- Verified against a **real Hermes 0.18.0 `gateway/run.py`**: completion hook lands on line 11664, before the `already_sent` branch on line 11710; the queued completion hook is now applied (line 19305, previously skipped); the patched file parses; re-applying is idempotent.
- The equivalent hand-applied hook (same emit + explicit reply-anchor `message_id` before the `already_sent` return) has been running on a production Hermes 0.18.0 + Feishu deployment: cards complete normally and the duplicate native reply is gone.