### PR TITLE
docs: record v4.0.12 release verification

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 
 详细路线见 [docs/superpowers/specs/2026-06-30-v3-8-design.md](docs/superpowers/specs/2026-06-30-v3-8-design.md) 和 [docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md](docs/superpowers/plans/2026-06-30-v3-8-card-ux-stability.md)。
 
-### V4.0.12：上下文压缩、字号与凭据可观测性（发布候选）
+### V4.0.12：上下文压缩、字号与凭据可观测性（已发布）
 
 - [x] Issue #133：从 Hermes 精确 `Compacting context` callback 生成 `context-compaction` 阶段；已有卡继续更新，无卡时只创建一张 primary card。
 - [x] `card.text_sizes` 支持 `body`、`reasoning`、`tool`、`notice`、`footer`，以及 `default` / `pc` / `mobile` 映射；物理 width/height 明确由客户端控制。
@@ -14,7 +14,7 @@
 - [x] Noop 模式显示 `degraded` / `noop_mode`，发送返回 `not_sent` 并记录 `feishu_noop_attempts`，不再制造假 message id/success。
 - [x] 自动化覆盖压缩 hook/session/render/server、字号 schema/merge/render/device，以及 selected-env/Noop process 集成。
 - [x] 最终全量 gate `1460 passed, 4 skipped`、`git diff --check`、sdist/wheel 与干净 Python 3.12 wheel import `4.0.12` 通过。
-- [ ] 合并发布 PR，创建 annotated tag、GitHub Release，验证四个 assets/checksums 与公共 tagged installer fixture。
+- [x] 合并发布 PR；annotated tag `v4.0.12` 指向 `00a48a7`，Release 四个 assets/checksums 与公共 tagged installer fixture 验证通过。
 
 ### V4.0.11：system.notice 可靠投递（发布候选）
 

--- a/docs/release-notes-v4.0.12.en.md
+++ b/docs/release-notes-v4.0.12.en.md
@@ -50,6 +50,8 @@ card:
 - `hermes-feishu-card-v4.0.12-windows.zip`
 - `hermes-feishu-card-v4.0.12-checksums.txt`
 
+Post-release verification: annotated tag `v4.0.12` points to merge commit `00a48a7`, and release-assets workflow `29632908140` succeeded. After downloading all four public assets, SHA-256 verification passed for the Linux, macOS, and Windows packages. An isolated Python 3.12 environment installed the public tag, imported `4.0.12` from `site-packages`, and passed the CLI smoke. Issues #133 and #136 were closed with the remaining verification boundaries documented.
+
 ## Credits
 
 - Thanks to @tianxia3111 for Issue #133's production compaction gap and mobile-readability request.

--- a/docs/release-notes-v4.0.12.md
+++ b/docs/release-notes-v4.0.12.md
@@ -50,6 +50,8 @@ card:
 - `hermes-feishu-card-v4.0.12-windows.zip`
 - `hermes-feishu-card-v4.0.12-checksums.txt`
 
+发布后验证：annotated tag `v4.0.12` 指向合并提交 `00a48a7`；release-assets workflow `29632908140` 成功。下载四个公开资产后，Linux、macOS、Windows 包的 SHA-256 校验全部通过；隔离 Python 3.12 环境从公开 tag 安装并从 `site-packages` 导入 `4.0.12`，CLI smoke 通过。Issues #133 和 #136 已附验证边界回复并关闭。
+
 ## Credits
 
 - 感谢 @tianxia3111 提交 Issue #133 的生产压缩空窗与移动端可读性需求。

--- a/docs/release-readiness.en.md
+++ b/docs/release-readiness.en.md
@@ -2,7 +2,7 @@
 
 [中文](release-readiness.md) | [English](release-readiness.en.md)
 
-Current release candidate: `4.0.12`. It fixes Issues #133/#136 by keeping context compaction visible, adding PC/mobile mappings for five text-size roles, and making selected-env credentials and Noop degradation verifiable and diagnosable. V3.9.1 was released on 2026-07-11, and V4.0.11 and earlier releases are public.
+Current public release: `4.0.12`. It fixes Issues #133/#136 by keeping context compaction visible, adding PC/mobile mappings for five text-size roles, and making selected-env credentials and Noop degradation verifiable and diagnosable. V3.9.1 was released on 2026-07-11, and V4.0.11 and earlier releases are public.
 
 ## Ready
 
@@ -151,7 +151,7 @@ The `v3.9.0` release-assets workflow publishes four assets: the macOS tarball, L
 - A real selected-env subprocess starts as `healthy/live`; a credential-free subprocess starts as `degraded/noop`, returns `not_sent`, and does not increase successes: **passed**.
 - Automatic long-session compaction smoke and final desktop/mobile visual confirmation: **not run by release decision and not claimed as passed**.
 - Final full automation: **passed (`1460 passed, 4 skipped`)**; `git diff --check`, sdist/wheel, and clean Python 3.12 import `4.0.12` also passed.
