### PR TITLE
fix: isolate orphaned self-improvement notices

### DIFF
--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -1976,6 +1976,18 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             }
         ), None
 
+    if (
+        session is None
+        and event.event == "system.notice"
+        and not _is_independent_notice_event(event)
+    ):
+        # Session-scoped notices are auxiliary timeline entries, not a reason
+        # to create a new primary card. Background callbacks can outlive the
+        # turn that supplied their reply anchor; report applied=False so the
+        # runtime wrapper retries it as an independent card with its own lifecycle.
+        metrics.events_ignored += 1
+        return web.json_response({"ok": True, "applied": False}), None
+
     if event.event == "message.started":
         if session is not None:
             if session.status in {"completed", "failed"}:

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -4886,6 +4886,95 @@ async def test_independent_system_notice_without_started_sends_notice_card(clien
     assert feishu_client.updated == []
 
 
+async def test_orphaned_self_improvement_notice_does_not_claim_next_turn(client):
+    test_client, feishu_client = client
+    conversation_id = "omt_self_improvement"
+    reply_anchor = "om_topic_root"
+    notice_data = {
+        "reply_to_message_id": reply_anchor,
+        "title": "自我改进",
+        "content": "💾 Self-improvement review: Memory updated",
+        "level": "info",
+        "notice_kind": "self-improvement",
+        "notice_id": "self-improvement:review-1",
+    }
+
+    orphaned = await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            1,
+            {**notice_data, "notice_scope": "session"},
+            conversation_id=conversation_id,
+            message_id=reply_anchor,
+            thread_id=conversation_id,
+        ),
+    )
+
+    assert orphaned.status == 200
+    assert await orphaned.json() == {"ok": True, "applied": False}
+    assert reply_anchor not in test_client.app[SESSIONS_KEY]
+    assert reply_anchor not in test_client.app[SESSION_ALIASES_KEY]
+    assert feishu_client.sent == []
+
+    independent = await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            2,
+            {**notice_data, "notice_scope": "independent"},
+            conversation_id=conversation_id,
+            message_id="notice_self_improvement",
+            thread_id=conversation_id,
+        ),
+    )
+
+    assert independent.status == 200
+    assert await independent.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 1
+    assert "生成中" not in str(feishu_client.sent[0][1])
+    assert test_client.app[SESSIONS_KEY]["notice_self_improvement"].status == "completed"
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": reply_anchor},
+            conversation_id=conversation_id,
+            message_id=reply_anchor,
+            thread_id=conversation_id,
+        ),
+    )
+    assert started.status == 200
+    assert await started.json() == {"ok": True, "applied": True}
+    assert len(feishu_client.sent) == 2
+
+    followup = await test_client.post(
+        "/events",
+        json=event_payload(
+            "answer.delta",
+            1,
+            {
+                "reply_to_message_id": reply_anchor,
+                "text": "后续对话应更新自己的卡片",
+            },
+            conversation_id=conversation_id,
+            message_id="om_followup_delta",
+            thread_id=conversation_id,
+        ),
+    )
+    assert followup.status == 200
+    assert await followup.json() == {"ok": True, "applied": True}
+    updated_message_id, _card = await wait_for_card_update(
+        feishu_client,
+        "后续对话应更新自己的卡片",
+    )
+    assert updated_message_id == "feishu-message-2"
+    assert test_client.app[SESSIONS_KEY]["notice_self_improvement"].status == "completed"
+    assert test_client.app[SESSIONS_KEY][reply_anchor].status == "thinking"
+
+
 async def test_independent_background_process_notice_updates_same_card(client):
     test_client, feishu_client = client
     message_id = "notice_background_process_proc_109e6dc419af"

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -1739,7 +1739,18 @@ def test_gateway_platform_notice_falls_back_for_non_system_notice(monkeypatch):
     ]
 
 
-def test_native_feishu_system_notice_retries_as_independent_card_when_current_session_done(monkeypatch):
+@pytest.mark.parametrize(
+    ("content", "expected_title"),
+    [
+        ("📚 Reading skill hermes-agent", "技能加载"),
+        ("💾 Self-improvement review: Memory updated", "自我改进"),
+    ],
+)
+def test_native_feishu_system_notice_retries_as_independent_card_when_session_missing(
+    monkeypatch,
+    content,
+    expected_title,
+):
     posted = []
 
     async def fake_post_json_ordered_response(url, payload, timeout):
@@ -1778,7 +1789,7 @@ def test_native_feishu_system_notice_retries_as_independent_card_when_current_se
     async def run():
         return await adapter.send(
             "oc_abc",
-            "📚 Reading skill hermes-agent",
+            content,
             reply_to="om_user_weather",
         )
 
@@ -1791,7 +1802,8 @@ def test_native_feishu_system_notice_retries_as_independent_card_when_current_se
     assert posted[0]["data"]["notice_scope"] == "session"
     assert posted[1]["message_id"].startswith("notice_")
     assert posted[1]["data"]["notice_scope"] == "independent"
-    assert posted[1]["data"]["title"] == "技能加载"
+    assert posted[1]["data"]["delivery_kind"] == "notice"
+    assert posted[1]["data"]["title"] == expected_title
     assert result.message_id == posted[1]["message_id"]
 
 


### PR DESCRIPTION
## Summary

- prevent orphaned session-scoped notices from creating a new primary streaming card
- let the runtime retry delayed self-improvement reviews as independent cards with their own lifecycle
- keep notices attached to an active session on the existing card timeline
- add regression coverage for the next conversation updating its own card

## Root cause

The self-improvement callback can arrive after its original turn has completed while still carrying that turn's reply anchor. The server treated the orphaned `system.notice` as a session-creating event, leaving a new card in the default `thinking` state. Topic aliases then routed later conversation progress into that stale card.

## User impact

Self-improvement cards now finish normally, and subsequent conversations update their own streaming cards instead of overwriting the self-improvement card.

## Validation

- focused runtime/session/server suite: `450 passed`
- full suite: `1317 passed, 3 skipped`
- `git diff --check`
