### PR TITLE
fix: restore hooks after Hermes TurnRunner refactor

### DIFF
--- a/hermes_feishu_card/install/detect.py
+++ b/hermes_feishu_card/install/detect.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 import subprocess
 
+from . import patcher
 from .patcher import apply_base_patch, remove_base_patch
 
 
@@ -173,6 +174,15 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     else:
         compatibility = "unsupported"
     if not core_ok:
+        return result(
+            False,
+            capability_error,
+            compatibility=compatibility,
+            capabilities=capabilities,
+            base_required=base_required,
+        )
+
+    if capability_error != "supported":
         return result(
             False,
             capability_error,
@@ -371,14 +381,14 @@ def _detect_capabilities(
     else:
         completion_return = _find_completion_return(handler)
 
+    callback_capabilities, callback_error = _detect_callback_patchability(
+        contents, module
+    )
     capabilities = {
         "message_handler": handler is not None,
         "completion_return": completion_return is not None,
         "run_agent": _find_run_agent(module) is not None,
-        "tool_callback": _find_callback(module, "progress_callback") is not None,
-        "answer_delta_callback": _find_callback(module, "_stream_delta_cb") is not None,
-        "thinking_delta_callback": _find_callback(module, "_interim_assistant_cb") is not None,
-        "status_callback": _has_patchable_status_callback(module),
+        **callback_capabilities,
         "cron_delivery": _has_cron_delivery(contents, cron_contents),
         "reply_context": "reply_to_message_id" in contents
         or "_reply_anchor_for_event" in contents,
@@ -390,8 +400,73 @@ def _detect_capabilities(
         return capabilities, f"gateway/run.py missing async anchor function: {HANDLER_NAME}"
     if not capabilities["completion_return"]:
         return capabilities, 'gateway/run.py missing handler anchor: hooks.emit("agent:end", ...)'
+    if callback_error:
+        return capabilities, callback_error
 
     return capabilities, "supported"
+
+
+def _detect_callback_patchability(
+    contents: str, module: ast.Module
+) -> tuple[dict[str, bool], str]:
+    try:
+        patched = patcher.apply_patch(contents, strategy="gateway_run_013_plus")
+    except ValueError:
+        # Detection also runs while the recovery planner is inspecting an
+        # already-installed file with damaged markers. Preserve the legacy
+        # structural capability report here so recovery, not compatibility
+        # detection, remains responsible for classifying that state.
+        return {
+            "tool_callback": _find_callback(module, "progress_callback") is not None,
+            "answer_delta_callback": _find_callback(module, "_stream_delta_cb")
+            is not None,
+            "thinking_delta_callback": _find_callback(
+                module, "_interim_assistant_cb"
+            )
+            is not None,
+            "status_callback": _has_patchable_status_callback(module),
+        }, ""
+
+    capabilities = {
+        "tool_callback": (
+            patcher.STABLE_TOOL_PATCH_BEGIN in patched
+            or patcher.TOOL_PATCH_BEGIN in patched
+        ),
+        "answer_delta_callback": patcher.ANSWER_DELTA_PATCH_BEGIN in patched,
+        "thinking_delta_callback": patcher.THINKING_DELTA_PATCH_BEGIN in patched,
+        "status_callback": patcher.STATUS_PATCH_BEGIN in patched,
+    }
+
+    turn_runner = _find_turn_runner(module)
+    if turn_runner is None:
+        return capabilities, ""
+
+    required_markers = []
+    if _turn_runner_assigns_agent_callback(turn_runner, "tool_start_callback"):
+        required_markers.append(
+            ("tool lifecycle", patcher.STABLE_TOOL_PATCH_BEGIN)
+        )
+    for callback_name, label, marker in (
+        ("_stream_delta_cb", "answer delta", patcher.ANSWER_DELTA_PATCH_BEGIN),
+        (
+            "_interim_assistant_cb",
+            "thinking delta",
+            patcher.THINKING_DELTA_PATCH_BEGIN,
+        ),
+        ("_clarify_callback_sync", "clarify", patcher.CLARIFY_PATCH_BEGIN),
+        ("_approval_notify_sync", "approval", patcher.APPROVAL_PATCH_BEGIN),
+        ("_status_callback_sync", "status", patcher.STATUS_PATCH_BEGIN),
+    ):
+        if _turn_runner_has_callback(turn_runner, callback_name):
+            required_markers.append((label, marker))
+
+    missing = [label for label, marker in required_markers if marker not in patched]
+    if missing:
+        return capabilities, (
+            "gateway/run.py TurnRunner hooks are not safely patchable: "
+            + ", ".join(missing)
+        )
+    return capabilities, ""
 
 
 def _has_cron_delivery(contents: str, cron_contents: str) -> bool:
@@ -476,6 +551,43 @@ def _find_callback(
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
             return node
     return None
+
+
+def _find_turn_runner(module: ast.Module) -> ast.ClassDef | None:
+    return next(
+        (
+            node
+            for node in module.body
+            if isinstance(node, ast.ClassDef) and node.name == "TurnRunner"
+        ),
+        None,
+    )
+
+
+def _turn_runner_has_callback(turn_runner: ast.ClassDef, name: str) -> bool:
+    return any(
+        isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == name
+        for node in ast.walk(turn_runner)
+    )
+
+
+def _turn_runner_assigns_agent_callback(
+    turn_runner: ast.ClassDef, attribute: str
+) -> bool:
+    for node in ast.walk(turn_runner):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(
+            isinstance(target, ast.Attribute)
+            and target.attr == attribute
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "agent"
+            for target in targets
+        ):
+            return True
+    return False
 
 
 def _has_patchable_status_callback(module: ast.Module) -> bool:

--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -98,6 +98,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
         ),
         required_callback_args=("text",),
         required_callback_calls=(("_stream_consumer", "on_delta"),),
+        allow_turn_context=True,
     )
     content = _apply_callback_patch(
         content,
@@ -112,6 +113,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
             "_run_still_current",
         ),
         required_callback_args=("text", "already_streamed"),
+        allow_turn_context=True,
     )
     content = _apply_callback_patch(
         content,
@@ -127,6 +129,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
             "_run_still_current",
         ),
         required_callback_args=("question", "choices"),
+        allow_turn_context=True,
     )
     content = _apply_callback_patch(
         content,
@@ -142,6 +145,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
             "_run_still_current",
         ),
         required_callback_args=("approval_data",),
+        allow_turn_context=True,
     )
     if strategy == "gateway_run_013_plus":
         content = _apply_callback_patch(
@@ -158,6 +162,7 @@ def apply_patch(content: str, strategy: str = "legacy_gateway_run") -> str:
                 "_run_still_current",
             ),
             required_callback_args=("event_type", "message"),
