### PR TITLE
feat: hermes_cli_gateway strategy — support Hermes v0.17+ (hermes_cli/gateway.py)

### DIFF
--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -2298,6 +2298,8 @@ def _run_install(args: argparse.Namespace) -> int:
                 return 1
             for action in recovery_result.actions:
                 print(action)
+    if detection.hook_strategy == "hermes_cli_gateway":
+        return _generate_bridge_files(detection)
 
     run_py = detection.run_py
     backup_path = _backup_path(run_py)
@@ -2375,6 +2377,65 @@ def _run_install(args: argparse.Namespace) -> int:
     print("install ok")
     if gateway_restart_required:
         print("gateway.restart_required: hermes gateway start")
+    return 0
+
+
+def _generate_bridge_files(detection: "HermesDetection") -> int:
+    """Generate bridge files for hermes_cli gateway (v0.17+).
+
+    Instead of patching gateway/run.py (which is dead code in v0.17+),
+    this creates a launcher script and bridge module that use Python
+    import hooks to patch FeishuAdapter.send at runtime.
+    """
+    import shutil
+
+    hermes_root = detection.root
+    bridge_src = Path(__file__).resolve().parent.parent / "hook_cli_bridge.py"
+    if not bridge_src.exists():
+        print(f"error: bridge module not found at {bridge_src}", file=sys.stderr)
+        return 1
+
+    # Determine user home for writing bridge files
+    user_home = Path(os.environ.get("HOME", str(Path.home())))
+    bridge_dest = user_home / ".hermes" / "feishu_card_bridge.py"
+    launcher_dest = user_home / ".hermes" / "gateway-launcher.py"
+
+    # Install bridge module
+    bridge_dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(bridge_src), str(bridge_dest))
+    bridge_dest.chmod(0o755)
+
+    # Create launcher script
+    launcher_content = f"""\
+#!/usr/bin/env python3
+\"\"\"Gateway launcher for Hermes v0.17+ with sidecar bridge.\"\"\"
+import sys
+import os
+bridge_path = r"{bridge_dest}"
+if bridge_path not in sys.path:
+    sys.path.insert(0, os.path.dirname(bridge_path))
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("feishu_card_bridge", bridge_path)
+    if spec and spec.loader:
+        spec.loader.exec_module(importlib.util.module_from_spec(spec))
+
+# Run the real gateway
+from hermes_cli.main import main
+sys.exit(main())
+"""
+    launcher_dest.write_text(launcher_content, encoding="utf-8")
+    launcher_dest.chmod(0o755)
+
+    print(f"bridge module installed: {bridge_dest}")
+    print(f"gateway launcher installed: {launcher_dest}")
+    print()
+    print("Installation for Hermes CLI gateway (v0.17+) requires:")
+    print("  1. Replace `hermes gateway run` with the launcher:")
+    print(f"     {launcher_dest} gateway run --replace")
+    print("  2. Set PYTHONPATH to include user site-packages")
+    print("  3. Ensure the sidecar is running on port 8765")
+    print()
+    print("See the README for post-install steps.")
     return 0
 
 

