### PR TITLE
feat: true multi-select for clarify via [hfc:multi-select] question prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Hermes 飞书流式卡片插件把 Hermes Agent Gateway 的飞书/Lark 回复变
 - **一张持续更新的飞书卡片**：`thinking.delta`、`answer.delta`、`tool.updated`、`message.completed` 会合并到同一张卡片。
 - **运行态 Header 看见当前动作**：Header title 保留用户自定义标题（默认 `Hermes Agent`），subtitle 将工具名与 `tool.updated.detail` 整理为实时动作摘要；完整命令留在 timeline。
 - **主答案和过程分区**：最终答案留在正文区，pre-tool answer、工具调用、系统 notice 进入“思考与工具” timeline。
-- **卡片内交互**：approval / clarify choices 渲染为按钮；`/new`、`/reset`、`/undo`、`/model` 等独立命令使用原生 interactive card。V4 的 `/model` 与 Hermes CLI 使用同一 Provider/模型列表，按 Provider → Model 两级选择，不再把全部模型挤进一个下拉框。
+- **卡片内交互**：approval / clarify choices 渲染为按钮；带 `[hfc:multi-select]` 前缀的 clarify 可渲染为 `multi_select_static + submit` 真多选卡并返回稳定值数组；`/new`、`/reset`、`/undo`、`/model` 等独立命令使用原生 interactive card。V4 的 `/model` 与 Hermes CLI 使用同一 Provider/模型列表，按 Provider → Model 两级选择，不再把全部模型挤进一个下拉框。
 - **飞书话题与提示可靠投递**：话题事件通过 `reply_to_message_id` 回到原卡片；初始卡片使用稳定 UUID 有界重试，确定未发送才回退原文，结果不明只发通用提示，避免重复外溢。
 - **群聊诊断更清楚**：`/hfc status` 会提示群内 chat binding 状态、绑定命令和 slash command 行为边界。
 - **运维卡有明确边界**：`/hfc doctor` 可给出诊断、两步安全修复和重启确认；私聊不比较操作者，群聊只允许发起者确认。运维卡不可用时继续使用 CLI，不改变普通流式卡的 layout 或 footer。

