### PR TITLE
fix: target answer delta hook at native text stream callback

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -97,6 +97,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
             "_run_still_current",
         ),
         required_callback_args=("text",),
+        required_callback_calls=(("_stream_consumer", "on_delta"),),
     )
     content = _apply_callback_patch(
         content,
@@ -716,6 +717,7 @@ def _apply_callback_patch(
     renderer,
     required_outer_names=(),
     required_callback_args=(),
+    required_callback_calls=(),
 ) -> str:
     owned_block = _find_simple_marker_block(
         content,
@@ -726,6 +728,22 @@ def _apply_callback_patch(
     if owned_block is not None:
         lines = content.splitlines(keepends=True)
         begin_index, end_index = owned_block
+        if required_callback_calls:
+            # Hermes may define the same local callback name for multiple
+            # mutually-exclusive transports. Rebuild selector-sensitive
+            # blocks from the unpatched source so upgrades can relocate an
+            # older hook that landed in the wrong callback.
+            content = "".join(lines[:begin_index] + lines[end_index + 1 :])
+            return _apply_callback_patch(
+                content,
+                callback_name=callback_name,
+                begin_marker=begin_marker,
+                end_marker=end_marker,
+                renderer=renderer,
+                required_outer_names=required_outer_names,
+                required_callback_args=required_callback_args,
+                required_callback_calls=required_callback_calls,
+            )
         indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
         newline = _line_ending(lines[begin_index]) or _detect_newline(content)
         expected = renderer(indent, newline)
@@ -741,6 +759,7 @@ def _apply_callback_patch(
         callback_name,
         required_outer_names=required_outer_names,
         required_callback_args=required_callback_args,
+        required_callback_calls=required_callback_calls,
     )
     if callback_body is None:
         return content
@@ -1006,10 +1025,12 @@ def _find_callback_body_location(
     *,
     required_outer_names=(),
     required_callback_args=(),
+    required_callback_calls=(),
 ):
     run_agent = _find_run_agent_node(tree)
     if run_agent is None:
         return None
+    candidates = []
     for node in ast.walk(run_agent):
         if isinstance(node, ast.FunctionDef) and node.name == callback_name:
             if not _has_required_callback_scope(
@@ -1018,9 +1039,21 @@ def _find_callback_body_location(
                 required_outer_names,
                 required_callback_args,
             ):
-                return None
-            return _body_location(node, lines)
-    return None
+                continue
+            candidates.append(node)
+    if required_callback_calls:
+        preferred = [
+            node
+            for node in candidates
+            if _has_required_callback_calls(node, required_callback_calls)
+        ]
+        if preferred:
+            candidates = preferred
+        elif len(candidates) != 1:
+            return None
+    if not candidates:
+        return None
+    return _body_location(candidates[0], lines)
 
 
 def _find_stable_tool_lifecycle_location(tree, lines):
@@ -1068,6 +1101,19 @@ def _has_required_callback_scope(
     return set(required_outer_names).issubset(outer_names) and set(
         required_callback_args
     ).issubset(callback_args)
+
+
+def _has_required_callback_calls(callback, required_callback_calls) -> bool:
+    if not required_callback_calls:
+        return True
+    calls = {
+        (child.func.value.id, child.func.attr)
+        for child in ast.walk(callback)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and isinstance(child.func.value, ast.Name)
+    }
+    return set(required_callback_calls).issubset(calls)
 
 
 def _function_scope_names(node) -> set[str]:

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -816,6 +816,79 @@ def test_apply_patch_inserts_streaming_callback_hooks():
     assert patcher.remove_patch(patched) == content
 
 
+def test_answer_delta_hook_targets_native_text_stream_when_tts_fallback_exists():
+    content = (
+        "async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "    return await self._run_agent(event_message_id=event.message_id)\n"
+        "\n"
+        "async def _run_agent(self, source, event_message_id=None):\n"
+        "    _loop_for_step = asyncio.get_running_loop()\n"
+        "    session_key = 'sess-1'\n"
+        "    _status_chat_id = source.chat_id\n"
+        "    _approval_session_key = session_key\n"
+        "    def _run_still_current():\n"
+        "        return True\n"
+        "\n"
+        "    if _want_stream_deltas or _want_interim_consumer:\n"
+        "        try:\n"
+        "            if _adapter:\n"
+        "                if _want_stream_deltas:\n"
+        "                    def _stream_delta_cb(text: str) -> None:\n"
+        "                        if _run_still_current():\n"
+        "                            _stream_consumer.on_delta(text)\n"
+        "        except Exception:\n"
+        "            pass\n"
+        "\n"
+        "    if _stream_delta_cb is None and _stts_consumer_ref is not None:\n"
+        "        def _stream_delta_cb(text: str) -> None:\n"
+        "            if _run_still_current():\n"
+        "                _stts_consumer_ref.on_delta(text)\n"
+        "\n"
+        "    def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:\n"
+        "        status_queue.put(text)\n"
+    )
+
+    patched = patcher.apply_patch(content)
+
+    native_stream_index = patched.index("_stream_consumer.on_delta(text)")
+    tts_fallback_index = patched.index("_stts_consumer_ref.on_delta(text)")
+    answer_hook_index = patched.index(patcher.ANSWER_DELTA_PATCH_BEGIN)
+    assert answer_hook_index < native_stream_index < tts_fallback_index
+    assert patched.count(patcher.ANSWER_DELTA_PATCH_BEGIN) == 1
+    assert patcher.remove_patch(patched) == content
+
+    patched_lines = patched.splitlines(keepends=True)
+    begin = next(
+        index
+        for index, line in enumerate(patched_lines)
+        if patcher.ANSWER_DELTA_PATCH_BEGIN in line
+    )
+    end = next(
+        index
+        for index, line in enumerate(patched_lines[begin:], start=begin)
+        if patcher.ANSWER_DELTA_PATCH_END in line
+    )
+    stale = "".join(patched_lines[:begin] + patched_lines[end + 1 :])
+    fallback_body = (
+        "            if _run_still_current():\n"
+        "                _stts_consumer_ref.on_delta(text)\n"
+    )
+    stale = stale.replace(
+        fallback_body,
+        "".join(patcher._render_answer_delta_hook_block("            ", "\n"))
+        + fallback_body,
+        1,
+    )
+
+    upgraded = patcher.apply_patch(stale)
+
+    assert upgraded.index(patcher.ANSWER_DELTA_PATCH_BEGIN) < upgraded.index(
+        "_stream_consumer.on_delta(text)"
+    )
+    assert upgraded.count(patcher.ANSWER_DELTA_PATCH_BEGIN) == 1
+    assert patcher.remove_patch(upgraded) == content
+
+
 def test_apply_patch_uses_stable_tool_call_ids_when_gateway_exposes_callbacks():
     content = (
         "async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"


### PR DESCRIPTION
## Summary

- select the `_stream_delta_cb` that forwards to `_stream_consumer.on_delta` when Hermes defines multiple callbacks with the same local name
- relocate an existing owned answer-delta hook during upgrade when callback-selection requirements are present
- keep backward compatibility for Hermes sources with a single matching callback and fail open when multiple candidates cannot be disambiguated
- add a regression test covering both fresh installation and relocation of the previously misplaced hook

## Root cause

Recent Hermes versions define a deeply nested native text-stream `_stream_delta_cb` and a shallower TTS-only fallback with the same name. The patcher used the first function returned by `ast.walk`, which could place the answer-delta hook in the TTS fallback. The native text stream then remained active and split long percent-encoded Markdown links across a native Feishu post and text tail, separating the token from the URL.

## Validation

- `pytest tests/unit/test_patcher.py -q`: 95 passed
- full suite: 2198 passed, 4 skipped
- `git diff --check`
- installed against Hermes v2026.7.20 and verified the managed hook is placed before `_stream_consumer.on_delta`
- manually confirmed a WeChat article summary link, including its token, remains intact in the Feishu streaming card