### PR TITLE
test: wait for operations repair scheduling

### DIFF
--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -2627,6 +2627,7 @@ async def test_group_operations_first_claim_missing_identity_and_read_only_matri
             json=operations_action_payload(confirm, operator="ou_claimant"),
         )
         completed_body = await completed.json()
+        await _wait_until(lambda: len(calls) == 1)
     finally:
         await test_client.close()
 


### PR DESCRIPTION
## What changed

Wait for the promised asynchronous operations-repair callback before closing the aiohttp test server and asserting the call count.

## Why

The main-branch Python 3.12 run after V4.0.8 returned the expected successful executing response, but the test closed the server before the response's after-EOF callback had scheduled execute_recovery. This is a test-only scheduling race; production behavior and V4.0.8 attachment delivery are unchanged.

## Validation

- affected Python 3.12 test passed 20 consecutive runs
- full local suite: 1328 passed, 3 skipped
- git diff --check

Follow-up to the post-merge CI run for #128.
