### PR TITLE
fix: resolve slash-confirm off the Feishu callback path to avoid 3s timeout

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -3653,7 +3653,7 @@ def _hfc_command_result_card(
 
     normalized_content = str(content or "").strip() or "已处理。"
     return {
-        "config": {"wide_screen_mode": True},
+        "config": {"wide_screen_mode": True, "update_multi": True},
         "header": {
             "title": {"content": title, "tag": "plain_text"},
             "template": template,
@@ -5447,7 +5447,7 @@ async def _hfc_send_native_slash_confirm(
     prompt_title = str(title or "").strip() or "确认命令"
     detail = _hfc_slash_confirm_detail(message)
     card = {
-        "config": {"wide_screen_mode": True},
+        "config": {"wide_screen_mode": True, "update_multi": True},
         "header": {
             "title": {"content": prompt_title, "tag": "plain_text"},
             "template": "orange",
@@ -6305,17 +6305,97 @@ def _hfc_handle_native_slash_action(
     data: Any,
     action_value: dict[str, Any],
 ) -> Any:
+    """Resolve a slash-confirm button click without blocking the Feishu callback.
+
+    The Feishu card-action callback has a hard timeout of a few seconds; the
+    confirm handler can be arbitrarily slow (e.g. /reload-mcp runs a full MCP
+    reload).  Resolving synchronously inside the callback would exceed that
+    timeout and the returned result card would be discarded by Feishu, leaving
+    the card visually unresponsive even though the action succeeded.
+
+    Strategy: acknowledge the click immediately (empty callback response),
+    then resolve the confirm on the event loop in the background and push the
+    result card via a message PATCH update.  When the loop/submit helpers are
+    unavailable, fall back to the previous synchronous resolve so the confirm
+    still completes.
+    """
     _hfc_info("inline card action received: slash_confirm")
-    resolved = _hfc_resolve_native_slash_action(adapter, data, action_value)
-    if resolved is None:
+    prepared = _hfc_prepare_native_slash_action(adapter, data, action_value)
+    if prepared is None:
         _hfc_info("inline slash_confirm ignored: unresolved")
         return _hfc_empty_feishu_callback_response(adapter)
+
+    loop = getattr(adapter, "_loop", None)
+    submit = getattr(adapter, "_submit_on_loop", None)
+    if loop is None or not callable(submit):
+        # No event loop to schedule on — resolve synchronously (legacy path)
+        # so the confirmation still takes effect.
+        _hfc_resolve_native_slash_action(adapter, data, action_value)
+        return _hfc_empty_feishu_callback_response(adapter)
+
+    coroutine = _hfc_resolve_slash_confirm_background(adapter, data, action_value)
+    submitted = False
+    try:
+        submitted = bool(submit(loop, coroutine))
+        if not submitted:
+            _hfc_warn("background slash_confirm schedule failed")
+    except Exception as exc:
+        _hfc_warn(
+            "background slash_confirm schedule failed: "
+            f"{_hfc_exception_summary(exc)}"
+        )
+    finally:
+        if not submitted:
+            coroutine.close()
+    return _hfc_empty_feishu_callback_response(adapter)
+
+
+async def _hfc_resolve_slash_confirm_background(
+    adapter: Any,
+    data: Any,
+    action_value: dict[str, Any],
+) -> None:
+    """Resolve a slash-confirm off the Feishu callback path, then update the card.
+
+    After the confirm handler finishes (which may take seconds), the original
+    message card is updated in place via PATCH.  If the card cannot be
+    updated (e.g. message too old or update_multi not supported), a fresh
+    result card is sent as a follow-up message so the user still sees the
+    outcome.
+    """
+    resolved = await _hfc_resolve_native_slash_action_async(adapter, data, action_value)
+    if resolved is None:
+        _hfc_info("background slash_confirm ignored: unresolved")
+        return
     card, message_id = resolved
     _hfc_info(
-        "inline slash_confirm resolved: "
+        "background slash_confirm resolved: "
         f"{_hfc_log_reference('message', message_id)}"
     )
-    return _hfc_raw_feishu_callback_response(adapter, card)
+    if message_id and await _hfc_update_native_command_card(adapter, message_id, card):
+        _hfc_info("background slash_confirm: original card updated")
+        return
+    chat_id = _hfc_action_chat_id(data)
+    if not chat_id:
+        _hfc_warn("background slash_confirm: cannot determine chat_id for result card")
+        return
+    if not hasattr(adapter, "_feishu_send_with_retry"):
+        _hfc_warn("background slash_confirm: adapter has no _feishu_send_with_retry")
+        return
+    try:
+        await adapter._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=serialize_card_for_delivery(card),
+            reply_to=message_id or None,
+            metadata=_hfc_action_metadata(data),
+        )
+        _hfc_info("background slash_confirm: result card sent")
+    except Exception as exc:
+        _hfc_warn(
+            "background slash_confirm: result card send failed: "
+            f"{_hfc_exception_summary(exc)}"
+        )
 
 
 def _hfc_model_picker_choice_allowed(

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -982,6 +982,7 @@ def test_install_feishu_command_card_methods_adds_native_slash_confirm():
     assert adapter.sent["reply_to"] == "om_user_cmd"
 
     card = json.loads(adapter.sent["payload"])
+    assert card["config"] == {"wide_screen_mode": True, "update_multi": True}
     assert card["header"]["template"] == "orange"
     assert card["header"]["title"]["content"] == "/new"
     assert "This starts a fresh session" in card["elements"][0]["content"]
@@ -3608,7 +3609,7 @@ def test_refresh_feishu_event_handler_fails_open_when_ws_loop_state_raises():
     assert adapter._ws_client._event_handler is live_handler
 
 
-def test_feishu_command_card_action_resolves_native_slash_confirm(monkeypatch):
+def test_feishu_command_card_action_resolves_native_slash_confirm_in_background(monkeypatch):
     class FakeCallBackCard:
         def __init__(self):
             self.type = None
@@ -3630,6 +3631,7 @@ def test_feishu_command_card_action_resolves_native_slash_confirm(monkeypatch):
             self._loop = object()
             self._allowed_group_users = {"ou_user"}
             self.updated = None
+            self.sent = None
 
         def _loop_accepts_callbacks(self, loop):
             return loop is self._loop
@@ -3655,6 +3657,10 @@ def test_feishu_command_card_action_resolves_native_slash_confirm(monkeypatch):
             self.updated = request
             return SimpleNamespace(success=lambda: True)
 
+        async def _feishu_send_with_retry(self, **kwargs):
+            self.sent = kwargs
+            return SimpleNamespace(success=True, message_id="om_fallback")
+
         def _on_card_action_trigger(self, data):
             return "original"
 
@@ -3667,10 +3673,15 @@ def test_feishu_command_card_action_resolves_native_slash_confirm(monkeypatch):
     resolved = []
     slash_confirm_module = types.ModuleType("tools.slash_confirm")
 
+    async def fake_resolve(session_key, confirm_id, choice):
+        resolved.append((session_key, confirm_id, choice))
+        return "New session started."
+
     def fake_resolve_sync_compat(loop, session_key, confirm_id, choice):
         resolved.append((loop, session_key, confirm_id, choice))
         return "New session started."
 
+    slash_confirm_module.resolve = fake_resolve
     slash_confirm_module.resolve_sync_compat = fake_resolve_sync_compat
     tools_module = types.ModuleType("tools")
     tools_module.slash_confirm = slash_confirm_module
@@ -3704,13 +3715,131 @@ def test_feishu_command_card_action_resolves_native_slash_confirm(monkeypatch):
 
     response = adapter._on_card_action_trigger(data)
 
-    assert resolved == [(adapter._loop, "feishu:oc_abc", "cf-1", "once")]
+    # The callback returns an empty ack immediately (within Feishu's 3s
+    # callback timeout) instead of blocking on the slow confirm handler.
+    assert resolved == [("feishu:oc_abc", "cf-1", "once")]
     assert "cf-1" not in adapter._hfc_slash_confirm_state
-    assert adapter.updated is None
-    assert response.card.type == "raw"
-    card = response.card.data
+    assert response.card is None
+    # The result card is pushed via a background PATCH update instead of the
+    # callback response.
+    assert adapter.updated is not None
+    card = json.loads(adapter.updated.request_body.content)
     assert card["header"]["template"] == "green"
     assert "允许一次" in card["header"]["title"]["content"]
+    assert "New session started." in card["elements"][0]["content"]
+
+
+def test_feishu_command_card_action_slash_confirm_fallback_sends_result_when_patch_fails(monkeypatch):
+    """When the background PATCH update fails, a result card is still sent.
+
+    The confirm must never be lost silently: if the original message cannot
+    be updated (e.g. message too old, update_multi not honoured), the result
+    card is delivered as a new follow-up message.
+    """
+    class FakeCallBackCard:
+        def __init__(self):
+            self.type = None
+            self.data = None
+
+    class FakeP2Response:
+        def __init__(self):
+            self.card = None
+
+    class DummyFeishuAdapter:
+        name = "feishu"
+
+        def __init__(self):
+            self._client = SimpleNamespace(
+                im=SimpleNamespace(
+                    v1=SimpleNamespace(message=SimpleNamespace(update=lambda request: None))
+                )
+            )
+            self._loop = object()
+            self._allowed_group_users = {"ou_user"}
+            self.sent = None
+
+        def _loop_accepts_callbacks(self, loop):
+            return loop is self._loop
+
+        def _allow_group_message(self, sender_id, chat_id, is_bot=False):
+            return sender_id.open_id == "ou_user" and chat_id == "oc_abc"
+
+        def _get_cached_sender_name(self, open_id):
+            return "Bailey" if open_id == "ou_user" else ""
+
+        def _submit_on_loop(self, loop, coro):
+            assert loop is self._loop
+            asyncio.run(coro)
+            return True
+
+        def _build_update_message_body(self, *, msg_type, content):
+            return SimpleNamespace(msg_type=msg_type, content=content)
+
+        def _build_update_message_request(self, message_id, request_body):
+            return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+        async def _run_blocking(self, func, request):
+            # PATCH update fails.
+            return SimpleNamespace(success=lambda: False)
+
+        async def _feishu_send_with_retry(self, **kwargs):
+            self.sent = kwargs
+            return SimpleNamespace(success=True, message_id="om_result_card")
+
+        def _on_card_action_trigger(self, data):
+            return "original"
+
+    DummyFeishuAdapter.__module__ = hook_runtime.__name__
+    monkeypatch.setattr(
+        hook_runtime, "P2CardActionTriggerResponse", FakeP2Response, raising=False
+    )
+    monkeypatch.setattr(hook_runtime, "CallBackCard", FakeCallBackCard, raising=False)
+
+    async def fake_resolve(session_key, confirm_id, choice):
+        return "New session started."
+
+    slash_confirm_module = types.ModuleType("tools.slash_confirm")
+    slash_confirm_module.resolve = fake_resolve
+    tools_module = types.ModuleType("tools")
+    tools_module.slash_confirm = slash_confirm_module
+    monkeypatch.setitem(sys.modules, "tools", tools_module)
+    monkeypatch.setitem(sys.modules, "tools.slash_confirm", slash_confirm_module)
+
+    adapter = DummyFeishuAdapter()
+    adapter._hfc_slash_confirm_state = {
+        "cf-1": {
+            "session_key": "feishu:oc_abc",
+            "chat_id": "oc_abc",
+            "message_id": "om_slash_card",
+        }
+    }
+    runner = SimpleNamespace(adapters={"feishu": adapter})
+    assert hook_runtime.install_feishu_command_card_adapter_methods(runner) is True
+
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            action=SimpleNamespace(
+                value={
+                    "hfc_action": "slash_confirm",
+                    "hfc_confirm_id": "cf-1",
+                    "hfc_choice": "once",
+                }
+            ),
+            context=SimpleNamespace(open_chat_id="oc_abc"),
+            operator=SimpleNamespace(open_id="ou_user", user_id="u_1"),
+        )
+    )
+
+    response = adapter._on_card_action_trigger(data)
+
+    assert response.card is None
+    assert "cf-1" not in adapter._hfc_slash_confirm_state
+    assert adapter.sent is not None
+    assert adapter.sent["chat_id"] == "oc_abc"
+    assert adapter.sent["msg_type"] == "interactive"
+    assert adapter.sent["reply_to"] == "om_slash_card"
+    card = json.loads(adapter.sent["payload"])
+    assert card["header"]["template"] == "green"
     assert "New session started." in card["elements"][0]["content"]
 
 


### PR DESCRIPTION
## Summary

Slash-confirm button clicks (`/reload-mcp`, `/new`, etc.) were resolved **synchronously inside the Feishu card-action callback**. Feishu has a hard ~3-second card callback timeout (not configurable); when the confirm handler is slow — e.g. `/reload-mcp` runs a full MCP reload that takes several seconds — the callback response arrives too late, Feishu discards the result card, and the card stays visually unresponsive even though the action actually succeeded. Repeated clicks are then silently ignored (`ignored: unresolved`), making it look completely broken.

**Observed in the wild** (2026-08-05): click → handler completed and MCP reload succeeded at 10:24:49, but the callback response only returned at 10:24:52 (~4.2s), exceeding Feishu's 3s limit → card UI never updated.

## Fix

Follow the pattern already used by `model_picker` background switching (`_hfc_switch_model_background_task`):

1. **Ack the click immediately** with an empty callback response (within Feishu's timeout).
2. **Resolve the confirm in the background** on the event loop (new `_hfc_resolve_slash_confirm_background` → existing `_hfc_resolve_native_slash_action_async`).
3. **Push the result card via PATCH** (`_hfc_update_native_command_card`); if the original message can't be updated, send the result card as a follow-up message so the outcome is never lost.
4. Fall back to the previous synchronous resolve when the adapter has no loop/submit helpers.

Also declare **`"update_multi": true`** on slash-confirm and command result cards — Feishu requires this on a sent card before `PATCH /im/v1/messages/{id}` can update it. Without it, card updates fail with HTTP 500 / api_code 2200 (seen repeatedly in sidecar logs).

## Tests

- Updated `test_feishu_command_card_action_resolves_native_slash_confirm_in_background` to assert: empty ack response, background resolve, state cleanup, and PATCH update with the result card.
- Added `test_feishu_command_card_action_slash_confirm_fallback_sends_result_when_patch_fails`: when PATCH fails, the result card is delivered as a follow-up message.
- Added assertion that slash-confirm cards declare `update_multi: true`.
- All 380 unit tests in `tests/unit/test_hook_runtime.py` pass. (5 pre-existing integration-test failures are environment-related and fail identically on the base commit.)

## Checklist

- [x] Root cause identified with logs + code path
- [x] Fix follows existing in-repo pattern (`model_picker` background task)
- [x] Tests updated/added for new behavior
- [x] CHANGELOG updated