--- a/hermes_feishu_card/hook_cli_bridge.py
+++ b/hermes_feishu_card/hook_cli_bridge.py
@@ -1,0 +1,132 @@
+"""Hermes CLI Gateway Bridge — import-hook-based FeishuAdapter patching.
+
+For Hermes v0.17+ where the gateway runs from hermes_cli/gateway.py
+instead of the legacy gateway/run.py. This module is placed in the
+user site-packages and auto-imported via a launcher script.
+
+Monkey-patches FeishuAdapter.send() to POST message.completed events
+to the sidecar, which renders them as Feishu CardKit cards.
+"""
+
+import functools
+import http.client
+import json
+import logging
+import os
+import re
+import sys
+
+logger = logging.getLogger("hermes_feishu_card.cli_bridge")
+
+SIDECAR_HOST = "127.0.0.1"
+SIDECAR_PORT = 8765
+_patched = False
+_token = None
+
+
+def _discover_token() -> str | None:
+    """Read sidecar token from running process cmdline."""
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/cmdline", "rb") as f:
+                cmd = f.read().decode("utf-8", errors="replace")
+                if "hermes_feishu_card.runner" in cmd:
+                    m = re.search(r"--token\s+(\S+)", cmd)
+                    if m:
+                        return m.group(1)
+        except (OSError, PermissionError):
+            pass
+    return None
+
+
+def _post_event(event_type: str, **data) -> None:
+    """Fire-and-forget POST to sidecar /events."""
+    global _token
+    if _token is None:
+        _token = _discover_token()
+    try:
+        conn = http.client.HTTPConnection(
+            SIDECAR_HOST, SIDECAR_PORT, timeout=1
+        )
+        headers = {"Content-Type": "application/json"}
+        if _token:
+            headers["Authorization"] = f"Bearer {_token}"
+        payload = json.dumps({
+            "event": event_type,
+            "data": data,
+            "schema_version": 2,
+        })
+        conn.request("POST", "/events", body=payload, headers=headers)
+        conn.getresponse().read()
+        conn.close()
+    except Exception:
+        pass  # fail-open — sidecar down = plain text
+
+
+def _do_patch(adapter_module) -> bool:
+    """Patch FeishuAdapter.send on the given module."""
+    global _patched
+    FeishuAdapter = getattr(adapter_module, "FeishuAdapter", None)
+    if not FeishuAdapter:
+        return False
+
+    original_send = FeishuAdapter.send
+
+    @functools.wraps(original_send)
+    async def patched_send(self, chat_id, content, reply_to=None, metadata=None):
+        result = await original_send(
+            self, chat_id, content, reply_to, metadata
+        )
+        try:
+            mid = getattr(result, "message_id", "") if result else ""
+            _post_event(
+                "message.completed",
+                chat_id=chat_id,
+                content=content[:3000],
+                message_id=mid or "",
+                reply_to=reply_to or "",
+            )
+        except Exception:
+            pass
+        return result
+
+    FeishuAdapter.send = patched_send
+    _patched = True
+    return True
+
+
+def patch_feishu_adapter() -> bool:
+    """Find and patch FeishuAdapter.send among loaded modules."""
+    if _patched:
+        return True
+    target = None
+    for mod_name, mod in sorted(sys.modules.items(), key=lambda x: x[0]):
+        if mod_name == __name__ or not hasattr(mod, "FeishuAdapter"):
+            continue
+        target = mod
+        if "adapter" in mod_name:
+            break
+    if target is None:
+        return False
+    return _do_patch(target)
+
+
+if isinstance(__builtins__, dict):
+    _original_import = __builtins__["__import__"]
+else:
+    _original_import = __builtins__.__import__
+
+
+def _hook_import(name, *args, **kwargs):
+    result = _original_import(name, *args, **kwargs)
+    if not _patched and ("feishu" in name.lower() or "adapter" in name.lower()):
+        patch_feishu_adapter()
+    return result
+
+
+if isinstance(__builtins__, dict):
+    __builtins__["__import__"] = _hook_import
+else:
+    __builtins__.__import__ = _hook_import

--- a/hermes_feishu_card/install/detect.py
+++ b/hermes_feishu_card/install/detect.py
@@ -35,6 +35,8 @@ class HermesDetection:
     supported: bool
     reason: str
     hook_strategy: str = ""
+    hermes_cli_py: Path | None = None
+    hermes_cli_exists: bool = False
     cron_py: Path | None = None
     cron_py_exists: bool = False
     cron_hook_strategy: str = ""
@@ -48,6 +50,7 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     hermes_root = Path(root)
     run_py = hermes_root / "gateway" / "run.py"
     cron_py = hermes_root / "cron" / "scheduler.py"
+    hermes_cli_py = hermes_root / "hermes_cli" / "gateway.py"
     version, version_error, version_source = _read_version(hermes_root / "VERSION")
     if version == "unknown" and version_error is None:
         git_version = _read_git_version(hermes_root)
@@ -72,6 +75,8 @@ def detect_hermes(root: str | Path) -> HermesDetection:
             minimum_version=MIN_SUPPORTED_VERSION,
             run_py=run_py,
             run_py_exists=run_py.exists(),
+            hermes_cli_py=hermes_cli_py,
+            hermes_cli_exists=hermes_cli_py.exists(),
             supported=supported,
             reason=reason,
             hook_strategy=hook_strategy,
