### PR TITLE
fix: rebind Windows detached runner pid

### DIFF
--- a/hermes_feishu_card/process.py
+++ b/hermes_feishu_card/process.py
@@ -613,8 +613,22 @@ def wait_for_managed_pidfile(
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         record = read_pid_record()
-        if record == {"pid": pid, "token": token, "manager": "detached"}:
+        expected = {"pid": pid, "token": token, "manager": "detached"}
+        if record == expected:
             return True
+        if sys.platform == "win32":
+            launcher_pid = os.getppid()
+            launcher_record = {
+                "pid": launcher_pid,
+                "token": token,
+                "manager": "detached",
+            }
+            if record == launcher_record:
+                try:
+                    write_pid_record(pid, token, manager="detached")
+                except (OSError, ValueError):
+                    return False
+                return read_pid_record() == expected
         time.sleep(0.05)
     return False
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -2362,6 +2362,73 @@ def test_managed_pidfile_handshake_requires_exact_detached_pid_and_token(
     assert process.wait_for_managed_pidfile(4444, "owned", timeout=5) is True
 
 
+def test_managed_pidfile_handshake_rebinds_windows_launcher_parent(monkeypatch):
+    record = {"pid": 4444, "token": "owned", "manager": "detached"}
+    writes = []
+
+    def write_record(pid, token, **kwargs):
+        nonlocal record
+        writes.append((pid, token, kwargs))
+        record = {"pid": pid, "token": token, "manager": kwargs["manager"]}
+
+    monkeypatch.setattr(process.sys, "platform", "win32")
+    monkeypatch.setattr(process.os, "getppid", lambda: 4444)
+    monkeypatch.setattr(process, "read_pid_record", lambda: record)
+    monkeypatch.setattr(process, "write_pid_record", write_record)
+    monkeypatch.setattr(process.time, "monotonic", iter((0, 0)).__next__)
+
+    assert process.wait_for_managed_pidfile(5555, "owned", timeout=5) is True
+    assert writes == [(5555, "owned", {"manager": "detached"})]
+
+
+@pytest.mark.parametrize(
+    ("platform", "record", "parent_pid"),
+    (
+        ("linux", {"pid": 4444, "token": "owned", "manager": "detached"}, 4444),
+        ("win32", {"pid": 4444, "token": "wrong", "manager": "detached"}, 4444),
+        (
+            "win32",
+            {
+                "pid": 4444,
+                "token": "owned",
+                "manager": "systemd-user",
+                "unit": process.SYSTEMD_UNIT_NAME,
+            },
+            4444,
+        ),
+        ("win32", {"pid": 4444, "token": "owned", "manager": "detached"}, 3333),
+    ),
+)
+def test_managed_pidfile_handshake_rejects_untrusted_rebind(
+    monkeypatch, platform, record, parent_pid
+):
+    monkeypatch.setattr(process.sys, "platform", platform)
+    monkeypatch.setattr(process.os, "getppid", lambda: parent_pid)
+    monkeypatch.setattr(process, "read_pid_record", lambda: record)
+    monkeypatch.setattr(
+        process,
+        "write_pid_record",
+        lambda *_args, **_kwargs: pytest.fail("untrusted identity must not be rebound"),
+    )
+    monkeypatch.setattr(process.time, "monotonic", iter((0, 0, 6)).__next__)
+    monkeypatch.setattr(process.time, "sleep", lambda _seconds: None)
+
+    assert process.wait_for_managed_pidfile(5555, "owned", timeout=5) is False
+
+
+def test_managed_pidfile_handshake_rejects_unverified_rebind_write(monkeypatch):
+    record = {"pid": 4444, "token": "owned", "manager": "detached"}
+
+    monkeypatch.setattr(process.sys, "platform", "win32")
+    monkeypatch.setattr(process.os, "getppid", lambda: 4444)
+    monkeypatch.setattr(process, "read_pid_record", lambda: record)
+    monkeypatch.setattr(process, "write_pid_record", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(process.time, "monotonic", iter((0, 0, 6)).__next__)
+    monkeypatch.setattr(process.time, "sleep", lambda _seconds: None)
+
+    assert process.wait_for_managed_pidfile(5555, "owned", timeout=5) is False
+
+
 def test_detached_pidfile_write_failure_waits_for_managed_child_self_exit(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Summary

修复 Windows detached Sidecar 在 venv launcher PID 与实际 runner PID 不一致时的严格 pidfile 握手失败。

Windows 上 `venv/Scripts/python.exe` 可能作为 launcher parent 启动实际 base-runtime Python child：launcher 将自己的 PID 写入 pidfile，而 runner 使用自身 PID 验证，导致 `wait_for_managed_pidfile()` 超时、runner 退出、watchdog 重复拉起。

## Security boundary

本 PR 不放宽一般 PID ownership。仅在以下条件全部满足时允许 parent → child rebind：

1. `sys.platform == "win32"`；
2. pidfile manager 精确为 `detached`；
3. process token 与 runner 收到的 token 精确一致；
4. pidfile PID 精确等于 runner 的 `os.getppid()`；
5. 使用现有 atomic `write_pid_record()` 写入 runner PID；
6. 写后重新读取，只有精确等于 `{pid, token, manager}` 才返回成功。

错误 token、错误 manager、错误 parent、非 Windows、写入异常或写后验证失败均保持 fail-closed。

## TDD / verification

RED（修复前）：

```text
1 failed, 5 passed
```

唯一失败为 Windows launcher-parent rebind 接受路径；所有拒绝路径保持通过。

GREEN（修复后）：

```text
7 passed in 0.10s
```

Windows baseline-aware lifecycle matrix：

```text
upstream/main: 53 existing failures, 72 passed
this branch:   53 existing failures, 78 passed
branch-only failures: 0
```

现有失败来自上游 Windows 下的 POSIX permissions / `os.getuid` / systemd 测试假设，与本 PR 无关。另已通过：

- `git diff --check`
- added-lines secret / shell injection / eval / pickle / conflict-marker scan

GitHub Ubuntu Python 3.9/3.12 CI 作为最终全量门禁。
