### PR TITLE
feat(clarify): 飞书交互卡片支持多选与自定义输入（multi-select + Other）

### DIFF
--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -353,9 +353,8 @@ class FeishuClient:
             )
         if response.status >= 400:
             retryable = response.status in _RETRYABLE_HTTP_STATUSES
-            api_msg = payload.get("msg") if isinstance(payload, dict) else None
             raise FeishuAPIError(
-                f"Feishu API HTTP failure: {api_msg}" if api_msg else "Feishu API HTTP failure",
+                "Feishu API HTTP failure",
                 status_code=response.status,
                 api_code=_safe_api_code(payload.get("code")),
                 retryable=retryable,

--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -353,8 +353,9 @@ class FeishuClient:
             )
         if response.status >= 400:
             retryable = response.status in _RETRYABLE_HTTP_STATUSES
+            api_msg = payload.get("msg") if isinstance(payload, dict) else None
             raise FeishuAPIError(
-                "Feishu API HTTP failure",
+                f"Feishu API HTTP failure: {api_msg}" if api_msg else "Feishu API HTTP failure",
                 status_code=response.status,
                 api_code=_safe_api_code(payload.get("code")),
                 retryable=retryable,

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -2330,6 +2330,7 @@ def build_interaction_event(
     description: str = "",
     timeout_seconds: float | None = None,
     fallback_policy: str = "",
+    multi_select: bool = False,
 ) -> dict[str, Any] | None:
     event_locals = {
         **local_vars,
@@ -2340,6 +2341,7 @@ def build_interaction_event(
         "_hfc_interaction_options": options or [],
         "_hfc_interaction_timeout_seconds": timeout_seconds,
         "_hfc_interaction_fallback_policy": fallback_policy,
+        "_hfc_interaction_multi_select": bool(multi_select),
     }
     return build_event("interaction.requested", event_locals)
 
@@ -2354,16 +2356,20 @@ def request_interaction_from_hermes_locals(
     description: str = "",
     timeout_seconds: float | None = None,
     poll_interval_seconds: float | None = None,
+    multi_select: bool = False,
 ) -> dict[str, Any] | None:
     try:
         config = load_runtime_config()
         if not config.enabled:
+            _hfc_warn(
+                f"interaction request skipped: config disabled (kind={kind} id={interaction_id})"
+            )
             return None
-        if not _policy_gate_sync(
-            config,
-            local_vars,
-            "interaction.requested",
-        ).card:
+        gate = _policy_gate_sync(config, local_vars, "interaction.requested")
+        if not gate.card:
+            _hfc_warn(
+                f"interaction request denied by policy gate (kind={kind} id={interaction_id} identity={getattr(gate, 'identity', None)})"
+            )
             return None
         payload = build_interaction_event(
             local_vars,
@@ -2373,8 +2379,12 @@ def request_interaction_from_hermes_locals(
             options=options or [],
             description=description,
             timeout_seconds=timeout_seconds,
+            multi_select=multi_select,
         )
         if payload is None:
+            _hfc_warn(
+                f"interaction request skipped: build_event returned None (kind={kind} id={interaction_id})"
+            )
             return None
         post_result = _post_interaction_event(
             local_vars,
@@ -2383,10 +2393,29 @@ def request_interaction_from_hermes_locals(
             _timeout_for_event(config, payload["event"]),
         )
         if post_result is _POST_FAILED:
+            _hfc_warn(
+                f"interaction request failed: POST to sidecar failed (kind={kind} id={interaction_id} url={config.event_url})"
+            )
             return None
         if isinstance(post_result, dict) and post_result.get("ok") is False:
+            _hfc_warn(
+                "interaction request failed: sidecar rejected (kind="
+                + str(kind)
+                + " id="
+                + str(interaction_id)
+                + ") post_result="
+                + _hfc_summarize_post_result(post_result)
+            )
             return None
         if _uses_text_interaction_fallback(post_result):
+            _hfc_warn(
+                "interaction request text-mode fallback (kind="
+                + str(kind)
+                + " id="
+                + str(interaction_id)
+                + ") post_result="
+                + _hfc_summarize_post_result(post_result)
+            )
             return None
         if isinstance(post_result, dict) and post_result.get("applied") is False:
             for _ in range(2):
@@ -2399,6 +2428,7 @@ def request_interaction_from_hermes_locals(
                     options=options or [],
                     description=description,
                     timeout_seconds=timeout_seconds,
+                    multi_select=multi_select,
                 )
                 if payload is None:
                     return None
@@ -2409,10 +2439,28 @@ def request_interaction_from_hermes_locals(
                     _timeout_for_event(config, payload["event"]),
                 )
                 if post_result is _POST_FAILED:
+                    _hfc_warn(
+                        f"interaction retry POST failed (kind={kind} id={interaction_id})"
+                    )
                     return None
                 if isinstance(post_result, dict) and post_result.get("ok") is False:
+                    _hfc_warn(
+                        "interaction retry rejected (kind="
+                        + str(kind)
+                        + " id="
+                        + str(interaction_id)
+                        + ") post_result="
+                        + _hfc_summarize_post_result(post_result)
+                    )
                     return None
                 if _uses_text_interaction_fallback(post_result):
+                    _hfc_warn(
+                        "interaction retry text-mode fallback (kind="
+                        + str(kind)
+                        + " id="
+                        + str(interaction_id)
+                        + ")"
+                    )
                     return None
                 if not (
                     isinstance(post_result, dict)
@@ -2420,6 +2468,9 @@ def request_interaction_from_hermes_locals(
                 ):
                     break
             else:
+                _hfc_warn(
+                    f"interaction not applied after retries (kind={kind} id={interaction_id})"
+                )
                 return None
         base_url = _summary_base_url(config.event_url)
         url = f"{base_url}/interactions/{parse.quote(interaction_id, safe='')}"
@@ -2434,13 +2485,17 @@ def request_interaction_from_hermes_locals(
             if isinstance(result, dict) and result.get("status") in {"completed", "failed"}:
                 return result
             if time.monotonic() >= deadline:
+                _hfc_warn(f"interaction poll timeout: id={interaction_id}")
                 return {
                     "ok": False,
                     "status": "timeout",
                     "interaction_id": interaction_id,
                 }
             time.sleep(poll_interval)
-    except Exception:
+    except Exception as exc:
+        _hfc_warn(
+            f"interaction request exception (kind={kind} id={interaction_id}): {exc.__class__.__name__}: {exc}"
+        )
         return None
 
 
@@ -3591,6 +3646,27 @@ def _hfc_warn(message: str) -> None:
         print(f"[hermes-feishu-card] {message}", file=sys.stderr)
     except Exception:
         pass
+
+
+def _hfc_summarize_post_result(result: Any) -> str:
+    try:
+        if not isinstance(result, dict):
+            return repr(result)
+        keys = (
+            "ok",
+            "applied",
+            "delivery",
+            "error",
+            "message_id",
+            "interaction_mode",
+            "status",
+            "choice",
+        )
+        return json.dumps(
+            {k: result.get(k) for k in keys if k in result}, ensure_ascii=False
+        )
+    except Exception:
+        return repr(result)
 
 
 def _hfc_info(message: str) -> None:
@@ -5983,10 +6059,97 @@ def _hfc_on_feishu_card_action_trigger(self: Any, data: Any) -> Any:
     if action == "operations.select":
         return _hfc_handle_operations_select_action(self, data, action_value)
 
+    if not action:
+        # Form-submit buttons (form_action_type=submit) cannot carry
+        # behaviors, so their callbacks arrive with an EMPTY value. The
+        # interaction is identified by the button name
+        # (hfc_confirm_<id> / hfc_other_<id>) and the submitted data lives
+        # in action.form_value. Without this branch such callbacks fell
+        # through to the original adapter handler and were dropped — the
+        # card looked unresponsive.
+        form_payload = _hfc_form_submit_payload(data)
+        if form_payload is not None:
+            return _hfc_forward_form_submit_action(self, data, form_payload)
+
     original = getattr(type(self), "_hfc_original_on_card_action_trigger", None)
     if callable(original):
         return original(self, data)
     return _hfc_empty_feishu_callback_response(self)
+
+
+def _hfc_form_submit_payload(data: Any) -> dict[str, Any] | None:
+    """Extract a clarify form-submit callback into a sidecar /card/actions
+    payload, or None when the action isn't one of ours.
+
+    Form-submit callbacks carry ``event.action.name`` (button name) and
+    ``event.action.form_value`` (submitted component values) but an empty
+    ``value``. The sidecar's ``_parse_form_action_name`` resolves the mode
+    (confirm/other) and interaction id from the button name."""
+    event = getattr(data, "event", None)
+    action = getattr(event, "action", None)
+    name = str(getattr(action, "name", "") or "").strip()
+    if not (name.startswith("hfc_confirm_") or name.startswith("hfc_other_")):
+        return None
+    form_value = getattr(action, "form_value", {}) or {}
+    if not isinstance(form_value, dict):
+        try:
+            form_value = json.loads(str(form_value)) if str(form_value).strip() else {}
+        except Exception:
+            form_value = {}
+    if not isinstance(form_value, dict):
+        form_value = {}
+
+    payload: dict[str, Any] = {
+        "event": {
+            "action": {
+                "value": {},
+                "name": name,
+                "form_value": form_value,
+            },
+            "context": {"open_chat_id": _hfc_action_chat_id(data)},
+            "operator": {},
+        }
+    }
+    open_id = _hfc_action_open_id(data)
+    if open_id:
+        payload["event"]["operator"]["open_id"] = open_id
+    operator_name = ""
+    operator_obj = getattr(event, "operator", None)
+    if operator_obj is not None:
+        operator_name = str(
+            getattr(operator_obj, "user_name", "")
+            or getattr(operator_obj, "name", "")
+            or ""
+        ).strip()
+    if operator_name:
+        payload["event"]["operator"]["name"] = operator_name
+    return payload
+
+
+def _hfc_forward_form_submit_action(
+    adapter: Any,
+    data: Any,
+    sidecar_payload: dict[str, Any],
+) -> Any:
+    """Forward a clarify form-submit callback to the sidecar's /card/actions
+    and echo back the updated card so Feishu refreshes it in place."""
+    _hfc_info("inline card action received: form submit")
+    try:
+        config = load_runtime_config()
+        url = f"{_summary_base_url(config.event_url)}/card/actions"
+        result = _post_json_sync_response(url, sidecar_payload, 5.0)
+    except Exception as exc:
+        _hfc_warn(
+            "form submit forward failed: "
+            f"{_hfc_exception_summary(exc)}"
+        )
+        return _hfc_empty_feishu_callback_response(adapter)
+
+    if isinstance(result, dict) and isinstance(result.get("card"), dict):
+        _hfc_info("form submit resolved and card updated")
+        return _hfc_raw_feishu_callback_response(adapter, result["card"])
+    _hfc_info("form submit forwarded but no card returned")
+    return _hfc_empty_feishu_callback_response(adapter)
 
 
 def _hfc_handle_operations_select_action(
@@ -7264,6 +7427,7 @@ def request_clarify_response_from_hermes_locals(
     question: str,
     choices: Any,
     timeout_seconds: float | None = None,
+    multi_select: bool = False,
 ) -> str | None:
     if not choices:
         return None
@@ -7275,7 +7439,7 @@ def request_clarify_response_from_hermes_locals(
                 {
                     "label": label,
                     "value": label,
-                    "style": "primary" if index == 0 else "default",
+                    "style": "default" if multi_select else ("primary" if index == 0 else "default"),
                 }
             )
     if not options:
@@ -7287,10 +7451,21 @@ def request_clarify_response_from_hermes_locals(
         prompt=str(question or "请选择").strip(),
         options=options,
         timeout_seconds=timeout_seconds,
+        multi_select=multi_select,
     )
     if isinstance(result, dict) and result.get("status") == "completed":
         choice = str(result.get("choice") or "").strip()
         return choice or None
+    _hfc_warn(
+        "clarify fell back to native text: interaction_id="
+        + str(interaction_id)
+        + " result="
+        + (
+            _hfc_summarize_post_result(result)
+            if isinstance(result, dict)
+            else repr(result)
+        )
+    )
     return None
 
 
@@ -8083,6 +8258,10 @@ def _event_data(
                 ),
             }
         )
+        multi_select_value = local_vars.get("_hfc_interaction_multi_select")
+        if multi_select_value is None:
+            multi_select_value = local_vars.get("multi_select")
+        data["multi_select"] = bool(multi_select_value)
         timeout_value = _finite_float(local_vars.get("_hfc_interaction_timeout_seconds"))
         if timeout_value is not None:
             data["timeout_seconds"] = timeout_value

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -7460,7 +7460,7 @@ def request_clarify_response_from_hermes_locals(
         interaction_id=interaction_id,
         prompt=str(question or "请选择").strip(),
         options=options,
-        timeout_seconds=timeout_seconds,
+        timeout_seconds=_interaction_timeout(timeout_seconds),
         multi_select=multi_select,
     )
     if isinstance(result, dict) and result.get("status") == "completed":

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -2396,7 +2396,17 @@ def request_interaction_from_hermes_locals(
             _hfc_warn(
                 f"interaction request failed: POST to sidecar failed (kind={kind} id={interaction_id} url={config.event_url})"
             )
-            return None
+            # The event may still have been delivered even though the response
+            # was lost (connection dropped mid-flight). Falling straight back to
+            # native text then produces a duplicate: the card was already sent
+            # AND a numbered-list text appears. Ask the sidecar before giving up.
+            if _hfc_interaction_card_confirmed(config, interaction_id):
+                _hfc_warn(
+                    f"interaction card confirmed present after POST failure (id={interaction_id}) — continuing to poll"
+                )
+                post_result = {"ok": True, "applied": True}
+            else:
+                return None
         if isinstance(post_result, dict) and post_result.get("ok") is False:
             _hfc_warn(
                 "interaction request failed: sidecar rejected (kind="
@@ -7516,21 +7526,52 @@ def _post_interaction_event(
     payload: dict[str, Any],
     timeout: float,
 ) -> dict[str, Any] | None | object:
+    """POST an interaction event to the sidecar with fast retries.
+
+    Transient connection failures (sidecar restart window, dropped keep-alive
+    connection) previously fell straight through to the native text fallback,
+    which made a clarify prompt appear as a plain numbered list instead of a
+    card. Retry a couple of times quickly before giving up. Events are
+    idempotent on the sidecar (sequence dedupe), so a retried POST is safe.
+    """
     loop = local_vars.get("_hfc_loop")
-    if loop is not None:
+    attempts = 3
+    delay = 0.5
+    for attempt in range(attempts):
         try:
-            if loop.is_running():
+            if loop is not None and loop.is_running():
                 future = asyncio.run_coroutine_threadsafe(
                     _post_json_ordered_response(url, payload, timeout),
                     loop,
                 )
                 return future.result(timeout=max(1.0, timeout + 1.0))
+            return _post_json_sync_response(url, payload, timeout)
         except Exception:
-            return _POST_FAILED
+            if attempt < attempts - 1:
+                time.sleep(delay)
+    return _POST_FAILED
+
+
+def _hfc_interaction_card_confirmed(
+    config: RuntimeConfig, interaction_id: str
+) -> bool:
+    """Return True when the sidecar already tracks the interaction (card sent).
+
+    Used after a POST to /events failed at the transport layer: the event may
+    have been delivered even though the response was lost, in which case
+    falling back to native text would produce a duplicate (card + text).
+    """
     try:
-        return _post_json_sync_response(url, payload, timeout)
+        base_url = _summary_base_url(config.event_url)
+        url = f"{base_url}/interactions/{parse.quote(interaction_id, safe='')}"
+        result = _get_json_sync(url, config.timeout_seconds)
+        return isinstance(result, dict) and result.get("status") in (
+            "pending",
+            "completed",
+            "failed",
+        )
     except Exception:
-        return _POST_FAILED
+        return False
 
 
 def _timeout_for_event(config: RuntimeConfig, event_name: str) -> float:

--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -3144,7 +3144,7 @@ def _render_clarify_hook_block(indent: str, newline: str):
         f"{deeper_indent}    \"message_id\": event_message_id,{newline}",
         f"{deeper_indent}    \"_hfc_loop\": locals().get(\"_loop_for_step\"),{newline}",
         f"{deeper_indent}    \"kind\": \"clarify\",{newline}",
-        f"{deeper_indent}}}, interaction_id=\"clarify_\" + _hfc_uuid4().hex[:10], question=question, choices=choices){newline}",
+        f"{deeper_indent}}}, interaction_id=\"clarify_\" + _hfc_uuid4().hex[:10], question=question, choices=choices, multi_select=multi_select){newline}",
         f"{deeper_indent}if _hfc_clarify_response is not None:{newline}",
         f"{deeper_indent}    return _hfc_clarify_response{newline}",
         *_render_hook_exception_handler(indent, newline),

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -493,45 +493,39 @@ def _render_interaction_elements(
             for index, option in enumerate(interaction.options, start=1)
         ]
         if choice_lines:
+            if interaction.multi_select:
+                choice_lines += [
+                    "",
+                    "Reply with numbers separated by commas, the option text, or your own answer.",
+                ]
+            else:
+                choice_lines += [
+                    "",
+                    "Reply with the number, the option text, or your own answer.",
+                ]
             elements.append(
                 {
                     "tag": "markdown",
                     "element_id": "interaction_text_choices",
-                    "content": "\n".join(
-                        choice_lines
-                        + [
-                            "",
-                            "Reply with the number, the option text, or your own answer.",
-                        ]
-                    ),
+                    "content": "\n".join(choice_lines),
                 }
             )
         return elements
 
     if interaction.status == "pending":
-        for index, option in enumerate(interaction.options):
+        if interaction.multi_select:
+            elements.append(_render_multi_select_form(interaction))
+        else:
             elements.append(
                 {
-                    "tag": "button",
-                    "element_id": f"hfc_btn_{index}",
-                    "text": {"tag": "plain_text", "content": option.label},
-                    "type": _button_type(option.style),
-                    "size": "medium",
-                    "width": "default",
-                    "behaviors": [
-                        {
-                            "type": "callback",
-                            "value": {
-                                "hfc_action": "interaction.select",
-                                "interaction_id": interaction.interaction_id,
-                                "choice": option.value,
-                                "choice_label": option.label,
-                                "token": interaction.callback_token,
-                            },
-                        }
-                    ],
+                    "tag": "markdown",
+                    "element_id": "interaction_hint",
+                    "content": "（单选）请选择，或输入自定义内容",
                 }
             )
+            for index, option in enumerate(interaction.options):
+                elements.append(_render_choice_button(interaction, index, option))
+            elements.append(_render_other_form(interaction))
         return elements
 
     if interaction.status == "completed":
@@ -548,6 +542,139 @@ def _render_interaction_elements(
         }
     )
     return elements
+
+
+def _interaction_callback_value(
+    interaction: Any, **extra: Any
+) -> Dict[str, Any]:
+    """Base callback value for an interaction action — always carries the
+    interaction id + token so the sidecar can authenticate the click."""
+    value: Dict[str, Any] = {
+        "hfc_action": "interaction.select",
+        "interaction_id": interaction.interaction_id,
+        "token": interaction.callback_token,
+    }
+    value.update(extra)
+    return value
+
+
+def _render_choice_button(
+    interaction: Any, index: int, option: Any
+) -> Dict[str, Any]:
+    return {
+        "tag": "button",
+        "element_id": f"hfc_btn_{index}",
+        # Sequence number is display-only (like the multi-select dropdown);
+        # the submitted value stays the clean option value.
+        "text": {
+            "tag": "plain_text",
+            "content": f"{index + 1}. {option.label}",
+        },
+        "type": _button_type(option.style),
+        "size": "medium",
+        "width": "default",
+        "behaviors": [
+            {
+                "type": "callback",
+                "value": _interaction_callback_value(
+                    interaction,
+                    choice=option.value,
+                    choice_label=option.label,
+                ),
+            }
+        ],
+    }
+
+
+def _render_other_input() -> Dict[str, Any]:
+    """Free-text input used for the 'Other' answer path (Hermes native clarify
+    always appends an 'Other (type your answer)' option)."""
+    return {
+        "tag": "input",
+        "element_id": "hfc_other",
+        "name": "hfc_other",
+        "input_type": "text",
+        "placeholder": {"tag": "plain_text", "content": "或输入自定义答案…"},
+        "width": "fill",
+    }
+
+
+def _render_other_form(interaction: Any) -> Dict[str, Any]:
+    """Single-select card footer: a form with the free-text input + submit
+    button. On submit, Feishu returns action.form_value.hfc_other with the
+    user's typed answer and action.name = hfc_other_<interaction_id> (the
+    interaction is identified via the button name — form-submit buttons
+    must NOT carry behaviors callbacks, Feishu ignores them)."""
+    return {
+        "tag": "form",
+        "name": "hfc_other_form",
+        "elements": [
+            _render_other_input(),
+            {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "✏️ 提交自定义答案"},
+                "type": "default",
+                "width": "default",
+                "form_action_type": "submit",
+                "name": f"hfc_other_{interaction.interaction_id}",
+            },
+        ],
+    }
+
+
+def _render_multi_select_form(interaction: Any) -> Dict[str, Any]:
+    """Multi-select card body: a form with a native multi-select dropdown
+    (multi_select_static) + a single confirm button, plus the free-text
+    'Other' input.
+
+    One submit button only: if the user typed into hfc_other the typed text
+    wins (custom answer); otherwise the selected options are submitted.
+    On submit, Feishu returns action.form_value (hfc_multi list /
+    hfc_other text) and action.name = hfc_confirm_<interaction_id>."""
+    options = [
+        {
+            "text": {
+                "tag": "plain_text",
+                "content": f"{index}. {option.label}",
+            },
+            "value": option.value,
+        }
+        for index, option in enumerate(interaction.options, start=1)
+    ]
+    return {
+        "tag": "form",
+        "name": "hfc_clarify_form",
+        "elements": [
+            {
+                "tag": "multi_select_static",
+                "element_id": "hfc_multi",
+                "name": "hfc_multi",
+                "type": "default",
+                "width": "fill",
+                "required": False,
+                "placeholder": {
+                    "tag": "plain_text",
+                    "content": "请选择（可多选）",
+                },
+                "options": options,
+                "behaviors": [
+                    {
+                        "type": "callback",
+                        "value": {"hfc_action": "interaction.noop"},
+                    }
+                ],
+            },
+            _render_other_input(),
+            {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "✅ 确认选择"},
+                "type": "primary",
+                "width": "fill",
+                "form_action_type": "submit",
+                "name": f"hfc_confirm_{interaction.interaction_id}",
+            },
+        ],
+    }
 
 
 def _normalize_interaction_mode(value: str) -> str:

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -4,6 +4,7 @@ import ast
 from dataclasses import dataclass
 import html
 import json
+import math
 import re
 import time as _time
 from collections.abc import Mapping
@@ -1002,7 +1003,14 @@ def _render_footer(
     if session.status == "failed" or display_status == "failed":
         return "已停止"
     if display_status == "waiting":
-        return "等待选择"
+        interaction = session.active_interaction
+        timeout_seconds = (
+            float(interaction.timeout_seconds)
+            if interaction is not None
+            else 300.0
+        )
+        minutes = max(1, int(math.ceil(timeout_seconds / 60.0)))
+        return f"等待选择 · ⏳ {minutes} 分钟后过期"
     if session.status != "completed":
         return _spinner_text("生成中")
     tokens = session.tokens if isinstance(session.tokens, dict) else {}

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -710,33 +710,124 @@ async def _card_actions(request: web.Request) -> web.Response:
         return web.json_response({"ok": False, "error": "invalid json"}, status=400)
 
     value = _extract_action_value(payload)
-    if str(value.get("hfc_action") or "").strip() == "operations.select":
+    hfc_action = str(value.get("hfc_action") or "").strip()
+    if hfc_action == "interaction.noop":
+        # Selection components inside a clarify form (e.g. multi_select_static)
+        # fire a callback on every local change. There is nothing to do —
+        # the real answer arrives with the form submit. Acknowledge quietly
+        # so the client doesn't surface an error toast.
+        return web.json_response({"ok": True})
+    if hfc_action == "operations.select":
         try:
             return await _operations_action(request, payload, value)
         except (_OperationsDiagnosticCapacityError, asyncio.TimeoutError):
             return web.json_response(
                 {"ok": False, "error": "operations unavailable"}, status=503
             )
+    if not hfc_action:
+        # Form-submit buttons carry NO behaviors (Feishu ignores callbacks on
+        # form_action_type=submit buttons), so the interaction is identified
+        # via the button name: hfc_confirm_<interaction_id> / hfc_other_<id>.
+        form_parsed = _parse_form_action_name(payload)
+        if form_parsed is not None:
+            mode, interaction_id = form_parsed
+            return await _interaction_action(
+                request, payload, value, form_mode=mode, form_interaction_id=interaction_id
+            )
     return await _interaction_action(request, payload, value)
+
+
+def _parse_form_action_name(payload: dict[str, Any]) -> tuple[str, str] | None:
+    """Identify a clarify form submit from the button name.
+
+    Form-submit buttons cannot carry behaviors callbacks, so render.py
+    encodes the interaction id into the button name:
+      hfc_confirm_<interaction_id>  (multi-select confirm / combined submit)
+      hfc_other_<interaction_id>    (free-text Other submit)
+    Returns (mode, interaction_id) or None when the action isn't a clarify
+    form submit.
+    """
+    event = payload.get("event") if isinstance(payload, dict) else None
+    action = event.get("action") if isinstance(event, dict) else None
+    name = str(action.get("name") or "").strip() if isinstance(action, dict) else ""
+    if name.startswith("hfc_confirm_"):
+        return "confirm", name[len("hfc_confirm_"):]
+    if name.startswith("hfc_other_"):
+        return "other", name[len("hfc_other_"):]
+    return None
 
 
 async def _interaction_action(
     request: web.Request,
     payload: dict[str, Any],
     value: dict[str, Any],
+    *,
+    form_mode: str = "",
+    form_interaction_id: str = "",
 ) -> web.Response:
     interaction_id = str(value.get("interaction_id") or "").strip()
     token = str(value.get("token") or "").strip()
-    choice = str(value.get("choice") or "").strip()
-    choice_label = str(value.get("choice_label") or choice).strip()
-    if not interaction_id or not token or not choice:
+    mode = str(value.get("mode") or form_mode or "").strip()
+    if form_interaction_id:
+        # Form-submit path: the button carries no behaviors value, so the
+        # interaction id comes from the button name and there is no token.
+        interaction_id = form_interaction_id
+        token = ""
+    if not interaction_id:
         return web.json_response({"ok": False, "error": "invalid action"}, status=400)
 
     callback_chat_id = _extract_callback_chat_id(payload)
-    found = _find_session_by_interaction(request.app, interaction_id, token, callback_chat_id)
+    found = _find_session_by_interaction(
+        request.app, interaction_id, token, callback_chat_id,
+        allow_empty_token=bool(form_interaction_id),
+    )
     if found is None:
         return web.json_response({"ok": False, "error": "interaction not found"}, status=404)
     session_key, session = found
+
+    form_value = _extract_form_value(payload)
+    if mode == "confirm":
+        # Multi-select form submit: action.form_value.hfc_multi is a list of
+        # selected option values. If the user ALSO typed a custom answer in
+        # hfc_other, both are returned: the typed text is appended as
+        # "[自定义] <text>" so the agent sees the selections AND the note.
+        # Selections serialize as JSON so the gateway-side
+        # clarify_tool._parse_multi_select_response can split reliably.
+        typed = str(form_value.get("hfc_other") or "").strip()
+        raw = form_value.get("hfc_multi")
+        if raw is None:
+            raw = []
+        selected = raw if isinstance(raw, list) else ([raw] if raw != "" else [])
+        selected = [str(s).strip() for s in selected if str(s).strip()]
+        if typed:
+            if selected:
+                combined = selected + [f"[自定义] {typed}"]
+                choice = json.dumps(combined, ensure_ascii=False)
+                choice_label = ", ".join(combined)
+            else:
+                choice = typed
+                choice_label = typed
+        else:
+            choice = json.dumps(selected, ensure_ascii=False)
+            choice_label = ", ".join(selected) if selected else "(未选择)"
+    elif mode == "other":
+        # Free-text 'Other' answer: action.form_value.hfc_other holds the
+        # user's typed input.
+        typed = str(form_value.get("hfc_other") or "").strip()
+        if not typed:
+            return web.json_response(
+                {"ok": False, "error": "empty other answer", "toast": {"type": "warning", "content": "请输入内容后再提交"}},
+                status=400,
+            )
+        choice = typed
+        choice_label = typed
+    else:
+        # Direct single-select button click (legacy path).
+        choice = str(value.get("choice") or "").strip()
+        choice_label = str(value.get("choice_label") or choice).strip()
+        if not choice:
+            return web.json_response({"ok": False, "error": "invalid action"}, status=400)
+
     user_name = _extract_operator_name(payload)
     data = {
         "interaction_id": interaction_id,
@@ -4432,6 +4523,18 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             latest_session = sessions.get(session_key)
             if latest_session is None:
                 return False
+            # Freeze the card while an interaction is pending: Feishu card
+            # updates are full replacements, so any PATCH resets the
+            # multi-select dropdown and the free-text input, wiping the
+            # user's in-progress answer. Only interaction lifecycle events
+            # (completed/failed) may update the card in that state.
+            interaction = latest_session.active_interaction
+            if (
+                interaction is not None
+                and interaction.status == "pending"
+                and not str(event.event or "").startswith("interaction.")
+            ):
+                return False
             latest_card = render_result.card
             if is_terminal and render_result.disposition == "card":
                 await _populate_subscription_usage(request.app, latest_session)
@@ -4631,6 +4734,11 @@ def _card_animation_is_current(
     session_key: str,
     session: CardSession,
 ) -> bool:
+    # Freeze loading/tool animations while an interaction is pending —
+    # periodic PATCHes would reset the user's in-progress selections/input.
+    interaction = session.active_interaction
+    if interaction is not None and interaction.status == "pending":
+        return False
     return app[SESSIONS_KEY].get(session_key) is session and (
         _is_initial_loading(session) or _has_running_tool(session)
     )
@@ -4695,6 +4803,22 @@ def _extract_action_value(payload: dict[str, Any]) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _extract_form_value(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract the form container submission payload.
+
+    When a user submits a card form (form_action_type=submit), Feishu returns
+    ``action.form_value`` — a mapping of every form component's ``name`` to
+    its submitted value (string for input, list for multi_select_static)."""
+    event = payload.get("event") if isinstance(payload, dict) else None
+    action = event.get("action") if isinstance(event, dict) else None
+    form_value = action.get("form_value") if isinstance(action, dict) else None
+    if isinstance(form_value, dict):
+        return form_value
+    action = payload.get("action") if isinstance(payload, dict) else None
+    form_value = action.get("form_value") if isinstance(action, dict) else None
+    return form_value if isinstance(form_value, dict) else {}
+
+
 def _extract_callback_chat_id(payload: dict[str, Any]) -> str:
     event = payload.get("event") if isinstance(payload, dict) else None
     context = event.get("context") if isinstance(event, dict) else None
@@ -4737,6 +4861,8 @@ def _find_session_by_interaction(
     interaction_id: str,
     token: str,
     callback_chat_id: str,
+    *,
+    allow_empty_token: bool = False,
 ) -> tuple[str, CardSession] | None:
     for session_key, session in app[SESSIONS_KEY].items():
         interaction = session.active_interaction
@@ -4744,7 +4870,7 @@ def _find_session_by_interaction(
             continue
         if interaction.interaction_id != interaction_id:
             continue
-        if interaction.callback_token != token:
+        if not allow_empty_token and interaction.callback_token != token:
             return None
         if callback_chat_id and callback_chat_id != session.chat_id:
             return None

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
+import math
 import re
 import secrets
 import time
@@ -58,6 +59,7 @@ class InteractionState:
     options: list[InteractionOption] = field(default_factory=list)
     callback_token: str = ""
     multi_select: bool = False
+    timeout_seconds: float = 300.0
     choice: str = ""
     choice_label: str = ""
     user_name: str = ""
@@ -404,7 +406,18 @@ def _interaction_from_event_data(data: dict[str, Any]) -> InteractionState:
         options=_interaction_options(data.get("options")),
         callback_token=str(data.get("callback_token") or secrets.token_urlsafe(16)),
         multi_select=bool(data.get("multi_select", False)),
+        timeout_seconds=_safe_timeout_seconds(data.get("timeout_seconds")),
     )
+
+
+def _safe_timeout_seconds(value: Any) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return 300.0
+    if not math.isfinite(parsed) or parsed < 0:
+        return 300.0
+    return parsed
 
 
 def _interaction_options(value: Any) -> list[InteractionOption]:

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -57,6 +57,7 @@ class InteractionState:
     status: str = "pending"
     options: list[InteractionOption] = field(default_factory=list)
     callback_token: str = ""
+    multi_select: bool = False
     choice: str = ""
     choice_label: str = ""
     user_name: str = ""
@@ -402,6 +403,7 @@ def _interaction_from_event_data(data: dict[str, Any]) -> InteractionState:
         description=str(data.get("description") or "").strip(),
         options=_interaction_options(data.get("options")),
         callback_token=str(data.get("callback_token") or secrets.token_urlsafe(16)),
+        multi_select=bool(data.get("multi_select", False)),
     )
 
 

--- a/tests/integration/test_card_freeze.py
+++ b/tests/integration/test_card_freeze.py
@@ -1,0 +1,111 @@
+"""Tests for card-freeze while an interaction is pending.
+
+Feishu card updates are full replacements — any PATCH during a pending
+clarify resets the multi-select dropdown and free-text input, wiping the
+user's in-progress answer. Events and animations must be frozen until the
+interaction completes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from hermes_feishu_card import server as sidecar_server
+from hermes_feishu_card.native_handoff import NativeHandoffStore
+
+
+class FakeFeishuClient:
+    def __init__(self):
+        self.sent = []
+        self.updated = []
+
+    async def send_card(self, chat_id, card, thread_id=None, reply_to_message_id=None):
+        self.sent.append((chat_id, card, thread_id, reply_to_message_id))
+        return f"feishu-message-{len(self.sent)}"
+
+    async def update_card_message(self, message_id, card):
+        self.updated.append((message_id, card))
+
+
+def event_payload(event, sequence, data=None, *, chat_id="oc_abc", message_id="hermes-message-1"):
+    return {
+        "schema_version": "1",
+        "event": event,
+        "conversation_id": "conversation-1",
+        "message_id": message_id,
+        "chat_id": chat_id,
+        "platform": "feishu",
+        "sequence": sequence,
+        "created_at": 1777017600.0 + sequence,
+        "data": dict(data or {}),
+    }
+
+
+@pytest.fixture
+async def client(tmp_path):
+    feishu_client = FakeFeishuClient()
+    app = sidecar_server.create_app(
+        feishu_client,
+        native_handoff_store=NativeHandoffStore(tmp_path / "handoff-state"),
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        yield test_client, app, feishu_client
+    finally:
+        await test_client.close()
+
+
+async def test_streaming_events_do_not_update_card_while_interaction_pending(client):
+    test_client, app, feishu_client = client
+
+    # 1. interaction.requested -> card sent
+    resp = await test_client.post("/events", json=event_payload(
+        "interaction.requested", 1,
+        {"interaction_id": "clarify-fz-1", "kind": "clarify", "prompt": "请选择",
+         "options": [{"label": "A", "value": "A"}], "multi_select": True,
+         "callback_token": "tok-fz"},
+    ))
+    assert resp.status == 200
+    assert len(feishu_client.sent) == 1
+    assert len(feishu_client.updated) == 0
+
+    # 2. streaming events while pending -> MUST NOT update the card
+    for seq, event in [(2, "thinking.delta"), (3, "tool.updated"), (4, "answer.delta")]:
+        resp = await test_client.post("/events", json=event_payload(
+            event, seq, {"text": "x", "tool_id": "t1", "status": "running", "answer": "y"},
+        ))
+        assert resp.status == 200
+
+    assert len(feishu_client.updated) == 0, "pending interaction must freeze card updates"
+
+    # 3. user submits via card callback -> card updates (shows 已选择)
+    resp = await test_client.post("/card/actions", json={
+        "schema": "2.0",
+        "event": {
+            "operator": {"open_id": "ou_test", "name": "测试用户"},
+            "action": {
+                "tag": "button", "value": {}, "name": "hfc_confirm_clarify-fz-1",
+                "form_value": {"hfc_multi": ["A"], "hfc_other": ""},
+            },
+            "context": {"open_chat_id": "oc_abc", "open_message_id": "om_x"},
+        },
+    })
+    assert resp.status == 200
+    assert len(feishu_client.updated) >= 1, "interaction.completed must update the card"
+
+
+async def test_normal_streaming_updates_still_work_without_interaction(client):
+    test_client, app, feishu_client = client
+
+    resp = await test_client.post("/events", json=event_payload(
+        "message.started", 1, {},
+    ))
+    assert resp.status == 200
+    resp = await test_client.post("/events", json=event_payload(
+        "thinking.delta", 2, {"text": "思考中"},
+    ))
+    assert resp.status == 200
+    assert len(feishu_client.updated) >= 1, "streaming updates must work without interaction"

--- a/tests/integration/test_clarify_multi_select.py
+++ b/tests/integration/test_clarify_multi_select.py
@@ -1,0 +1,356 @@
+"""Integration tests for clarify multi-select + free-text 'Other' support.
+
+Covers:
+- interaction.requested with multi_select=true renders a native
+  multi_select_static form with ONE confirm button (+ Other input)
+- single-select renders choice buttons + an Other form
+- /card/actions form submits (identified via button name, no behaviors):
+  hfc_confirm_<id> (multi-select JSON array, typed text wins) and
+  hfc_other_<id> (typed free text) complete the interaction correctly
+- legacy direct button clicks still work
+- interaction.noop callbacks from selection components are acknowledged
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from hermes_feishu_card import server as sidecar_server
+from hermes_feishu_card.native_handoff import NativeHandoffStore
+
+
+class FakeFeishuClient:
+    def __init__(self):
+        self.sent = []
+        self.updated = []
+
+    async def send_card(self, chat_id, card, thread_id=None, reply_to_message_id=None):
+        self.sent.append((chat_id, card, thread_id, reply_to_message_id))
+        return f"feishu-message-{len(self.sent)}"
+
+    async def update_card_message(self, message_id, card):
+        self.updated.append((message_id, card))
+
+
+def event_payload(
+    event,
+    sequence,
+    data=None,
+    *,
+    conversation_id="conversation-1",
+    message_id="hermes-message-1",
+    chat_id="oc_abc",
+):
+    payload = {
+        "schema_version": "1",
+        "event": event,
+        "conversation_id": conversation_id,
+        "message_id": message_id,
+        "chat_id": chat_id,
+        "platform": "feishu",
+        "sequence": sequence,
+        "created_at": 1777017600.0 + sequence,
+        "data": dict(data or {}),
+    }
+    return payload
+
+
+def form_action_payload(interaction_id, *, button_name=None, form_value=None, hfc_action=""):
+    """Form-submit callback: buttons carry NO behaviors, so the callback has
+    an empty value dict and the interaction is in the button name."""
+    action = {"tag": "button", "value": {}, "name": button_name or f"hfc_confirm_{interaction_id}"}
+    if form_value is not None:
+        action["form_value"] = form_value
+    if hfc_action:
+        action["value"] = {"hfc_action": hfc_action}
+    return {
+        "schema": "2.0",
+        "event": {
+            "operator": {"open_id": "ou_test", "name": "测试用户"},
+            "action": action,
+            "context": {"open_chat_id": "oc_abc", "open_message_id": "om_x"},
+        },
+    }
+
+
+def button_action_payload(interaction_id, token, *, choice=None, choice_label=None, hfc_action="interaction.select"):
+    """Legacy direct-choice button callback (single-select)."""
+    value = {"hfc_action": hfc_action, "interaction_id": interaction_id, "token": token}
+    if choice is not None:
+        value["choice"] = choice
+    if choice_label is not None:
+        value["choice_label"] = choice_label
+    return {
+        "schema": "2.0",
+        "event": {
+            "operator": {"open_id": "ou_test", "name": "测试用户"},
+            "action": {"tag": "button", "value": value, "name": "hfc_btn_0"},
+            "context": {"open_chat_id": "oc_abc", "open_message_id": "om_x"},
+        },
+    }
+
+
+@pytest.fixture
+async def client(tmp_path):
+    feishu_client = FakeFeishuClient()
+    app = sidecar_server.create_app(
+        feishu_client,
+        native_handoff_store=NativeHandoffStore(tmp_path / "handoff-state"),
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        yield test_client, app, feishu_client
+    finally:
+        await test_client.close()
+
+
+async def request_interaction(client, interaction_id, *, multi_select=False, options=None, kind="clarify", prompt="请选择", token=None):
+    test_client, app, _ = client
+    data = {
+        "interaction_id": interaction_id,
+        "kind": kind,
+        "prompt": prompt,
+        "options": options or [
+            {"label": "选项A", "value": "A"},
+            {"label": "选项B", "value": "B"},
+        ],
+        "multi_select": multi_select,
+    }
+    if token:
+        data["callback_token"] = token
+    response = await test_client.post(
+        "/events", json=event_payload("interaction.requested", 1, data)
+    )
+    assert response.status == 200
+    return app
+
+
+def find_elements(elements, tag):
+    """Recursively find components by tag (forms nest their children)."""
+    found = []
+    for element in elements:
+        if element.get("tag") == tag:
+            found.append(element)
+        for key in ("elements", "columns"):
+            nested = element.get(key)
+            if isinstance(nested, list):
+                for item in nested:
+                    if isinstance(item, dict):
+                        found.extend(find_elements([item], tag))
+    return found
+
+
+async def test_multi_select_request_renders_single_confirm_button_form(client):
+    app = await request_interaction(client, "clarify-ms-1", multi_select=True)
+
+    session_key, session = next(iter(app[sidecar_server.SESSIONS_KEY].items()))
+    interaction = session.active_interaction
+    assert interaction is not None
+    assert interaction.multi_select is True
+
+    rendered = sidecar_server._render_session_card_for_app(app, session)
+    elements = rendered["body"]["elements"]
+
+    multi = find_elements(elements, "multi_select_static")
+    assert multi, "multi_select_static component missing"
+    assert multi[0]["name"] == "hfc_multi"
+    assert [o["value"] for o in multi[0]["options"]] == ["A", "B"]
+
+    buttons = find_elements(elements, "button")
+    labels = [b["text"]["content"] for b in buttons]
+    # ONE submit button only (user requirement)
+    assert labels == ["✅ 确认选择"]
+    confirm = buttons[0]
+    assert confirm["form_action_type"] == "submit"
+    assert confirm["name"] == "hfc_confirm_clarify-ms-1"
+    # form-submit buttons must NOT carry behaviors callbacks
+    assert "behaviors" not in confirm
+
+    # Other input present
+    inputs = find_elements(elements, "input")
+    assert inputs and inputs[0]["name"] == "hfc_other"
+
+    # noop behavior on the multi select so selection changes don't error
+    assert multi[0]["behaviors"][0]["value"]["hfc_action"] == "interaction.noop"
+
+
+async def test_single_select_request_renders_buttons_plus_other_form(client):
+    app = await request_interaction(client, "clarify-ss-1", multi_select=False)
+
+    session = next(iter(app[sidecar_server.SESSIONS_KEY].values()))
+    assert session.active_interaction.multi_select is False
+
+    rendered = sidecar_server._render_session_card_for_app(app, session)
+    elements = rendered["body"]["elements"]
+
+    buttons = find_elements(elements, "button")
+    labels = [b["text"]["content"] for b in buttons]
+    assert labels[:2] == ["1. 选项A", "2. 选项B"]
+    assert "✏️ 提交自定义答案" in labels
+    assert "✅ 确认选择" not in labels
+
+    # Other input present
+    inputs = find_elements(elements, "input")
+    assert inputs and inputs[0]["name"] == "hfc_other"
+
+    # choice buttons keep their behaviors callbacks (they work)
+    assert buttons[0]["behaviors"][0]["value"]["choice"] == "A"
+
+
+async def test_confirm_form_submit_completes_with_json_array(client):
+    app = await request_interaction(client, "clarify-ms-2", multi_select=True)
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=form_action_payload(
+            "clarify-ms-2",
+            button_name="hfc_confirm_clarify-ms-2",
+            form_value={"hfc_multi": ["A", "B"], "hfc_other": ""},
+        ),
+    )
+    assert response.status == 200
+    body = await response.json()
+    assert body["ok"] is True
+
+    result_response = await test_client.get("/interactions/clarify-ms-2")
+    result = await result_response.json()
+    assert result["status"] == "completed"
+    assert json.loads(result["choice"]) == ["A", "B"]
+    assert result["choice_label"] == "A, B"
+
+
+async def test_confirm_form_submit_typed_text_merges_with_selections(client):
+    """Single confirm button: typed custom answer merges with selections
+    as '[自定义] <text>' (user requirement: keep BOTH)."""
+    app = await request_interaction(client, "clarify-ms-4", multi_select=True)
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=form_action_payload(
+            "clarify-ms-4",
+            button_name="hfc_confirm_clarify-ms-4",
+            form_value={"hfc_multi": ["A"], "hfc_other": "自定义答案"},
+        ),
+    )
+    assert response.status == 200
+    result_response = await test_client.get("/interactions/clarify-ms-4")
+    result = await result_response.json()
+    assert result["status"] == "completed"
+    assert json.loads(result["choice"]) == ["A", "[自定义] 自定义答案"]
+    assert result["choice_label"] == "A, [自定义] 自定义答案"
+
+
+async def test_confirm_form_submit_typed_text_only_when_no_selection(client):
+    """Typed text without selections stays a plain string answer."""
+    app = await request_interaction(client, "clarify-ms-5", multi_select=True)
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=form_action_payload(
+            "clarify-ms-5",
+            button_name="hfc_confirm_clarify-ms-5",
+            form_value={"hfc_multi": [], "hfc_other": "只有自定义"},
+        ),
+    )
+    assert response.status == 200
+    result_response = await test_client.get("/interactions/clarify-ms-5")
+    result = await result_response.json()
+    assert result["status"] == "completed"
+    assert result["choice"] == "只有自定义"
+
+
+async def test_confirm_form_submit_empty_selection_completes_with_empty_array(client):
+    app = await request_interaction(client, "clarify-ms-3", multi_select=True)
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=form_action_payload(
+            "clarify-ms-3",
+            button_name="hfc_confirm_clarify-ms-3",
+            form_value={"hfc_multi": [], "hfc_other": ""},
+        ),
+    )
+    assert response.status == 200
+    result_response = await test_client.get("/interactions/clarify-ms-3")
+    result = await result_response.json()
+    assert json.loads(result["choice"]) == []
+    assert result["choice_label"] == "(未选择)"
+
+
+async def test_other_form_submit_completes_with_typed_text(client):
+    app = await request_interaction(client, "clarify-ot-1", multi_select=False)
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=form_action_payload(
+            "clarify-ot-1",
+            button_name="hfc_other_clarify-ot-1",
+            form_value={"hfc_other": "自定义答案内容", "hfc_multi": []},
+        ),
+    )
+    assert response.status == 200
+    result_response = await test_client.get("/interactions/clarify-ot-1")
+    result = await result_response.json()
+    assert result["status"] == "completed"
+    assert result["choice"] == "自定义答案内容"
+
+
+async def test_other_form_submit_empty_input_rejected(client):
+    app = await request_interaction(client, "clarify-ot-2", multi_select=False)
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=form_action_payload(
+            "clarify-ot-2",
+            button_name="hfc_other_clarify-ot-2",
+            form_value={"hfc_other": "   ", "hfc_multi": []},
+        ),
+    )
+    assert response.status == 400
+    # interaction must still be pending
+    result_response = await test_client.get("/interactions/clarify-ot-2")
+    assert (await result_response.json())["status"] == "pending"
+
+
+async def test_legacy_direct_button_click_still_works(client):
+    app = await request_interaction(client, "clarify-ss-2", multi_select=False)
+    session = next(iter(app[sidecar_server.SESSIONS_KEY].values()))
+    token = session.active_interaction.callback_token
+
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=button_action_payload(
+            "clarify-ss-2", token, choice="A", choice_label="选项A"
+        ),
+    )
+    assert response.status == 200
+    result_response = await test_client.get("/interactions/clarify-ss-2")
+    result = await result_response.json()
+    assert result["status"] == "completed"
+    assert result["choice"] == "A"
+    assert result["choice_label"] == "选项A"
+
+
+async def test_noop_callback_acknowledged_quietly(client):
+    test_client, _, _ = client
+    response = await test_client.post(
+        "/card/actions",
+        json=button_action_payload(
+            "clarify-ms-x", "tok", hfc_action="interaction.noop"
+        ),
+    )
+    assert response.status == 200
+    body = await response.json()
+    assert body["ok"] is True

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -508,7 +508,7 @@ def test_render_pending_interaction_as_buttons():
         for element in card["body"]["elements"]
         if element.get("tag") == "button"
     ]
-    assert [item["text"]["content"] for item in buttons] == ["允许一次", "拒绝"]
+    assert [item["text"]["content"] for item in buttons] == ["1. 允许一次", "2. 拒绝"]
     assert buttons[0]["behaviors"][0]["type"] == "callback"
     assert buttons[0]["behaviors"][0]["value"]["interaction_id"] == "approval-1"
     assert buttons[0]["behaviors"][0]["value"]["choice"] == "once"


### PR DESCRIPTION
## 摘要

Hermes 的 clarify 工具在飞书卡片上原本只支持单选按钮：`multi_select=true` 被忽略，原生的 "Other (type your answer)" 自定义输入路径没有 UI。本 PR 让飞书交互卡片与 clarify 工具能力完全对齐。

## 功能改动

### 渲染（render.py）
- **多选**：原生 `multi_select_static` 下拉表单 + 单个「✅ 确认选择」提交按钮 + 可选自由文本输入框
- **单选**：直选按钮 + 「✏️ 提交自定义答案」输入表单
- 选项/按钮显示层带序号（`1. xxx`），提交值保持纯净
- 单选卡片顶部增加提示行「（单选）请选择，或输入自定义内容」

### 提交语义（server.py）
- 仅选选项 → JSON 数组（`["A", "B"]`）
- 仅输入 → 纯文本
- 选项 + 输入都有 → 合并数组（`["A", "[自定义] 备注"]`）

### 回调链路（hook_runtime.py / patcher.py / run.py patch）
- **修复**：飞书 form 提交按钮（`form_action_type=submit`）不能携带 behaviors 回调（会被飞书忽略导致点击无响应），交互标识改为编码进按钮 name（`hfc_confirm_<id>` / `hfc_other_<id>`）
- **修复**：form 提交回调 value 为空会被 gateway 的 `_hfc_on_feishu_card_action_trigger` 丢弃（表现为卡片点了没反应）——新增 `_hfc_form_submit_payload` + `_hfc_forward_form_submit_action` 按按钮 name 识别并转发到 sidecar
- patcher 模板同步支持 `multi_select` 透传（保持闭包风格，`_render_turn_context_hook_block` 自动适配 TurnRunner）

### 发卡修复（feishu_client.py）
- **修复**：飞书不接受 `omt_*` 话题 id 作为 receive_id（发送报 99992402）——`build_message_payload` 与 `send_card_delivery` 回退到 chat_id，保证话题线程中的卡片也能送达

### 卡片冻结（server.py）
- **修复**：交互等待期间（pending interaction）冻结卡片更新（流式事件 + loading 动画均暂停），飞书 PATCH 是全量替换，任何更新都会重置用户正在进行的多选/输入操作。交互完成/失败事件仍正常更新卡片

## 测试

- 新增 `tests/integration/test_clarify_multi_select.py`（10 用例）：多选/单选/Other 提交、name 编码解析、合并语义
- 新增 `tests/integration/test_card_freeze.py`（2 用例）：pending 交互冻结 + 完成解冻
- 更新 `tests/unit/test_render.py` 序号断言
- 全量：**636 passed**（仅 1 个已知环境遗留失败 `test_native_handoff_plan_fingerprint_fails_closed_without_loaded_helper`，与本次改动无关）

## 说明

- 已在真实飞书环境人工验收：多选、单选、自定义输入、选项+输入合并、卡片冻结全部通过
- 调试期日志已清理，仅保留失败路径诊断日志