### PR TITLE
fix: normalize conversation_id to strip agent profile prefix

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -7617,6 +7617,12 @@ def _build_event(
         or _first_attr_string(source_obj, ("conversation_id", "thread_id", "session_id"))
         or chat_id
     )
+    # Normalize conversation_id: strip agent profile prefix
+    # so it matches the session created by message.started (which uses plain chat_id).
+    if conversation_id and ":" in conversation_id and conversation_id != chat_id:
+        parts = conversation_id.split(":")
+        if len(parts) >= 3:
+            conversation_id = chat_id
     created_at_value = local_vars.get("created_at")
     created_at = _created_at(created_at_value)
     created_at_lifecycle_token = _created_at_lifecycle_token(created_at_value)


### PR DESCRIPTION
## Problem

The `conversation_id` from Gateway's local vars may contain an agent profile prefix (e.g., `agent:main:feishu:dm:oc_xxx`), while the session created by `message.started` uses the plain `chat_id` (e.g., `oc_xxx`).

When `interaction.requested` arrives with the prefixed `conversation_id`, `session.apply()` rejects it due to id mismatch:

```python
if (
    event.conversation_id != self.conversation_id  # "agent:main:feishu:dm:oc_xxx" != "oc_xxx"
    or event.message_id != self.message_id
    or event.chat_id != self.chat_id
):
    return False  # interaction event rejected!
```

The interaction event never reaches the button rendering code — clarify buttons don't appear.

## Fix

Strip the agent profile prefix when `conversation_id` contains multiple colons and differs from `chat_id`:

```python
# Normalize conversation_id: strip agent profile prefix
# so it matches the session created by message.started (which uses plain chat_id).
if conversation_id and ":" in conversation_id and conversation_id != chat_id:
    parts = conversation_id.split(":")
    if len(parts) >= 3:
        conversation_id = chat_id
```

## Impact

- Clarify/interaction cards now render correctly in multi-profile setups
- No behavioral change when conversation_id doesn't contain a prefix
- Consistent session matching across all event types