### PR TITLE
docs: restore README cover rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <img alt="Sidecar only" src="https://img.shields.io/badge/Runtime-Sidecar--only-7C3AED?style=for-the-badge">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/baileyh8/hermes-feishu-streaming-card?style=for-the-badge&color=64748b"></a>
 </p>
+
 ![Hermes Feishu Streaming Card 封面](docs/assets/readme-cover.png)
 
 Hermes 飞书流式卡片插件把 Hermes Agent Gateway 的飞书/Lark 回复变成一张持续更新的交互式卡片。思考过程、工具调用、最终答案、授权确认、选项选择、系统提示和运行统计会收束在卡片内，而不是散落成多条灰色原生消息。<br><br>它面向真实飞书使用场景：流式内容漏字/乱序、长表格和代码块变成 raw markdown、工具过程不可见、approval/clarify 需要手工回复、话题里卡片不更新、多 bot / 多 profile 难排查，以及 Hermes 升级后 hook 兼容不确定。

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -69,7 +69,11 @@ def test_readme_documents_sidecar_only_and_supported_hermes_version():
     assert "thinking.delta" in readme
     assert "v2026.4.23" in readme
     assert "Git tag `v2026.4.23+`" in readme
-    assert len(readme.splitlines()) <= 260
+    assert (
+        "</p>\n\n"
+        "![Hermes Feishu Streaming Card 封面](docs/assets/readme-cover.png)"
+    ) in readme
+    assert len(readme.splitlines()) <= 261
     assert (ROOT / "docs/assets/readme-cover.png").exists()
     assert (ROOT / "docs/assets/feishu-card-showcase-v385.png").exists()
     assert (ROOT / "docs/assets/feishu-weather-card.png").exists()


### PR DESCRIPTION
## What changed

- restore the blank line that terminates the badge HTML block before the Markdown cover image
- add a regression assertion for the exact HTML-to-Markdown boundary
- allow the required syntactic blank line in the README length guard

## Root cause

The v4.0.14 release removed the blank line after `</p>` to stay within the README line-count guard. GitHub GFM therefore treated the following image Markdown as literal text inside the raw HTML block.

## Validation

- `python -m pytest tests/unit/test_docs.py -q`: 63 passed
- `git diff --check`
- GitHub Markdown API renders `docs/assets/readme-cover.png` as an `<img>` element

No runtime or release-version change.