--- a/docs/wiki/event-flow.md
+++ b/docs/wiki/event-flow.md
@@ -184,6 +184,12 @@ V3.10.0 的 command-card adapter hook 会在运行时包装 runner 的 `_handle_
 
 Agent 任务内的 `interaction.requested` 会渲染为当前 streaming card 里的按钮。
 
+HFC 还支持在不修改 Hermes `clarify` schema 的前提下请求真正多选：question 以
+`[hfc:multi-select]` 开头，choices 使用 `显示名::稳定值`。hook 会移除内部前缀，
+把选项渲染为 Card JSON 2.0 的 `form + multi_select_static + submit`，完成后向
+Hermes 返回稳定值 JSON 数组。空选择、未知值和重复提交不会重复完成 interaction；
+多选卡不可用时返回明确 sentinel，由 agent 回退普通文字，不降级成原生单选。
+
 HTTP callback 可达时，Feishu/Lark 直接 POST 到 sidecar `/card/actions`。在 WebSocket 长连接或本地/private sidecar 场景中，按钮点击会先到 Hermes Feishu adapter 的原生 card-action channel，再由 hook runtime 接管 `interaction.select` 并转发到 sidecar `/card/actions`。
 
 关键边界：
@@ -191,6 +197,8 @@ HTTP callback 可达时，Feishu/Lark 直接 POST 到 sidecar `/card/actions`。
 - sidecar 仍负责校验 `interaction_id` 和 callback token。
 - callback payload 带 `open_chat_id` 时，sidecar 还会确认 chat id 与 active session 匹配。
 - 成功后 sidecar 记录 `interaction.completed`，Hermes hook 轮询 `/interactions/{interaction_id}` 后继续执行。
+- 多选提交从 `action.form_value.hfc_choices` 读取数组，并逐项对照当前
+  interaction options 白名单校验。
 - sidecar 拒绝、超时或没有返回 card 时，hook 返回空 Feishu callback response，避免崩溃或落入未知原生 handler。
 
 ## 群聊边界

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -3258,6 +3258,7 @@ def _hfc_on_feishu_card_action_trigger(self: Any, data: Any) -> Any:
         "model_picker",
         "resume_picker",
         "interaction.select",
+        "interaction.multi_select",
     ):
         if _hfc_is_duplicate_card_action(self, data):
             return _hfc_empty_feishu_callback_response(self)
@@ -3269,6 +3270,8 @@ def _hfc_on_feishu_card_action_trigger(self: Any, data: Any) -> Any:
     if action == "resume_picker":
         return _hfc_handle_native_resume_action(self, data, action_value)
     if action == "interaction.select":
+        return _hfc_handle_interaction_select_action(self, data, action_value)
+    if action == "interaction.multi_select":
         return _hfc_handle_interaction_select_action(self, data, action_value)
     if action == "operations.select":
         return _hfc_handle_operations_select_action(self, data, action_value)
@@ -3419,13 +3422,18 @@ def _hfc_handle_interaction_select_action(
     so the Hermes hook polling ``/interactions/{id}`` unblocks), and return the
     sidecar's updated card so Feishu updates the card in place.
     """
-    _hfc_info("inline card action received: interaction.select")
+    action = str(action_value.get("hfc_action") or "interaction.select").strip()
+    is_multi_select = action == "interaction.multi_select"
+    _hfc_info(f"inline card action received: {action}")
     interaction_id = str(action_value.get("interaction_id") or "").strip()
     token = str(action_value.get("token") or "").strip()
     choice = str(action_value.get("choice") or action_value.get("hfc_choice") or "").strip()
     choice_label = str(action_value.get("choice_label") or choice).strip()
-    if not interaction_id or not token or not choice:
-        _hfc_info("interaction.select ignored: missing interaction_id/token/choice")
+    form_choices = _hfc_multi_select_choices_from_data(data) if is_multi_select else []
+    if not interaction_id or not token or (is_multi_select and not form_choices) or (
+        not is_multi_select and not choice
+    ):
+        _hfc_info(f"{action} ignored: missing interaction_id/token/choice")
         return _hfc_empty_feishu_callback_response(adapter)
 
     chat_id = _hfc_action_chat_id(data)
@@ -3446,17 +3454,20 @@ def _hfc_handle_interaction_select_action(
     if open_id:
         operator_payload["open_id"] = open_id
 
+    forwarded_value = {
+        "hfc_action": action,
+        "interaction_id": interaction_id,
+        "token": token,
+    }
+    forwarded_action: dict[str, Any] = {"value": forwarded_value}
+    if is_multi_select:
+        forwarded_action["form_value"] = {"hfc_choices": form_choices}
+    else:
+        forwarded_value["choice"] = choice
+        forwarded_value["choice_label"] = choice_label
     sidecar_payload = {
         "event": {
-            "action": {
-                "value": {
-                    "hfc_action": "interaction.select",
-                    "interaction_id": interaction_id,
-                    "choice": choice,
-                    "choice_label": choice_label,
-                    "token": token,
-                }
-            },
+            "action": forwarded_action,
             "context": {"open_chat_id": chat_id},
             "operator": operator_payload,
         }
@@ -3468,14 +3479,29 @@ def _hfc_handle_interaction_select_action(
         url = f"{base_url}/card/actions"
         result = _post_json_sync_response(url, sidecar_payload, 5.0)
     except Exception as exc:
-        _hfc_warn(f"interaction.select forward failed: {exc.__class__.__name__}: {exc}")
+        _hfc_warn(f"{action} forward failed: {exc.__class__.__name__}: {exc}")
         return _hfc_empty_feishu_callback_response(adapter)
 
     if isinstance(result, dict) and isinstance(result.get("card"), dict):
-        _hfc_info(f"interaction.select resolved: interaction_id={interaction_id!r}")
+        _hfc_info(f"{action} resolved: interaction_id={interaction_id!r}")
         return _hfc_raw_feishu_callback_response(adapter, result["card"])
-    _hfc_info("interaction.select forwarded but no card returned")
+    _hfc_info(f"{action} forwarded but no card returned")
     return _hfc_empty_feishu_callback_response(adapter)
+
+
+def _hfc_multi_select_choices_from_data(data: Any) -> list[str]:
+    event_obj = getattr(data, "event", None)
+    action_obj = getattr(event_obj, "action", None)
+    form_value = getattr(action_obj, "form_value", {}) or {}
+    raw_choices = form_value.get("hfc_choices") if isinstance(form_value, dict) else None
+    if not isinstance(raw_choices, list):
+        return []
+    choices: list[str] = []
+    for item in raw_choices:
+        normalized = str(item).strip()
+        if normalized and normalized not in choices:
+            choices.append(normalized)
+    return choices
 
 
 def _hfc_resolve_native_slash_action(
@@ -4117,6 +4143,16 @@ async def _hfc_handle_feishu_card_action_event(self: Any, data: Any) -> None:
             action_value,
         )
         return
+    if action == "interaction.multi_select":
+        if _hfc_is_duplicate_card_action(self, data):
+            return
+        await asyncio.to_thread(
+            _hfc_handle_interaction_select_action,
+            self,
+            data,
+            action_value,
+        )
+        return
     if action == "operations.select":
         _hfc_info("background operations.select claimed by HFC")
         return
@@ -4446,6 +4482,10 @@ def install_feishu_command_card_adapter_methods(runner: Any, event: Any = None) 
         return False
 
 
+_HFC_MULTI_SELECT_QUESTION_PREFIX = "[hfc:multi-select]"
+_HFC_MULTI_SELECT_CHOICE_SEPARATOR = "::"
+
+
 def request_clarify_response_from_hermes_locals(
     local_vars: dict[str, Any],
     *,
@@ -4456,14 +4496,26 @@ def request_clarify_response_from_hermes_locals(
 ) -> str | None:
     if not choices:
         return None
+    normalized_question = str(question or "请选择").strip()
+    is_multi_select = normalized_question.startswith(_HFC_MULTI_SELECT_QUESTION_PREFIX)
+    if is_multi_select:
+        normalized_question = normalized_question[
+            len(_HFC_MULTI_SELECT_QUESTION_PREFIX) :
+        ].strip() or "请选择"
     options = []
     for index, choice in enumerate(list(choices)):
         label = str(choice).strip()
+        value = label
+        if is_multi_select and _HFC_MULTI_SELECT_CHOICE_SEPARATOR in label:
+            label, value = (
+                part.strip()
+                for part in label.split(_HFC_MULTI_SELECT_CHOICE_SEPARATOR, 1)
+            )
         if label:
             options.append(
                 {
                     "label": label,
-                    "value": label,
+                    "value": value,
                     "style": "primary" if index == 0 else "default",
                 }
             )
@@ -4471,15 +4523,22 @@ def request_clarify_response_from_hermes_locals(
         return None
     result = request_interaction_from_hermes_locals(
         local_vars,
-        kind="clarify",
+        kind="multi_select" if is_multi_select else "clarify",
         interaction_id=interaction_id,
-        prompt=str(question or "请选择").strip(),
+        prompt=normalized_question,
         options=options,
         timeout_seconds=timeout_seconds,
     )
     if isinstance(result, dict) and result.get("status") == "completed":
+        if is_multi_select:
+            selected = result.get("choices")
+            if isinstance(selected, list) and selected:
+                values = [str(item).strip() for item in selected if str(item).strip()]
+                return json.dumps(values, ensure_ascii=False) if values else None
         choice = str(result.get("choice") or "").strip()
         return choice or None
+    if is_multi_select:
+        return "[hfc multi-select unavailable; ask the user to reply with text]"
     return None
 
 

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -335,6 +335,54 @@ def _render_interaction_elements(
             )
         return elements
 
+    if interaction.status == "pending" and interaction.kind == "multi_select":
+        elements.append(
+            {
+                "tag": "form",
+                "name": "hfc_multi_select_form",
+                "element_id": "interaction_multi_select_form",
+                "elements": [
+                    {
+                        "tag": "multi_select_static",
+                        "name": "hfc_choices",
+                        "element_id": "interaction_multi_select_choices",
+                        "required": True,
+                        "options": [
+                            {
+                                "text": {
+                                    "tag": "plain_text",
+                                    "content": option.label,
+                                },
+                                "value": option.value,
+                            }
+                            for option in interaction.options
+                        ],
+                    },
+                    {
+                        "tag": "button",
+                        "name": "hfc_multi_select_submit",
+                        "element_id": "interaction_multi_select_submit",
+                        "text": {"tag": "plain_text", "content": "确认选择"},
+                        "type": "primary",
+                        "size": "medium",
+                        "width": "default",
+                        "form_action_type": "submit",
+                        "behaviors": [
+                            {
+                                "type": "callback",
+                                "value": {
+                                    "hfc_action": "interaction.multi_select",
+                                    "interaction_id": interaction.interaction_id,
+                                    "token": interaction.callback_token,
+                                },
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+        return elements
+
     if interaction.status == "pending":
         for index, option in enumerate(interaction.options):
             elements.append(
@@ -362,7 +410,10 @@ def _render_interaction_elements(
         return elements
 
     if interaction.status == "completed":
-        choice = interaction.choice_label or interaction.choice or "已完成"
+        if interaction.kind == "multi_select":
+            choice = "、".join(interaction.choice_labels or interaction.choices) or "已完成"
+        else:
+            choice = interaction.choice_label or interaction.choice or "已完成"
         user = f" by {interaction.user_name}" if interaction.user_name else ""
         content = f"已选择：{choice}{user}"
     else:

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -414,9 +414,12 @@ async def _interaction_action(
 ) -> web.Response:
     interaction_id = str(value.get("interaction_id") or "").strip()
     token = str(value.get("token") or "").strip()
+    is_multi_select = str(value.get("hfc_action") or "").strip() == (
+        "interaction.multi_select"
+    )
     choice = str(value.get("choice") or "").strip()
     choice_label = str(value.get("choice_label") or choice).strip()
-    if not interaction_id or not token or not choice:
+    if not interaction_id or not token or (not is_multi_select and not choice):
         return web.json_response({"ok": False, "error": "invalid action"}, status=400)
 
     callback_chat_id = _extract_callback_chat_id(payload)
@@ -424,13 +427,43 @@ async def _interaction_action(
     if found is None:
         return web.json_response({"ok": False, "error": "interaction not found"}, status=404)
     session_key, session = found
+    if (
+        session.active_interaction is not None
+        and session.active_interaction.status == "completed"
+    ):
+        return web.json_response(
+            {
+                "ok": True,
+                "toast": {"type": "success", "content": "已选择"},
+                "card": _render_session_card(request, session),
+            }
+        )
     user_name = _extract_operator_name(payload)
-    data = {
-        "interaction_id": interaction_id,
-        "choice": choice,
-        "choice_label": choice_label,
-        "user_name": user_name,
-    }
+    if is_multi_select:
+        interaction = session.active_interaction
+        if interaction is None or interaction.kind != "multi_select":
+            return web.json_response(
+                {"ok": False, "error": "invalid action"}, status=400
+            )
+        selected = _extract_multi_select_choices(payload)
+        allowed_labels = {option.value: option.label for option in interaction.options}
+        if not selected or any(item not in allowed_labels for item in selected):
+            return web.json_response(
+                {"ok": False, "error": "invalid selection"}, status=400
+            )
+        data = {
+            "interaction_id": interaction_id,
+            "choices": selected,
+            "choice_labels": [allowed_labels[item] for item in selected],
+            "user_name": user_name,
+        }
+    else:
+        data = {
+            "interaction_id": interaction_id,
+            "choice": choice,
+            "choice_label": choice_label,
+            "user_name": user_name,
+        }
     if ":" in session_key:
         data["profile_id"] = session_key.split(":", 1)[0]
     event = SidecarEvent(
@@ -2380,12 +2413,21 @@ def _store_interaction_result(app: web.Application, session: CardSession) -> Non
     interaction = session.active_interaction
     if interaction is None:
         return
-    app[INTERACTION_RESULTS_KEY][interaction.interaction_id] = {
-        "interaction_id": interaction.interaction_id,
-        "status": interaction.status,
-        "choice": interaction.choice,
-        "choice_label": interaction.choice_label,
-    }
+    if interaction.kind == "multi_select":
+        result = {
+            "interaction_id": interaction.interaction_id,
+            "status": interaction.status,
+            "choices": interaction.choices,
+            "choice_labels": interaction.choice_labels,
+        }
+    else:
+        result = {
+            "interaction_id": interaction.interaction_id,
+            "status": interaction.status,
+            "choice": interaction.choice,
+            "choice_label": interaction.choice_label,
+        }
+    app[INTERACTION_RESULTS_KEY][interaction.interaction_id] = result
     app[INTERACTION_RESULT_SESSION_KEYS_KEY][interaction.interaction_id] = (
         _session_key_for_session(app, session)
     )
@@ -2400,6 +2442,23 @@ def _extract_action_value(payload: dict[str, Any]) -> dict[str, Any]:
     action = payload.get("action") if isinstance(payload, dict) else None
     value = action.get("value") if isinstance(action, dict) else None
     return value if isinstance(value, dict) else {}
+
+
+def _extract_multi_select_choices(payload: dict[str, Any]) -> list[str]:
+    event = payload.get("event") if isinstance(payload, dict) else None
+    action = event.get("action") if isinstance(event, dict) else None
+    if not isinstance(action, dict):
+        action = payload.get("action") if isinstance(payload, dict) else None
+    form_value = action.get("form_value") if isinstance(action, dict) else None
+    raw_choices = form_value.get("hfc_choices") if isinstance(form_value, dict) else None
+    if not isinstance(raw_choices, list):
+        return []
+    choices: list[str] = []
+    for item in raw_choices:
+        normalized = str(item).strip()
+        if normalized and normalized not in choices:
+            choices.append(normalized)
+    return choices
 
 
 def _extract_callback_chat_id(payload: dict[str, Any]) -> str:

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -54,6 +54,8 @@ class InteractionState:
     callback_token: str = ""
     choice: str = ""
     choice_label: str = ""
+    choices: list[str] = field(default_factory=list)
+    choice_labels: list[str] = field(default_factory=list)
     user_name: str = ""
     error: str = ""
 
@@ -352,6 +354,18 @@ class CardSession:
         self.active_interaction.choice_label = str(
             data.get("choice_label") or self.active_interaction.choice
         ).strip()
+        choices = data.get("choices")
+        self.active_interaction.choices = (
+            [str(item).strip() for item in choices if str(item).strip()]
+            if isinstance(choices, list)
+            else []
+        )
+        choice_labels = data.get("choice_labels")
+        self.active_interaction.choice_labels = (
+            [str(item).strip() for item in choice_labels if str(item).strip()]
+            if isinstance(choice_labels, list)
+            else []
+        )
         self.active_interaction.user_name = str(data.get("user_name") or "").strip()
 
     def _fail_interaction(self, data: dict[str, Any]) -> None:

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -4763,6 +4763,131 @@ async def test_interaction_request_renders_buttons_and_callback_resolves(client)
     assert "已选择：允许一次" in str(feishu_client.updated[-1][1])
 
 
+async def test_multi_select_interaction_submit_returns_stable_values(client):
+    test_client, feishu_client = client
+
+    await test_client.post("/events", json=event_payload("message.started", 0))
+    requested = await test_client.post(
+        "/events",
+        json=event_payload(
+            "interaction.requested",
+            1,
+            {
+                "interaction_id": "materials-1",
+                "kind": "multi_select",
+                "prompt": "请选择接待物料",
+                "options": [
+                    {"label": "水牌", "value": "water_sign"},
+                    {"label": "会议桌签", "value": "table_card"},
+                    {"label": "会议用纸", "value": "meeting_paper"},
+                ],
+            },
+        ),
+    )
+    assert requested.status == 200
+
+    interaction_card = feishu_client.updated[-1][1]
+    form = next(
+        element
+        for element in interaction_card["body"]["elements"]
+        if element.get("tag") == "form"
+    )
+    submit = next(
+        element for element in form["elements"] if element.get("tag") == "button"
+    )
+    action_value = submit["behaviors"][0]["value"]
+
+    callback_payload = {
+        "event": {
+            "operator": {"open_id": "ou_bailey", "name": "Bailey"},
+            "context": {"open_chat_id": "oc_abc"},
+            "action": {
+                "value": action_value,
+                "form_value": {
+                    "hfc_choices": ["water_sign", "table_card"],
+                },
+            },
+        }
+    }
+    callback = await test_client.post(
+        "/card/actions",
+        json=callback_payload,
+    )
+    result = await test_client.get("/interactions/materials-1")
+
+    assert callback.status == 200
+    assert (await callback.json())["ok"] is True
+    assert result.status == 200
+    assert await result.json() == {
+        "ok": True,
+        "status": "completed",
+        "choices": ["water_sign", "table_card"],
+        "choice_labels": ["水牌", "会议桌签"],
+        "interaction_id": "materials-1",
+    }
+    completed_card = str(feishu_client.updated[-1][1])
+    assert "已选择：水牌、会议桌签" in completed_card
+
+    updates_after_first_submit = len(feishu_client.updated)
+    duplicate = await test_client.post("/card/actions", json=callback_payload)
+    assert duplicate.status == 200
+    assert (await duplicate.json())["ok"] is True
+    assert len(feishu_client.updated) == updates_after_first_submit
+
+
+@pytest.mark.parametrize("selected", [[], ["unknown_material"]])
+async def test_multi_select_interaction_rejects_empty_or_unknown_values(
+    client, selected
+):
+    test_client, feishu_client = client
+
+    await test_client.post("/events", json=event_payload("message.started", 0))
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "interaction.requested",
+            1,
+            {
+                "interaction_id": "materials-invalid",
+                "kind": "multi_select",
+                "prompt": "请选择接待物料",
+                "options": [
+                    {"label": "水牌", "value": "water_sign"},
+                    {"label": "会议桌签", "value": "table_card"},
+                ],
+            },
+        ),
+    )
+    interaction_card = feishu_client.updated[-1][1]
+    form = next(
+        element
+        for element in interaction_card["body"]["elements"]
+        if element.get("tag") == "form"
+    )
+    submit = next(
+        element for element in form["elements"] if element.get("tag") == "button"
+    )
+
+    callback = await test_client.post(
+        "/card/actions",
+        json={
+            "event": {
+                "context": {"open_chat_id": "oc_abc"},
+                "action": {
+                    "value": submit["behaviors"][0]["value"],
+                    "form_value": {"hfc_choices": selected},
+                },
+            }
+        },
+    )
+    result = await test_client.get("/interactions/materials-invalid")
+
+    assert callback.status == 400
+    assert (await callback.json()) == {"ok": False, "error": "invalid selection"}
+    assert (await result.json())["status"] == "pending"
+    assert "multi_select_static" in str(feishu_client.updated[-1][1])
+
+
 def test_interaction_operator_name_never_falls_back_to_feishu_ids():
     assert sidecar_server._extract_operator_name(
         {"event": {"operator": {"open_id": "ou_private", "user_id": "on_private"}}}

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -3982,6 +3982,64 @@ def test_request_interaction_returns_none_for_text_fallback_mode(monkeypatch):
     assert result is None
 
 
+def test_clarify_multi_select_marker_returns_stable_values(monkeypatch):
+    captured = {}
+
+    def fake_request(local_vars, **kwargs):
+        captured.update(kwargs)
+        return {
+            "ok": True,
+            "status": "completed",
+            "choices": ["water_sign", "table_card"],
+            "choice_labels": ["水牌", "会议桌签"],
+        }
+
+    monkeypatch.setattr(
+        hook_runtime,
+        "request_interaction_from_hermes_locals",
+        fake_request,
+    )
+
+    result = hook_runtime.request_clarify_response_from_hermes_locals(
+        {},
+        interaction_id="materials-1",
+        question="[hfc:multi-select]请选择接待物料",
+        choices=[
+            "水牌::water_sign",
+            "会议桌签::table_card",
+            "会议用纸::meeting_paper",
+            "台卡::desk_card",
+        ],
+    )
+
+    assert json.loads(result) == ["water_sign", "table_card"]
+    assert captured["kind"] == "multi_select"
+    assert captured["prompt"] == "请选择接待物料"
+    assert captured["options"] == [
+        {"label": "水牌", "value": "water_sign", "style": "primary"},
+        {"label": "会议桌签", "value": "table_card", "style": "default"},
+        {"label": "会议用纸", "value": "meeting_paper", "style": "default"},
+        {"label": "台卡", "value": "desk_card", "style": "default"},
+    ]
+
+
+def test_clarify_multi_select_does_not_fall_back_to_native_single_select(monkeypatch):
+    monkeypatch.setattr(
+        hook_runtime,
+        "request_interaction_from_hermes_locals",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = hook_runtime.request_clarify_response_from_hermes_locals(
+        {},
+        interaction_id="materials-1",
+        question="[hfc:multi-select]请选择接待物料",
+        choices=["水牌::water_sign", "会议桌签::table_card"],
+    )
+
+    assert result == "[hfc multi-select unavailable; ask the user to reply with text]"
+
+
 def test_request_interaction_polls_through_transient_not_found(monkeypatch):
     polls = iter(
         [
@@ -6322,6 +6380,77 @@ def test_interaction_select_forwards_to_sidecar_and_returns_card(monkeypatch):
     }
     assert sent["context"]["open_chat_id"] == "oc_abc"
     assert sent["operator"] == {"name": "Bailey", "open_id": "ou_user"}
+    assert response.card.type == "raw"
+    assert response.card.data["header"]["template"] == "green"
+
+
+def test_interaction_multi_select_forwards_form_values_to_sidecar(monkeypatch):
+    class FakeCallBackCard:
+        def __init__(self):
+            self.type = None
+            self.data = None
+
+    class FakeP2Response:
+        def __init__(self):
+            self.card = None
+
+    class DummyFeishuAdapter:
+        name = "feishu"
+
+        def __init__(self):
+            self._loop = object()
+
+        def _on_card_action_trigger(self, data):
+            return "original"
+
+    DummyFeishuAdapter.__module__ = hook_runtime.__name__
+    monkeypatch.setattr(
+        hook_runtime, "P2CardActionTriggerResponse", FakeP2Response, raising=False
+    )
+    monkeypatch.setattr(hook_runtime, "CallBackCard", FakeCallBackCard, raising=False)
+
+    posted = {}
+
+    def fake_post(url, payload, timeout):
+        posted["url"] = url
+        posted["payload"] = payload
+        return {"ok": True, "card": {"header": {"template": "green"}}}
+
+    monkeypatch.setattr(hook_runtime, "_post_json_sync_response", fake_post)
+    monkeypatch.setattr(
+        hook_runtime,
+        "load_runtime_config",
+        lambda: SimpleNamespace(event_url="http://127.0.0.1:8765/events"),
+    )
+
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            action=SimpleNamespace(
+                value={
+                    "hfc_action": "interaction.multi_select",
+                    "interaction_id": "materials-1",
+                    "token": "tok-1",
+                },
+                form_value={"hfc_choices": ["water_sign", "table_card"]},
+            ),
+            context=SimpleNamespace(open_chat_id="oc_abc"),
+            operator=SimpleNamespace(open_id="ou_user", user_name="Bailey"),
+        )
+    )
+
+    response = hook_runtime._hfc_on_feishu_card_action_trigger(
+        DummyFeishuAdapter(), data
+    )
+
+    assert posted["url"] == "http://127.0.0.1:8765/card/actions"
+    assert posted["payload"]["event"]["action"] == {
+        "value": {
+            "hfc_action": "interaction.multi_select",
+            "interaction_id": "materials-1",
+            "token": "tok-1",
+        },
+        "form_value": {"hfc_choices": ["water_sign", "table_card"]},
+    }
     assert response.card.type == "raw"
     assert response.card.data["header"]["template"] == "green"
 

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -451,6 +451,66 @@ def test_render_pending_interaction_as_buttons():
     assert "rm -rf /tmp/demo" in str(card)
 
 
+def test_render_pending_multi_select_as_form_with_submit():
+    from hermes_feishu_card.events import SidecarEvent
+
+    session = CardSession(conversation_id="chat-1", message_id="msg-1", chat_id="oc_abc")
+    session.apply(
+        SidecarEvent(
+            schema_version="1",
+            event="interaction.requested",
+            conversation_id="chat-1",
+            message_id="msg-1",
+            chat_id="oc_abc",
+            platform="feishu",
+            sequence=1,
+            created_at=0.0,
+            data={
+                "interaction_id": "materials-1",
+                "kind": "multi_select",
+                "prompt": "请选择接待物料",
+                "options": [
+                    {"label": "水牌", "value": "water_sign"},
+                    {"label": "会议桌签", "value": "table_card"},
+                ],
+            },
+        )
+    )
+
+    card = render_card(session)
+
+    form = next(
+        element for element in card["body"]["elements"] if element.get("tag") == "form"
+    )
+    selector = next(
+        element
+        for element in form["elements"]
+        if element.get("tag") == "multi_select_static"
+    )
+    submit = next(
+        element for element in form["elements"] if element.get("tag") == "button"
+    )
+    assert form["name"] == "hfc_multi_select_form"
+    assert selector["name"] == "hfc_choices"
+    assert selector["required"] is True
+    assert selector["options"] == [
+        {
+            "text": {"tag": "plain_text", "content": "水牌"},
+            "value": "water_sign",
+        },
+        {
+            "text": {"tag": "plain_text", "content": "会议桌签"},
+            "value": "table_card",
+        },
+    ]
+    assert submit["form_action_type"] == "submit"
+    assert submit["behaviors"][0]["value"] == {
+        "hfc_action": "interaction.multi_select",
+        "interaction_id": "materials-1",
+        "token": session.active_interaction.callback_token,
+    }
+
+
 def test_render_pending_interaction_as_text_choices_for_localhost_mode():
     from hermes_feishu_card.events import SidecarEvent
 


### PR DESCRIPTION
## Summary

This PR adds two features that let an agent request a **true multi-select** from a Feishu/Lark user through the existing `clarify` seam, without any change to the Hermes `clarify` schema:

### 1. `[hfc:multi-select]` protocol → real multi-select card

- A clarify whose question starts with the `[hfc:multi-select]` prefix is rendered as a Card JSON 2.0 `form + multi_select_static + submit` card instead of single-choice buttons. The internal prefix is stripped before display.
- Choices may use `label::value` to separate the display label from a stable value (e.g. `会议桌签::table_card`), so the agent gets machine-stable keys back regardless of display wording.
- On submit, the hook forwards `form_value.hfc_choices` to the sidecar `/card/actions`; the sidecar validates every submitted value against the interaction's option whitelist, and the completed interaction returns a **JSON array of stable values** to Hermes.
- Empty selections, unknown values and duplicate submissions never complete the interaction.

### 2. Explicit unavailability sentinel (no silent degradation)

- When the multi-select card cannot be delivered or the interaction does not complete, the hook returns the explicit sentinel `[hfc multi-select unavailable; ask the user to reply with text]` instead of `None` or a native single-select fallback.
- This gives the agent a deterministic signal to fall back to plain-text collection, and guarantees a multi-select request is never silently answered by a single choice.

## Production context

We run this in production for a reception-material pipeline where the agent asks the requester to pick any subset of four material types in one card; the stable-value array feeds directly into downstream task creation.

## Tests

- `tests/unit/test_hook_runtime.py`: prefix parsing, `label::value` splitting, stable-value array return, no-fallback-to-single-select, sentinel on unavailability.
- `tests/unit/test_render.py`: `form + multi_select_static + submit` rendering.
- `tests/integration/test_server.py`: submit returns stable values; empty/unknown values rejected.
- Full suite: **522 passed** locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)