@@ -119,6 +124,31 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     if cron_error is not None:
         return result(False, cron_error)
 
+    # If hermes_cli/gateway.py exists, the gateway runs from the CLI module,
+    # not from gateway/run.py. Hooks in run.py would be dead code.
+    # This applies to v0.17+ (version >= 0.17 or version unknown from Docker).
+    if hermes_cli_py.exists():
+        parsed_version = _parse_version(version)
+        if parsed_version is None:
+            # Version unknown (e.g. Docker install without VERSION file).
+            # Assume v0.17+ if hermes_cli exists — the CLI gateway is present.
+            return result(
+                True,
+                "hermes_cli_gateway",
+                hook_strategy="hermes_cli_gateway",
+                compatibility="partial",
+                capabilities={},
+            )
+        if parsed_version >= (0, 17, 0):
+            # v0.17+ always uses hermes_cli gateway — run.py hooks are dead
+            return result(
+                True,
+                "hermes_cli_gateway",
+                hook_strategy="hermes_cli_gateway",
+                compatibility="partial",
+                capabilities={},
+            )
+
     capabilities, capability_error = _detect_capabilities(contents, cron_contents)
     core_ok = all(capabilities.get(name, False) for name in CORE_CAPABILITIES)
     optional_ok = all(capabilities.get(name, False) for name in OPTIONAL_CAPABILITIES)
@@ -129,6 +159,14 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     else:
         compatibility = "unsupported"
     if not core_ok:
+        # Still check hermes_cli as fallback (e.g. version detection failed)
+        if hermes_cli_py.exists():
+            return result(
+                True,
+                "hermes_cli_gateway (fallback)",
+                hook_strategy="hermes_cli_gateway",
+                compatibility="partial",
+            )
         return result(
             False,
             capability_error,

--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -39,13 +39,18 @@ HFC_COMMAND_PATCH_END = "# HERMES_FEISHU_CARD_HFC_COMMAND_PATCH_END"
 _HANDLER_NAME = "_handle_message_with_agent"
 _CRON_DELIVER_NAME = "_deliver_result"
 _NO_FINAL_NEWLINE = "# HERMES_FEISHU_CARD_NO_FINAL_NEWLINE"
-_SUPPORTED_STRATEGIES = {"legacy_gateway_run", "gateway_run_013_plus"}
+_SUPPORTED_STRATEGIES = {"legacy_gateway_run", "gateway_run_013_plus", "hermes_cli_gateway"}
 
 
 def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
     """Insert the Feishu card hook block into a safe Hermes message handler."""
     if strategy not in _SUPPORTED_STRATEGIES:
         raise ValueError(f"unsupported patch strategy: {strategy}")
+    if strategy == "hermes_cli_gateway":
+        # Hermes v0.17+ runs from hermes_cli/gateway.py, not gateway/run.py.
+        # Bridge files (launcher + hook module) are generated separately.
+        # Return content unmodified — run.py is not the active entry point.
+        return content
     content = _apply_start_patch(content, strategy=strategy)
     content = _apply_complete_patch(content, strategy=strategy)
     content = _apply_queued_complete_patch(content)


### PR DESCRIPTION
## Problem

Hermes v0.17+ restructured the gateway entry point from gateway/run.py to hermes_cli/gateway.py. The sidecar hook injection still targets gateway/run.py, making all injected hooks dead code. Streaming cards silently stop working.

See issue #158 for the full discussion.

## Solution

Adds a new hermes_cli_gateway strategy that:
1. Detection: detect_hermes() checks if hermes_cli/gateway.py exists. For v0.17+, returns hermes_cli_gateway strategy.
2. Patching: apply_patch() returns content unchanged for this strategy.
3. Bridge files: _generate_bridge_files() installs hook_cli_bridge.py + gateway-launcher.py.

## Files changed

- hermes_feishu_card/install/detect.py - hermes_cli gateway detection
- hermes_feishu_card/install/patcher.py - add hermes_cli_gateway strategy
- hermes_feishu_card/cli.py - _generate_bridge_files() for installation
- hermes_feishu_card/hook_cli_bridge.py - new import-hook bridge module