### PR TITLE
fix: normalize Windows manifest paths and diagnostics

### DIFF
--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -1450,7 +1450,7 @@ def _check_runtime_feishu_sdk(runtime_python: Path) -> dict[str, Any]:
             check=False,
             capture_output=True,
             text=True,
-            timeout=8,
+            timeout=30,
             cwd=str(cwd) if cwd is not None else None,
         )
     except subprocess.TimeoutExpired:
@@ -2234,6 +2234,8 @@ def _candidate_hermes_config_paths(hermes_root: Path) -> tuple[Path, ...]:
         hermes_root / "config.yml",
         hermes_root / "configs" / "config.yaml",
         hermes_root / "configs" / "config.yml",
+        hermes_root.parent / "config.yaml",
+        hermes_root.parent / "config.yml",
         Path.home() / ".hermes" / "config.yaml",
         Path.home() / ".hermes" / "config.yml",
     )
@@ -4449,9 +4451,9 @@ def _render_install_manifest(
 ) -> str:
     manifest = {
         "manifest_version": INSTALL_MANIFEST_VERSION,
-        "run_py": str(run_py.relative_to(manifest_path.parent)),
+        "run_py": run_py.relative_to(manifest_path.parent).as_posix(),
         "patched_sha256": _restore_text_sha256(run_contents),
-        "backup": str(backup_path.relative_to(manifest_path.parent)),
+        "backup": backup_path.relative_to(manifest_path.parent).as_posix(),
         "backup_sha256": _restore_text_sha256(run_source),
     }
     if (
@@ -4462,9 +4464,11 @@ def _render_install_manifest(
     ):
         manifest.update(
             {
-                "cron_py": str(cron_py.relative_to(manifest_path.parent)),
+                "cron_py": cron_py.relative_to(manifest_path.parent).as_posix(),
                 "cron_patched_sha256": _restore_text_sha256(cron_contents),
-                "cron_backup": str(cron_backup_path.relative_to(manifest_path.parent)),
+                "cron_backup": cron_backup_path.relative_to(
+                    manifest_path.parent
+                ).as_posix(),
                 "cron_backup_sha256": _restore_text_sha256(cron_source),
             }
         )
@@ -4476,11 +4480,11 @@ def _render_install_manifest(
     ):
         manifest.update(
             {
-                "base_py": str(base_py.relative_to(manifest_path.parent)),
+                "base_py": base_py.relative_to(manifest_path.parent).as_posix(),
                 "base_patched_sha256": _restore_text_sha256(base_contents),
-                "base_backup": str(
-                    base_backup_path.relative_to(manifest_path.parent)
-                ),
+                "base_backup": base_backup_path.relative_to(
+                    manifest_path.parent
+                ).as_posix(),
                 "base_backup_sha256": _restore_text_sha256(base_source),
             }
         )

--- a/hermes_feishu_card/install/recovery.py
+++ b/hermes_feishu_card/install/recovery.py
@@ -2808,7 +2808,7 @@ def _manifest_hash(manifest: Dict[str, object], key: str) -> str:
 
 def _relative_path(root: Path, path: Path) -> str:
     try:
-        return str(path.relative_to(root))
+        return path.relative_to(root).as_posix()
     except ValueError:
         return ""
 

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from argparse import Namespace
 from hashlib import sha256
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -43,6 +43,74 @@ def copy_hermes(tmp_path):
     hermes_dir = tmp_path / "hermes"
     shutil.copytree(FIXTURE, hermes_dir)
     return hermes_dir
+
+
+def test_runtime_feishu_sdk_probe_allows_windows_cold_start(monkeypatch):
+    observed = {}
+
+    def fake_run(*_args, **kwargs):
+        observed.update(kwargs)
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{\"version\":\"1.6.8\",\"supports_extra_ua_tags\":true}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    report = cli._check_runtime_feishu_sdk(Path(sys.executable))
+
+    assert report["status"] == "ok"
+    assert observed["timeout"] == 30
+
+
+def test_candidate_hermes_config_paths_include_hermes_home_parent(tmp_path):
+    hermes_root = tmp_path / "hermes" / "hermes-agent"
+
+    candidates = cli._candidate_hermes_config_paths(hermes_root)
+
+    assert hermes_root.parent / "config.yaml" in candidates
+    assert hermes_root.parent / "config.yml" in candidates
+
+
+def test_render_install_manifest_uses_portable_windows_paths(monkeypatch):
+    root = PureWindowsPath("C:/Users/test/AppData/Local/hermes/hermes-agent")
+    manifest_path = root / ".hermes_feishu_card_manifest"
+    monkeypatch.setattr(
+        cli,
+        "build_integrity_provenance",
+        lambda *_args, **_kwargs: {},
+    )
+
+    rendered = cli._render_install_manifest(
+        manifest_path,
+        run_py=root / "gateway" / "run.py",
+        run_contents="patched\n",
+        backup_path=root / "gateway" / "run.py.hermes_feishu_card.bak",
+        run_source="original\n",
+        cron_py=root / "cron" / "scheduler.py",
+        cron_contents="patched cron\n",
+        cron_backup_path=root / "cron" / "scheduler.py.hermes_feishu_card.bak",
+        cron_source="original cron\n",
+        base_py=root / "gateway" / "platforms" / "base.py",
+        base_contents="patched base\n",
+        base_backup_path=(
+            root / "gateway" / "platforms" / "base.py.hermes_feishu_card.bak"
+        ),
+        base_source="original base\n",
+    )
+
+    manifest = json.loads(rendered)
+    for key in (
+        "run_py",
+        "backup",
+        "cron_py",
+        "cron_backup",
+        "base_py",
+        "base_backup",
+    ):
+        assert "\\" not in manifest[key]
 
 
 def stub_setup_runtime(monkeypatch, hermes_dir):

--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -4,7 +4,7 @@ import errno
 import json
 from dataclasses import FrozenInstanceError, replace
 from hashlib import sha256
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import shutil
 import subprocess
 import sys
@@ -45,6 +45,13 @@ CRON_FIXTURE = (
 EXACT_BASE_FIXTURE = (
     Path(__file__).resolve().parents[1] / "fixtures" / "hermes_exact_base.py"
 )
+
+
+def test_relative_path_uses_portable_windows_separator():
+    root = PureWindowsPath("C:/Users/test/AppData/Local/hermes/hermes-agent")
+    target = root / "gateway" / "platforms" / "base.py"
+
+    assert recovery._relative_path(root, target) == "gateway/platforms/base.py"
 
 
 def test_execute_recovery_fails_closed_without_dirfd_support(monkeypatch):


### PR DESCRIPTION
## Summary

- 将 ownership manifest 的 Gateway/Cron/Base 相对路径统一写为 POSIX 表示，避免 Windows `\\` 与 `/` 混用导致 ownership/recovery 比较失败。
- 将 recovery planner 的相对路径表示同步改为 POSIX，确保 writer 与 comparator 使用同一 canonical form。
- 当 `--hermes-dir` 指向 `%LOCALAPPDATA%/hermes/hermes-agent` 时，补充查找父级 HERMES_HOME 的 `config.yaml` / `config.yml`，避免 doctor 将已启用 streaming 误报为 `not_detected`。
- 将 Hermes runtime Feishu SDK 冷启动检查超时从 8 秒调整为 30 秒，避免 Windows venv/Defender 冷启动造成 false negative。

## Windows reproduction

在 Windows 11 + Python 3.11 + Hermes runtime venv 中实测：

- `Path.relative_to()` 的 `str(...)` 结果为 `gateway\\platforms\\base.py`，而 portable manifest/recovery contract 使用 `gateway/platforms/base.py`。
- Hermes 用户配置位于 `%LOCALAPPDATA%/hermes/config.yaml`，传入的 Hermes checkout 则是其子目录 `hermes-agent`。
- `lark_oapi.ws.Client` 冷启动首次导入可超过原 8 秒诊断窗口，但 Sidecar/runtime 本身兼容并可正常运行。

这是 closed Issue #171 / PR #172 之后的 Windows follow-up；不改变 recovery 的 fail-closed mutation policy。

## TDD / verification

RED（修复前）：新增 4 个聚焦测试均失败，分别命中 timeout、parent config、manifest separator、recovery separator。

GREEN（修复后）：

```text
4 passed in 0.96s
```

Windows baseline-aware 相关矩阵：

```text
upstream/main: 134 existing failures, 154 passed, 4 skipped
this branch:   119 existing failures, 173 passed, 4 skipped
branch-only failures: 0
fixed baseline failures: 15
```

其余失败来自上游测试中已有的 POSIX `dir_fd`/权限语义假设。另已通过：

- `git diff --check`
- added-lines secret / shell injection / eval / pickle / conflict-marker scan

GitHub Ubuntu Python 3.9/3.12 CI 作为最终全量门禁。
