### PR TITLE
fix: support Hermes 0.20 async delivery ledger

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -1855,10 +1855,11 @@ def _find_exact_base_patch_locations(tree, lines):
         lambda node: _is_exact_mark_failed_call(node),
     )
 
-    # The ledger operations must finish in one direct child statement before
-    # the send. Merely checking line order would accept a source drift where
-    # `_send_with_retry` moved inside the ledger try, reopening the exact crash
-    # window this patch is meant to close.
+    # Hermes 0.20 keeps the ledger writes in a nested pre-send guard (and
+    # routes the blocking calls through asyncio.to_thread). The important
+    # invariant is that every ledger operation completes before `_send_with_retry`
+    # and that the send is not nested inside the ledger block; requiring all
+    # ledger nodes to precede the send preserves that crash-window boundary.
     send_position = _direct_child_position(text_guard.body, send)
     ledger_positions = {
         _direct_child_position(text_guard.body, node)
@@ -1867,8 +1868,7 @@ def _find_exact_base_patch_locations(tree, lines):
     if (
         send_position is None
         or None in ledger_positions
-        or len(ledger_positions) != 1
-        or next(iter(ledger_positions)) >= send_position
+        or any(position >= send_position for position in ledger_positions)
     ):
         raise ValueError("could not find safe BasePlatformAdapter contract")
 
@@ -1974,7 +1974,28 @@ def _same_expression(node, source: str) -> bool:
     )
 
 
+def _unwrap_asyncio_to_thread_call(call):
+    """Return the wrapped call for Hermes' blocking ledger adapters."""
+    if not isinstance(call, ast.Call):
+        return None
+    if not (
+        isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "asyncio"
+        and call.func.attr == "to_thread"
+        and call.args
+        and isinstance(call.args[0], ast.Name)
+    ):
+        return call
+    return ast.Call(
+        func=call.args[0],
+        args=call.args[1:],
+        keywords=call.keywords,
+    )
+
+
 def _call_function(call):
+    call = _unwrap_asyncio_to_thread_call(call)
     if not isinstance(call, ast.Call):
         return None, None
     func = call.func
@@ -2041,7 +2062,9 @@ def _is_exact_constant_assignment(node, *, target: str, value) -> bool:
 def _is_exact_compute_obligation_assignment(node) -> bool:
     if _assignment_target_names(node) != ("_obligation_id",):
         return False