+            allow_turn_context=True,
         )
     return content
 
@@ -718,6 +723,7 @@ def _apply_callback_patch(
     required_outer_names=(),
     required_callback_args=(),
     required_callback_calls=(),
+    allow_turn_context=False,
 ) -> str:
     owned_block = _find_simple_marker_block(
         content,
@@ -743,10 +749,16 @@ def _apply_callback_patch(
                 required_outer_names=required_outer_names,
                 required_callback_args=required_callback_args,
                 required_callback_calls=required_callback_calls,
+                allow_turn_context=allow_turn_context,
             )
         indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
         newline = _line_ending(lines[begin_index]) or _detect_newline(content)
-        expected = renderer(indent, newline)
+        expected = (
+            _render_turn_context_hook_block(renderer, indent, newline)
+            if allow_turn_context
+            and any("_hfc_turn_ctx = ctx" in line for line in lines[begin_index : end_index + 1])
+            else renderer(indent, newline)
+        )
         if lines[begin_index : end_index + 1] == expected:
             return content
         return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
@@ -761,12 +773,26 @@ def _apply_callback_patch(
         required_callback_args=required_callback_args,
         required_callback_calls=required_callback_calls,
     )
+    use_turn_context = False
+    if callback_body is None and allow_turn_context:
+        callback_body = _find_turn_runner_callback_body_location(
+            tree,
+            lines,
+            callback_name,
+            required_callback_args=required_callback_args,
+            required_callback_calls=required_callback_calls,
+        )
+        use_turn_context = callback_body is not None
     if callback_body is None:
         return content
 
     newline = _detect_newline(content)
     insert_at, body_indent = callback_body
-    hook = renderer(body_indent, newline)
+    hook = (
+        _render_turn_context_hook_block(renderer, body_indent, newline)
+        if use_turn_context
+        else renderer(body_indent, newline)
+    )
     return "".join(lines[:insert_at] + hook + lines[insert_at:])
 
 
@@ -782,7 +808,13 @@ def _apply_stable_tool_lifecycle_patch(content: str) -> str:
         begin_index, end_index = owned_block
         indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
         newline = _line_ending(lines[begin_index]) or _detect_newline(content)
-        expected = _render_stable_tool_lifecycle_hook_block(indent, newline)
+        expected = (
+            _render_turn_context_hook_block(
+                _render_stable_tool_lifecycle_hook_block, indent, newline
+            )
+            if any("_hfc_turn_ctx = ctx" in line for line in lines[begin_index : end_index + 1])
+            else _render_stable_tool_lifecycle_hook_block(indent, newline)
+        )
         if lines[begin_index : end_index + 1] == expected:
             return content
         return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
@@ -790,11 +822,21 @@ def _apply_stable_tool_lifecycle_patch(content: str) -> str:
     tree = _parse_content(content)
     lines = content.splitlines(keepends=True)
     location = _find_stable_tool_lifecycle_location(tree, lines)
+    use_turn_context = False
+    if location is None:
+        location = _find_turn_runner_stable_tool_lifecycle_location(tree, lines)
+        use_turn_context = location is not None
     if location is None:
         return content
     insert_at, indent = location
     newline = _detect_newline(content)
-    hook = _render_stable_tool_lifecycle_hook_block(indent, newline)
+    hook = (
+        _render_turn_context_hook_block(
+            _render_stable_tool_lifecycle_hook_block, indent, newline
+        )
+        if use_turn_context
+        else _render_stable_tool_lifecycle_hook_block(indent, newline)
+    )
     return "".join(lines[:insert_at] + hook + lines[insert_at:])
 
 
@@ -1056,6 +1098,58 @@ def _find_callback_body_location(
     return _body_location(candidates[0], lines)
 
 
+def _find_turn_runner_callback_body_location(
+    tree,
+    lines,
+    callback_name: str,
+    *,
+    required_callback_args=(),
+    required_callback_calls=(),
+):
+    turn_runner = _find_turn_runner_node(tree)
+    if turn_runner is None:
+        return None
+
+    if callback_name == "_status_callback_sync":
+        candidates = [
+            node
+            for node in turn_runner.body
+            if isinstance(node, ast.FunctionDef) and node.name == callback_name
+        ]
+    else:
+        run_sync = _find_direct_class_function_node(turn_runner, "run_sync")
+        if run_sync is None or not _binds_turn_context(run_sync):
+            return None
+        candidates = [
+            node
+            for node in ast.walk(run_sync)
+            if isinstance(node, ast.FunctionDef) and node.name == callback_name
+        ]
+
+    candidates = [
+        node
+        for node in candidates
+        if set(required_callback_args).issubset(_function_argument_names(node))
+    ]
+    if callback_name == "_status_callback_sync":
+        candidates = [node for node in candidates if _binds_turn_context(node)]
+    if required_callback_calls:
+        preferred = [
+            node
+            for node in candidates
+            if _has_required_callback_calls(node, required_callback_calls)
+        ]
+        if preferred:
+            candidates = preferred
+        elif len(candidates) != 1:
+            return None
+    if not candidates:
+        return None
+    if callback_name == "_status_callback_sync":
+        return _turn_context_binding_location(candidates[0], lines)
+    return _body_location(candidates[0], lines)
+
+
 def _find_stable_tool_lifecycle_location(tree, lines):
     run_agent = _find_run_agent_node(tree)
     if run_agent is None:
@@ -1079,6 +1173,82 @@ def _find_stable_tool_lifecycle_location(tree, lines):
         end_lineno = getattr(node, "end_lineno", None) or node.lineno
         return end_lineno, _line_indent(lines, node.lineno - 1)
     return None
+
+
+def _find_turn_runner_stable_tool_lifecycle_location(tree, lines):
+    turn_runner = _find_turn_runner_node(tree)
+    if turn_runner is None:
+        return None
+    run_sync = _find_direct_class_function_node(turn_runner, "run_sync")
+    if run_sync is None or not _binds_turn_context(run_sync):
+        return None
+    if "agent" not in _function_scope_names(run_sync):
+        return None
+    for node in ast.walk(run_sync):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(
+            _is_agent_callback_target(target, "tool_start_callback")
+            for target in targets
+        ):
+            continue
+        end_lineno = getattr(node, "end_lineno", None) or node.lineno
+        return end_lineno, _line_indent(lines, node.lineno - 1)
+    return None
+
+
+def _find_turn_runner_node(tree):
+    return next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "TurnRunner"
+        ),
+        None,
+    )
+
+
+def _find_direct_class_function_node(class_node, name: str):
+    return next(
+        (
+            node
+            for node in class_node.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ),
+        None,
+    )
+
+
+def _binds_turn_context(node) -> bool:
+    return _find_turn_context_binding(node) is not None
+
+
+def _find_turn_context_binding(node):
+    for statement in node.body:
+        if not isinstance(statement, ast.Assign) or len(statement.targets) != 1:
+            continue
+        target = statement.targets[0]
+        value = statement.value
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "ctx"
+            and isinstance(value, ast.Attribute)
+            and value.attr == "_ctx"
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "self"
+        ):
+            return statement
+    return None
+
+
+def _turn_context_binding_location(node, lines):
+    binding = _find_turn_context_binding(node)
+    if binding is None:
+        return None
+    end_lineno = getattr(binding, "end_lineno", None) or binding.lineno
+    return end_lineno, _line_indent(lines, binding.lineno - 1)
 
 
 def _is_agent_callback_target(node, attribute: str) -> bool:
