### PR TITLE
fix: exempt interaction events from sequence/status checks in session.apply()

### DIFF
--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -137,10 +137,12 @@ class CardSession:
         ):
             return False
         is_terminal_event = _is_terminal_session_event(event)
-        if event.sequence <= self.last_sequence and not is_terminal_event:
-            return False
-        if self.status in {"completed", "failed"}:
-            return False
+        is_interaction = event.event in {"interaction.requested", "interaction.completed", "interaction.failed"}
+        if not is_interaction:
+            if event.sequence <= self.last_sequence and not is_terminal_event:
+                return False
+            if self.status in {"completed", "failed"}:
+                return False
         self.last_sequence = max(self.last_sequence, event.sequence)
 
         self.display_status = event.display_status


### PR DESCRIPTION
## Problem

When streaming events (`thinking.delta`, `answer.delta`, `tool.updated`) push `last_sequence` above 0, a subsequent `interaction.requested` event with `sequence=0` is silently rejected in `session.apply()`:

```python
if event.sequence <= self.last_sequence and not is_terminal_event:
    return False  # interaction.requested gets rejected here!
if self.status in {"completed", "failed"}:
    return False  # or here if session already completed
```

This prevents clarify/interaction cards from rendering — the user sees gray text instead of interactive buttons.

## Fix

Exempt `interaction.requested`, `interaction.completed`, and `interaction.failed` events from the sequence and terminal-status guards:

```python
is_interaction = event.event in {"interaction.requested", "interaction.completed", "interaction.failed"}
if not is_interaction:
    if event.sequence <= self.last_sequence and not is_terminal_event:
        return False
    if self.status in {"completed", "failed"}:
        return False
```

## Impact

- Clarify buttons now render correctly after streaming events
- No behavioral change for non-interaction events
- Interaction events always reach the interaction handling branch regardless of session state