-    call = _assignment_value(node)
+    call = _unwrap_asyncio_to_thread_call(_assignment_value(node))
+    if call is None:
+        return False
     owner, function = _call_function(call)
     return (
         owner is None
@@ -2063,7 +2086,9 @@ def _expression_call(node):
 
 
 def _is_exact_ledger_call(node, *, function: str, required_keywords) -> bool:
-    call = _expression_call(node)
+    call = _unwrap_asyncio_to_thread_call(_expression_call(node))
+    if call is None:
+        return False
     owner, actual_function = _call_function(call)
     if owner is not None or actual_function != function or call.args:
         return False
@@ -2075,7 +2100,9 @@ def _is_exact_ledger_call(node, *, function: str, required_keywords) -> bool:
 
 
 def _is_exact_positional_call(node, *, function: str, args) -> bool:
-    call = _expression_call(node)
+    call = _unwrap_asyncio_to_thread_call(_expression_call(node))
+    if call is None:
+        return False
     owner, actual_function = _call_function(call)
     return (
         owner is None
@@ -2118,7 +2145,9 @@ def _is_exact_final_send_assignment(node) -> bool:
 
 
 def _is_exact_mark_failed_call(node) -> bool:
-    call = _expression_call(node)
+    call = _unwrap_asyncio_to_thread_call(_expression_call(node))
+    if call is None:
+        return False
     owner, function = _call_function(call)
     return (
         owner is None

--- a/tests/fixtures/hermes_exact_base_v020.py
+++ b/tests/fixtures/hermes_exact_base_v020.py
@@ -1,0 +1,96 @@
+import asyncio
+
+
+class BasePlatformAdapter:
+    async def _process_message_background(self, event, session_key):
+        def _record_delivery(result):
+            return None
+
+        interrupt_event = self._active_sessions.get(session_key)
+        try:
+            response = await self._message_handler(event)
+            is_ephemeral_response = isinstance(response, EphemeralReply)
+            if response:
+                media_files, response = self.extract_media(response)
+                media_files = self.filter_media_delivery_paths(media_files)
+                images, text_content = self.extract_images(response)
+                text_content = _strip_media_directives(text_content).strip()
+                local_files = []
+                if not is_ephemeral_response:
+                    local_files, text_content = self.extract_local_files(text_content)
+                    local_files = self.filter_local_delivery_paths(local_files)
+                if not (text_content or images or local_files or media_files):
+                    _recovered = _strip_media_directives(response).strip()
+                    if _recovered:
+                        text_content = _recovered
+                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _tts_path = None
+                if text_content and not media_files:
+                    _tts_path = await make_tts(text_content)
+                _tts_caption_delivered = False
+                if _tts_path:
+                    telegram_tts_caption = text_content
+                    tts_result = await self.play_tts(
+                        chat_id=event.source.chat_id,
+                        audio_path=_tts_path,
+                        caption=telegram_tts_caption,
+                        metadata=_final_thread_metadata,
+                    )
+                    _tts_caption_delivered = bool(
+                        telegram_tts_caption and getattr(tts_result, "success", False)
+                    )
+                if text_content and not _tts_caption_delivered:
+                    delivery_adapter = self._final_delivery_adapter(event.source)
+                    _reply_anchor = _reply_anchor_for_event(event)
+                    _obligation_id = None
+                    if not is_ephemeral_response:
+                        try:
+                            from gateway.delivery_ledger import (
+                                compute_obligation_id,
+                                ledger_enabled,
+                                mark_attempting,
+                                record_obligation,
+                            )
+                            if ledger_enabled():
+                                _obligation_id = compute_obligation_id(
+                                    session_key,
+                                    str(getattr(event, "message_id", "") or ""),
+                                    text_content,
+                                )
+                                await asyncio.to_thread(
+                                    record_obligation,
+                                    obligation_id=_obligation_id,
+                                    session_key=session_key,
+                                    platform=str(event.source.platform.value),
+                                    chat_id=event.source.chat_id,
+                                    thread_id=getattr(event.source, "thread_id", None),
+                                    content=text_content,
+                                )
+                                await asyncio.to_thread(
+                                    mark_attempting,
+                                    _obligation_id,
+                                )
+                        except Exception:
+                            _obligation_id = None
+                    result = await delivery_adapter._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=text_content,
+                        reply_to=_reply_anchor,
+                        metadata=_final_thread_metadata,
+                    )
+                    _record_delivery(result)
+                    if _obligation_id is not None:
+                        try:
+                            from gateway.delivery_ledger import mark_delivered, mark_failed
+                            if getattr(result, "success", False):
+                                await asyncio.to_thread(mark_delivered, _obligation_id)
+                            else:
+                                await asyncio.to_thread(
+                                    mark_failed,
+                                    _obligation_id,
+                                    str(result.error or ""),
+                                )
+                        except Exception:
+                            pass
+        finally:
+            self._active_sessions.pop(session_key, None)

--- a/tests/unit/test_installer_detection.py
+++ b/tests/unit/test_installer_detection.py
@@ -16,6 +16,9 @@ FIXTURE_ROOT = (
 EXACT_BASE_FIXTURE = (
     Path(__file__).resolve().parents[1] / "fixtures" / "hermes_exact_base.py"
 )
+EXACT_BASE_V020_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "hermes_exact_base_v020.py"
+)
 TURN_RUNNER_FIXTURE = (
     Path(__file__).resolve().parents[1] / "fixtures" / "hermes_turn_runner.py"
 )
@@ -32,6 +35,19 @@ def test_detect_hermes_supports_v2026_4_23_fixture():
     assert result.run_py.name == "run.py"
     assert result.supported is True
     assert result.reason == "supported"
+
+
+def test_detect_hermes_supports_v020_async_ledger_contract(tmp_path):
+    root = _write_hermes_root(tmp_path / "hermes", version="v0.20.0")
+    _write_exact_base(root, EXACT_BASE_V020_FIXTURE)
+
+    result = detect_hermes(root)
+
+    assert result.supported is True
+    assert result.reason == "supported"
+    assert result.base_required is True
+    assert result.base_hook_strategy == "exact_base_delivery"
+    assert result.capabilities["exact_base_delivery"] is True
 
 
 def test_detect_legacy_strategy_for_v2026_4_23_fixture():
@@ -1055,10 +1071,13 @@ def _supported_run_py() -> str:
     )
 
 
-def _write_exact_base(root: Path) -> Path:
+def _write_exact_base(
+    root: Path,
+    fixture: Path = EXACT_BASE_FIXTURE,
+) -> Path:
     base_py = root / "gateway" / "platforms" / "base.py"
     base_py.parent.mkdir(parents=True, exist_ok=True)
-    base_py.write_text(EXACT_BASE_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    base_py.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
     return base_py
 
 

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -9,6 +9,9 @@ from hermes_feishu_card.install import patcher
 TURN_RUNNER_FIXTURE = (
     Path(__file__).resolve().parents[1] / "fixtures" / "hermes_turn_runner.py"
 )
+HERMES_V020_BASE_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "hermes_exact_base_v020.py"
+)
 
 
 def test_apply_patch_accepts_explicit_legacy_strategy():
@@ -2067,6 +2070,27 @@ def test_apply_base_patch_inserts_exact_hooks_at_semantic_boundaries():
     ast.parse(patched)
     assert patcher.apply_base_patch(patched) == patched
     assert patcher.remove_base_patch(patched) == _EXACT_BASE_SOURCE
+
+
+def test_apply_base_patch_accepts_hermes_v020_async_ledger_contract():
+    content = HERMES_V020_BASE_FIXTURE.read_text(encoding="utf-8")
+
+    patched = patcher.apply_base_patch(content)
+
+    assert patched.index(patcher.EXACT_BASE_NO_TEXT_PATCH_BEGIN) < patched.index(
+        "if text_content and not _tts_caption_delivered:"
+    )
+    assert patched.index(
+        "await asyncio.to_thread(\n                                    mark_attempting,"
+    ) < patched.index(
+        "result = await delivery_adapter._send_with_retry("
+    )
+    assert patched.index(patcher.EXACT_BASE_FINAL_DELIVERY_PATCH_BEGIN) < patched.index(
+        "result = await delivery_adapter._send_with_retry("
+    )
+    ast.parse(patched)
+    assert patcher.apply_base_patch(patched) == patched
+    assert patcher.remove_base_patch(patched) == content
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add Hermes 0.20 exact Base-platform compatibility for delivery-ledger calls wrapped in `asyncio.to_thread(...)`.
- Allow the ledger pre-send operations to live in Hermes 0.20's nested guard while preserving the fail-closed send-order invariant.
- Add a Hermes 0.20 regression fixture and installer/patcher coverage, including patch idempotency and recovery round-trip checks.

## Validation

- `python3 -m pytest -q tests/unit/test_installer_detection.py tests/unit/test_patcher.py`
  - `172 passed`
- In-memory validation against the unpatched Hermes `HEAD` `gateway/platforms/base.py`:
  - patch applied successfully
  - `remove_base_patch(apply_base_patch(source)) == source`
- `git diff --check` passed.

The full local suite was also exercised. It reached `2386 passed, 5 skipped, 16 failed`; the failures are environment-sensitive CLI/process/runtime-integrity tests involving the locally installed sidecar, state-directory policy, and profile/Feishu environment, rather than the changed AST patcher tests. The targeted installer and patcher suite is green.

## Safety notes

- The patcher still rejects ambiguous or reordered contracts.
- `asyncio.to_thread` is only unwrapped when it has a positional named callable, after which the existing exact function/argument checks remain in force.
- No Hermes production files are changed by this PR.