-- Annotated tag, Release assets/checksums, and public tagged installer: **pending post-tag verification**.
+- Annotated tag `v4.0.12` points to merge commit `00a48a7`; release-assets workflow `29632908140` succeeded, and all four assets/checksums plus the public tagged installer: **passed**.
 
 ## Current Boundaries
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -2,7 +2,7 @@
 
 [中文](release-readiness.md) | [English](release-readiness.en.md)
 
-当前候选包版本为 `4.0.12`。它修复 Issues #133/#136：上下文压缩阶段保持卡片可见，五类文本支持 PC/mobile 字号映射，并让 selected-env 凭据和 Noop 降级状态可验证、可诊断。V3.9.1 已于 2026-07-11 发布，V4.0.11 及更早版本也已发布。
+当前已发布版本为 `4.0.12`。它修复 Issues #133/#136：上下文压缩阶段保持卡片可见，五类文本支持 PC/mobile 字号映射，并让 selected-env 凭据和 Noop 降级状态可验证、可诊断。V3.9.1 已于 2026-07-11 发布，V4.0.11 及更早版本也已发布。
 
 ## 已具备
 
@@ -151,7 +151,7 @@ python3 -m hermes_feishu_card.cli restore --hermes-dir ~/.hermes/hermes-agent --
 - selected env 真实子进程启动为 `healthy/live`；缺凭据子进程为 `degraded/noop`，发送 `not_sent` 且 success 不增加：**已通过**。
 - 自动压缩长会话 smoke 与桌面/移动端最终视觉确认：**按发布决定未执行，不写成已通过**。
 - 最终全量自动化：**已通过（`1460 passed, 4 skipped`）**；`git diff --check`、sdist/wheel 和干净 Python 3.12 import `4.0.12` 均通过。
-- annotated tag、Release assets/checksums 和公共 tagged installer：**待 tag 后验证**。
+- annotated tag `v4.0.12` 指向合并提交 `00a48a7`；release-assets workflow `29632908140` 成功，四个 assets/checksums 与公共 tagged installer：**已通过**。
 
 ## 当前边界
 

--- a/docs/wiki/feishu-acceptance.md
+++ b/docs/wiki/feishu-acceptance.md
@@ -11,7 +11,7 @@
 - 桌面端与移动端分别检查 `body`、`reasoning`、`tool`、`notice`、`footer` 的 scalar 和 `pc`/`mobile` 映射，覆盖长中文、代码块、表格、深色模式与 streaming-to-terminal；不得出现 `hfc_*` 可见文本或跨 bot 字号污染。
 - 卡片物理 width/height 不在验收范围，由 Feishu/Lark 客户端控制。
 
-2026-07-18 发布候选验收边界：已通过官方 setup/patcher 将候选 runtime 装入真实 Hermes，`doctor` 确认 `status_callback` capability 与 install state 一致；真实 Feishu 字号演示卡完成 create + update，五类 alias 均进入 Card JSON。手动 `/compress` 不经过 `_status_callback_sync`，因此不作为自动压缩 callback 证据；按发布决定不再执行自动压缩长会话 smoke，也不宣称桌面/移动端视觉验收完成。Issue #136 的 selected-env live/noop 分支由真实子进程集成测试覆盖；报告者的 Linux/systemd 环境仍邀请发布后复验。
+2026-07-18 发布候选验收边界：已通过官方 setup/patcher 将候选 runtime 装入真实 Hermes，`doctor` 确认 `status_callback` capability 与 install state 一致；真实 Feishu 字号演示卡完成 create + update，五类 alias 均进入 Card JSON。手动 `/compress` 不经过 `_status_callback_sync`，因此不作为自动压缩 callback 证据；按发布决定不再执行自动压缩长会话 smoke，也不宣称桌面/移动端视觉验收完成。Issue #136 的 selected-env live/noop 分支由真实子进程集成测试覆盖；报告者的 Linux/systemd 环境仍邀请发布后复验。发布后进一步确认 annotated tag `v4.0.12` 指向 `00a48a7`，四个 assets/checksums 与公共 tagged installer 均通过；这些发布验证不扩大上述真实客户端验收结论。
 
 ## V4.0.11 system.notice 可靠投递（发布候选验收）
 


### PR DESCRIPTION
## Summary
- mark v4.0.12 as released in TODO and readiness docs
- record the annotated tag, successful release-assets workflow, checksum verification, and public tagged install
- retain the explicit boundary that automatic long-session compaction, final desktop/mobile visual acceptance, and reporter-side Linux/systemd revalidation were not performed
- record that Issues #133 and #136 were closed with those boundaries

## Verification
- `python -m pytest tests/unit/test_docs.py tests/unit/test_package_metadata.py -q` → `63 passed`
- `git diff --check`