@@ -2047,6 +2217,17 @@ def _find_simple_owned_patch(
     expected_blocks = [expected]
     if renderer is _render_command_card_adapter_hook_block:
         expected_blocks.append(_render_legacy_command_card_adapter_hook_block(indent, newline))
+    if renderer in (
+        _render_stable_tool_lifecycle_hook_block,
+        _render_answer_delta_hook_block,
+        _render_thinking_delta_hook_block,
+        _render_clarify_hook_block,
+        _render_approval_hook_block,
+        _render_status_hook_block,
+    ):
+        expected_blocks.append(
+            _render_turn_context_hook_block(renderer, indent, newline)
+        )
     actual = lines[begin_index : end_index + 1]
     if actual not in expected_blocks:
         raise ValueError(f"corrupt {error_label}")
@@ -2659,6 +2840,40 @@ def _render_previous_async_complete_hook_block_without_platform_guard(
         *_render_hook_exception_handler(indent, newline),
         f"{indent}{COMPLETE_PATCH_END}{newline}",
     ]
+
+
+def _render_turn_context_hook_block(renderer, indent: str, newline: str):
+    """Adapt a legacy closure hook to Hermes' ``TurnRunner`` context seam."""
+    block = renderer(indent, newline)
+    replacements = (
+        ("_run_still_current()", "_hfc_turn_ctx._run_still_current()"),
+        ('"source": source,', '"source": _hfc_turn_ctx.source,'),
+        (
+            '"message_id": event_message_id,',
+            '"message_id": _hfc_turn_ctx.event_message_id,',
+        ),
+        ('"_hfc_loop": _loop_for_step,', '"_hfc_loop": _hfc_turn_ctx._loop_for_step,'),
+        (
+            '"_hfc_loop": locals().get("_loop_for_step"),',
+            '"_hfc_loop": _hfc_turn_ctx._loop_for_step,',
+        ),
+        ('"chat_id": _status_chat_id,', '"chat_id": _hfc_turn_ctx._status_chat_id,'),
+        (
+            '"conversation_id": session_key or _status_chat_id,',
+            '"conversation_id": _hfc_turn_ctx.session_key or _hfc_turn_ctx._status_chat_id,',
+        ),
+        (
+            '"conversation_id": _approval_session_key or _status_chat_id,',
+            '"conversation_id": _approval_session_key or _hfc_turn_ctx._status_chat_id,',
+        ),
+    )
+    adapted = []
+    for line in block:
+        for old, new in replacements:
+            line = line.replace(old, new)
+        adapted.append(line)
+    adapted.insert(1, f"{indent}_hfc_turn_ctx = ctx{newline}")
+    return adapted
 
 
 def _render_tool_hook_block(indent: str, newline: str):

--- a/tests/fixtures/hermes_turn_runner.py
+++ b/tests/fixtures/hermes_turn_runner.py
@@ -1,0 +1,102 @@
+class TurnContext:
+    pass
+
+
+class TurnRunner:
+    def __init__(self, runner, ctx):
+        self._runner = runner
+        self._ctx = ctx
+
+    def progress_callback(
+        self,
+        event_type: str,
+        tool_name: str = None,
+        preview: str = None,
+        args: dict = None,
+        **kwargs,
+    ):
+        ctx = self._ctx
+        if not ctx._run_still_current():
+            return
+        ctx.progress_queue.put((event_type, tool_name, preview))
+
+    def _status_callback_sync(self, event_type: str, message: str) -> None:
+        ctx = self._ctx
+        if not ctx._status_adapter or not ctx._run_still_current():
+            return
+        ctx.status_queue.put((event_type, message))
+
+    def run_sync(self):
+        ctx = self._ctx
+        agent = self._runner.agent
+        stream_consumer = self._runner.stream_consumer
+
+        def _stream_delta_cb(text: str) -> None:
+            if ctx._run_still_current():
+                stream_consumer.on_delta(text)
+
+        def _interim_assistant_cb(
+            text: str, *, already_streamed: bool = False
+        ) -> None:
+            if text and not already_streamed and ctx._run_still_current():
+                stream_consumer.on_commentary(text)
+
+        agent.tool_progress_callback = ctx.progress_callback
+        agent.tool_start_callback = self._runner.voice_ack_callback
+        agent.stream_delta_callback = _stream_delta_cb
+        agent.interim_assistant_callback = _interim_assistant_cb
+        agent.status_callback = ctx._status_callback_sync
+
+        def _clarify_callback_sync(question: str, choices):
+            if not ctx._status_adapter:
+                return ""
+            return ctx.wait_for_clarify(question, choices)
+
+        agent.clarify_callback = _clarify_callback_sync
+        _approval_session_key = ctx.session_key or ""
+
+        def _approval_notify_sync(approval_data: dict) -> None:
+            ctx.send_approval(_approval_session_key, approval_data)
+
+        agent.approval_callback = _approval_notify_sync
+        return agent
+
+
+class GatewayRunner:
+    async def _handle_message_with_agent(
+        self, event, source, _quick_key, run_generation
+    ):
+        response = "ok"
+        agent_result = {"model": "m"}
+        _response_time = 1.0
+        await self.hooks.emit("agent:end", {"response": response})
+        return response
+
+    async def _run_agent(self, source, event_message_id=None):
+        turn_ctx = TurnContext()
+        turn_ctx.source = source
+        turn_ctx.event_message_id = event_message_id
+        turn_ctx.session_key = "session"
+        turn_ctx._loop_for_step = self.loop
+        turn_ctx._run_still_current = self._run_still_current
+        turn_ctx._status_chat_id = source.chat_id
+        turn_ctx._status_adapter = self._adapter_for_source(source)
+        turn_ctx.progress_queue = self.progress_queue
+        turn_ctx.status_queue = self.status_queue
+        turn_ctx.agent_holder = [None]
+        turn_runner = TurnRunner(self, turn_ctx)
+        turn_ctx.progress_callback = turn_runner.progress_callback
+        turn_ctx._status_callback_sync = turn_runner._status_callback_sync
+        return turn_runner.run_sync()
+
+
+def _reply_anchor_for_event(event):
+    return getattr(event, "reply_to_message_id", None)
+
+
+def _deliver_media_from_response(response):
+    return extract_media(response)
+
+
+def _deliver_result(job: dict, content: str, adapters=None, loop=None):
+    return None

--- a/tests/unit/test_installer_detection.py
+++ b/tests/unit/test_installer_detection.py
@@ -16,6 +16,9 @@ FIXTURE_ROOT = (
 EXACT_BASE_FIXTURE = (
     Path(__file__).resolve().parents[1] / "fixtures" / "hermes_exact_base.py"
 )
+TURN_RUNNER_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "hermes_turn_runner.py"
+)
 
 
 def test_detect_hermes_supports_v2026_4_23_fixture():
@@ -119,6 +122,37 @@ class GatewayRunner:
 
     assert detection.supported is True
     assert detection.capabilities["status_callback"] is True
+
+
+def test_detect_turn_runner_callbacks_from_actual_patchability(tmp_path):
+    root = tmp_path / "hermes"
+    _write_hermes_root(
+        root,
+        version="v0.18.2",
+        run_py=TURN_RUNNER_FIXTURE.read_text(encoding="utf-8"),
+    )
+
+    detection = detect_hermes(root)
+
+    assert detection.supported is True
+    assert detection.compatibility == "full"
+    assert detection.capabilities["tool_callback"] is True
+    assert detection.capabilities["answer_delta_callback"] is True
+    assert detection.capabilities["thinking_delta_callback"] is True
+    assert detection.capabilities["status_callback"] is True
+
+
+def test_detect_rejects_named_turn_runner_callbacks_that_are_not_patchable(tmp_path):
+    root = tmp_path / "hermes"
+    unpatchable = TURN_RUNNER_FIXTURE.read_text(encoding="utf-8").replace(
+        "        ctx = self._ctx\n", "        context = self._ctx\n"
+    )
+    _write_hermes_root(root, version="v0.18.2", run_py=unpatchable)
+
+    detection = detect_hermes(root)
+
+    assert detection.supported is False
+    assert "not safely patchable" in detection.reason
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -913,6 +913,14 @@ def test_apply_patch_restores_hooks_after_turn_runner_refactor():
     assert 'event_name="answer.delta"' in patched
     assert 'event_name="thinking.delta"' in patched
     assert "_hfc_turn_ctx = ctx" in patched
+    assert '"source": _hfc_turn_ctx.source' in patched
+    assert '"message_id": _hfc_turn_ctx.event_message_id' in patched
+    assert '"_hfc_loop": _hfc_turn_ctx._loop_for_step' in patched
+    assert '"chat_id": _hfc_turn_ctx._status_chat_id' in patched
+    status_method = patched.index("def _status_callback_sync")
+    status_context = patched.index("ctx = self._ctx", status_method)
+    status_hook = patched.index(patcher.STATUS_PATCH_BEGIN, status_method)
+    assert status_context < status_hook
     ast.parse(patched)
     assert patcher.apply_patch(patched, strategy="gateway_run_013_plus") == patched
     assert patcher.remove_patch(patched) == content

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -1,8 +1,14 @@
 import ast
+from pathlib import Path
 
 import pytest
 
 from hermes_feishu_card.install import patcher
+
+
+TURN_RUNNER_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "hermes_turn_runner.py"
+)
 
 
 def test_apply_patch_accepts_explicit_legacy_strategy():
