### PR TITLE
docs: record v4.0.11 release verification

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 - [x] 自动化覆盖 503 后成功、永久 400、结果不明、topic 路由、同 UUID 重试与单次 hook `/events` 调用。
 - [x] 真实 loopback sidecar + Feishu API 的私聊 create 与 topic reply 均为 `delivered/applied`，2 次发送全部成功；诊断未包含验收正文或 UUID。
 - [x] 最终全量 gate `1389 passed, 4 skipped`、`git diff --check`、sdist/wheel 构建与干净 Python 3.12 wheel import `4.0.11` 通过。
-- [ ] annotated tag `v4.0.11`、GitHub Release、四个 assets/checksums 与公共 tagged installer fixture 验证通过。
+- [x] annotated tag `v4.0.11`、GitHub Release、四个 assets/checksums 与公共 tagged installer fixture 验证通过。
 
 ### V4.0.10：事件传输安全边界（已发布）
 

--- a/docs/release-notes-v4.0.11.en.md
+++ b/docs/release-notes-v4.0.11.en.md
@@ -27,6 +27,8 @@ V4.0.11 fixes Issue #135: unreliable Feishu create/reply results no longer let r
 - `uv build` produced both sdist and wheel. A clean Python 3.12 environment imported `hermes_feishu_card==4.0.11` from the wheel with the expected console entry point metadata.
 - After reloading the current worktree into a real Hermes `v2026.7.7.2` installation, Feishu DM create and topic reply through loopback `/events` both returned `delivered/applied`; both sends succeeded, failures/retries/unknown did not increase, and diagnostics contained neither smoke text nor UUIDs.
 - This direct `/events` smoke does not traverse the Hermes native-message branch, so it does not claim a completed client-side gray-text visual check or real Feishu fault injection; automated integration tests cover those branches.
+- The annotated `v4.0.11` tag points to merged commit `2a806d3`. The `release-assets` workflow succeeded, all four public assets were present, and every SHA-256 checksum passed.
+- A public `v4.0.11` tagged-installer fixture installed the Git tag into isolated Python 3.12 `site-packages` as version `4.0.11`; a temporary Hermes fixture then reported a complete, consistent hook install state.
 
 ## Release assets
 

--- a/docs/release-notes-v4.0.11.md
+++ b/docs/release-notes-v4.0.11.md
@@ -27,6 +27,8 @@ V4.0.11 修复 Issue #135：当 Feishu 初始 create/reply 的 HTTP 结果不可
 - `uv build` 成功生成 sdist/wheel；干净 Python 3.12 环境从 wheel 导入 `hermes_feishu_card==4.0.11`，console entry point metadata 正确。
 - 真实 Hermes `v2026.7.7.2` 重载当前工作树后，loopback `/events` 的 Feishu 私聊 create 与 topic reply 均返回 `delivered/applied`；2 次发送全部成功，失败、重试和 unknown 未增加，诊断未包含验收正文或 UUID。
 - 本次直接 `/events` smoke 不经过 Hermes 原生消息分支，因此不把客户端灰字去重或真实 Feishu 故障注入写成已完成；相关分支由自动化集成测试验证。
+- annotated tag `v4.0.11` 正确指向合并提交 `2a806d3`；`release-assets` workflow 成功，四个公开资产齐全并逐项通过 SHA-256 checksums。
+- 公共 `v4.0.11` tagged installer fixture 从 Git tag 安装到独立 Python 3.12 `site-packages`，版本为 `4.0.11`；临时 Hermes fixture 的 hook install state 完整一致。
 
 ## Release assets
 

--- a/docs/wiki/feishu-acceptance.md
+++ b/docs/wiki/feishu-acceptance.md
@@ -11,7 +11,7 @@
 - 受控 503 耗尽或连接结果不明返回 `unknown`：只尝试一次 `⚠️ 一条运行提示的卡片投递结果无法确认，请稍后查看 /hfc status。`，不重复原始通知文本，`notice_uncertain_warnings` 加一；飞书完全不可用时不要求该提示必达。
 - 检查 `/health`：`feishu_send_retries`、`feishu_send_unknown_outcomes`、`notice_native_fallbacks`、`notice_uncertain_warnings` 与脱敏 `last_send_error` 符合分支，且没有原始 chat/message id、UUID、通知正文、URL、token 或 secret。
 
-2026-07-18 发布候选验收结果：真实 Hermes `v2026.7.7.2` 通过项目 CLI 重载当前工作树的 sidecar，并使用 Gateway 官方 CLI 重启 Gateway；`doctor` 显示 runtime/import/install state 一致。通过 loopback `/events` 向已认证 Feishu 会话执行私聊 create 与 topic reply，两条事件均返回 `delivered/applied`，sidecar 指标增加 2 次接收、2 次应用和 2 次成功发送，失败、重试及 unknown 均未增加；card-safe diagnostics 未包含验收正文或 `delivery_uuid`。受控 503/400/unknown 与 hook 原生回退分支由自动化集成测试覆盖；本次直接 `/events` smoke 不宣称已完成客户端原生灰字去重视觉验收或真实 Feishu 故障注入。
+2026-07-18 发布验收结果：真实 Hermes `v2026.7.7.2` 通过项目 CLI 重载当前工作树的 sidecar，并使用 Gateway 官方 CLI 重启 Gateway；`doctor` 显示 runtime/import/install state 一致。通过 loopback `/events` 向已认证 Feishu 会话执行私聊 create 与 topic reply，两条事件均返回 `delivered/applied`，sidecar 指标增加 2 次接收、2 次应用和 2 次成功发送，失败、重试及 unknown 均未增加；card-safe diagnostics 未包含验收正文或 `delivery_uuid`。受控 503/400/unknown 与 hook 原生回退分支由自动化集成测试覆盖；本次直接 `/events` smoke 不宣称已完成客户端原生灰字去重视觉验收或真实 Feishu 故障注入。发布后进一步确认 annotated tag 指向 `2a806d3`、四个 assets/checksums 全部通过，公共 `v4.0.11` tag 可安装到独立 Python 3.12 `site-packages`，临时 Hermes fixture 的 hook install state 完整一致。
 
 ## V4.0.10 事件传输安全边界
 


### PR DESCRIPTION
## Summary

- mark the v4.0.11 tag, Release, assets, checksums, and public tagged-installer gate complete
- record the verified release commit and public Python 3.12 installation evidence
- keep the real `/events` smoke scope explicit and avoid claiming unperformed client-side fault injection

## Verification

- `pytest tests/unit/test_docs.py tests/unit/test_package_metadata.py -q`: 60 passed
- `git diff --check`
- release-assets workflow success
- all public asset SHA-256 checksums passed
- public `v4.0.11` tag installed as 4.0.11 from merged commit `2a806d3`; fixture hook install state consistent