@@ -887,6 +893,29 @@ def test_answer_delta_hook_targets_native_text_stream_when_tts_fallback_exists()
     )
     assert upgraded.count(patcher.ANSWER_DELTA_PATCH_BEGIN) == 1
     assert patcher.remove_patch(upgraded) == content
+
+
+def test_apply_patch_restores_hooks_after_turn_runner_refactor():
+    content = TURN_RUNNER_FIXTURE.read_text(encoding="utf-8")
+
+    patched = patcher.apply_patch(content, strategy="gateway_run_013_plus")
+
+    for marker in (
+        patcher.STABLE_TOOL_PATCH_BEGIN,
+        patcher.ANSWER_DELTA_PATCH_BEGIN,
+        patcher.THINKING_DELTA_PATCH_BEGIN,
+        patcher.CLARIFY_PATCH_BEGIN,
+        patcher.APPROVAL_PATCH_BEGIN,
+        patcher.STATUS_PATCH_BEGIN,
+    ):
+        assert marker in patched
+    assert 'event_name="tool.updated"' in patched
+    assert 'event_name="answer.delta"' in patched
+    assert 'event_name="thinking.delta"' in patched
+    assert "_hfc_turn_ctx = ctx" in patched
+    ast.parse(patched)
+    assert patcher.apply_patch(patched, strategy="gateway_run_013_plus") == patched
+    assert patcher.remove_patch(patched) == content
 
 
 def test_apply_patch_uses_stable_tool_call_ids_when_gateway_exposes_callbacks():


### PR DESCRIPTION
## Summary

- locate answer/thinking/clarify/approval callbacks and the stable tool lifecycle inside `TurnRunner.run_sync`
- adapt managed hook payloads to the `TurnContext` fields introduced by Hermes while preserving the legacy `_run_agent` path
- place the status hook only after `ctx = self._ctx` is bound
- derive callback capability reporting from actual patchability and reject an incompatible TurnRunner shape instead of reporting a false successful install
- preserve the existing corrupt-marker recovery path

This builds on the callback-selection fix from merged PR #168; that PR fixes duplicate `_stream_delta_cb` selection, while this PR restores the callbacks moved by the TurnRunner refactor.

## Validation

- `python -m pytest -q`: 2201 passed, 4 skipped
- focused patcher/detection/doctor/install suite: 511 passed
- `git diff --check`
- Hermes `1a3a9de630a809cf1b177ec0ddf5b7ff66291e65`: 14 managed hook blocks; all six moved hooks present exactly once; patched AST parses; repeat patch is idempotent; `remove_patch` restores the source byte-for-byte; detection reports `supported/full`

## Release handling

Addresses #169. After CI and merge, this fix will be folded into the existing v4.1.3 candidate PR #166. Keep #169 open until the reporter completes the official candidate retest.