### PR TITLE
修复：让命令审批卡按 Hermes 能力自适应

### DIFF
--- a/docs/event-protocol.en.md
+++ b/docs/event-protocol.en.md
@@ -18,6 +18,8 @@ The minimal Hermes hook sends message lifecycle events to the sidecar. The hook 
 | `interaction.completed` | A card button was clicked. The sidecar updates the original card with the selected option and lets the Hermes hook poll the result to continue. |
 | `interaction.failed` | The interaction failed or timed out. The sidecar preserves the failed state and the Hermes hook can fail open to native Hermes behavior. |
 
+`interaction.requested.data.allow_custom_input` explicitly declares whether the interaction accepts content outside the supplied options. When `true`, the card renders an Other input; when `false`, it renders only the fixed options supplied by Hermes. The hook emits `true` for Clarify interactions and defaults to `false` for approvals, keeping approval cards aligned with Hermes' native UI. For legacy events without this field, only `kind=clarify` defaults to custom input.
+
 ## Routing Fields
 
 All events keep the required `conversation_id`, `message_id`, and `chat_id` fields. From V3.6.4, events may also carry an optional `thread_id`; when it represents a Feishu `om_` / `omt_` thread context, the sidecar uses the Feishu reply API to create the initial card in the same thread where the user sent the message. Later updates still PATCH the created card message.

--- a/docs/event-protocol.md
+++ b/docs/event-protocol.md
@@ -18,6 +18,8 @@ Hermes 最小 hook 向 sidecar 发送消息生命周期事件。第二阶段 hoo
 | `interaction.completed` | 用户点击卡片按钮后发出。sidecar 更新原卡片为已选择状态，并让 Hermes hook 轮询到选择结果后继续执行。 |
 | `interaction.failed` | 交互请求失败或超时。sidecar 保留失败状态，Hermes hook 可 fail-open 回到原生 Hermes 交互路径。 |
 
+`interaction.requested.data.allow_custom_input` 明确声明当前交互是否允许用户输入选项之外的内容。为 `true` 时卡片显示“其他”输入框；为 `false` 时只显示 Hermes 下发的固定选项。hook 对 Clarify 交互下发 `true`，对审批交互默认下发 `false`，因此审批卡片与 Hermes 原生 UI 保持一致。兼容旧事件时，仅 `kind=clarify` 会默认允许自定义输入。
+
 ## 路由字段
 
 所有事件都保留 `conversation_id`、`message_id` 和 `chat_id` 三个必填字段。V3.6.4 起，事件还可以携带可选 `thread_id` 字段；当它是飞书 `om_` / `omt_` thread 上下文时，sidecar 会在创建初始卡片时使用飞书 reply API，把卡片发回用户所在的同一 thread。后续更新仍然 PATCH 这条已创建的卡片消息。

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -2332,7 +2332,10 @@ def build_interaction_event(
     timeout_seconds: float | None = None,
     fallback_policy: str = "",
     multi_select: bool = False,
+    allow_custom_input: bool | None = None,
 ) -> dict[str, Any] | None:
+    if allow_custom_input is None:
+        allow_custom_input = kind == "clarify"
     event_locals = {
         **local_vars,
         "_hfc_interaction_id": interaction_id,
@@ -2343,6 +2346,7 @@ def build_interaction_event(
         "_hfc_interaction_timeout_seconds": timeout_seconds,
         "_hfc_interaction_fallback_policy": fallback_policy,
         "_hfc_interaction_multi_select": bool(multi_select),
+        "_hfc_interaction_allow_custom_input": bool(allow_custom_input),
     }
     return build_event("interaction.requested", event_locals)
 
@@ -2358,6 +2362,7 @@ def request_interaction_from_hermes_locals(
     timeout_seconds: float | None = None,
     poll_interval_seconds: float | None = None,
     multi_select: bool = False,
+    allow_custom_input: bool | None = None,
 ) -> dict[str, Any] | None:
     try:
         config = load_runtime_config()
@@ -2383,6 +2388,7 @@ def request_interaction_from_hermes_locals(
             description=description,
             timeout_seconds=timeout_seconds,
             multi_select=multi_select,
+            allow_custom_input=allow_custom_input,
         )
         if payload is None:
             _hfc_warn(
@@ -7283,23 +7289,32 @@ def request_approval_choice_from_hermes_locals(
 ) -> str | None:
     command = str(approval_data.get("command") or "").strip()
     description = str(approval_data.get("description") or "dangerous command").strip()
+    smart_denied = approval_data.get("smart_denied") is True
+    allow_session = approval_data.get("allow_session", True) is not False
+    allow_permanent = approval_data.get("allow_permanent", True) is not False
+    allow_custom_input = approval_data.get("allow_custom_input") is True
+    options = [{"label": "允许一次", "value": "once", "style": "primary"}]
+    if not smart_denied and allow_session:
+        options.append({"label": "本会话允许", "value": "session"})
+        if allow_permanent:
+            options.append({"label": "始终允许", "value": "always"})
+    options.append({"label": "拒绝", "value": "deny", "style": "danger"})
     result = request_interaction_from_hermes_locals(
         local_vars,
         kind="approval",
         interaction_id=interaction_id,
         prompt="需要授权后继续执行",
         description=f"```\n{command[:3000]}\n```\n\n{description}",
-        options=[
-            {"label": "允许一次", "value": "once", "style": "primary"},
-            {"label": "本会话允许", "value": "session"},
-            {"label": "始终允许", "value": "always"},
-            {"label": "拒绝", "value": "deny", "style": "danger"},
-        ],
+        options=options,
         timeout_seconds=timeout_seconds,
+        allow_custom_input=allow_custom_input,
     )
     if isinstance(result, dict) and result.get("status") == "completed":
         choice = str(result.get("choice") or "").strip()
-        return choice or None
+        allowed_choices = {str(option["value"]) for option in options}
+        if allow_custom_input:
+            return choice or None
+        return choice if choice in allowed_choices else None
     return None
 
 
@@ -7601,6 +7616,7 @@ def request_clarify_response_from_hermes_locals(
         options=options,
         timeout_seconds=_interaction_timeout(timeout_seconds),
         multi_select=multi_select,
+        allow_custom_input=True,
     )
     if isinstance(result, dict) and result.get("status") == "completed":
         choice = str(result.get("choice") or "").strip()
@@ -8525,6 +8541,11 @@ def _event_data(
         if multi_select_value is None:
             multi_select_value = local_vars.get("multi_select")
         data["multi_select"] = bool(multi_select_value)
+        allow_custom_input = local_vars.get("_hfc_interaction_allow_custom_input")
+        if allow_custom_input is None:
+            allow_custom_input = local_vars.get("allow_custom_input")
+        if isinstance(allow_custom_input, bool):
+            data["allow_custom_input"] = allow_custom_input
         timeout_value = _finite_float(local_vars.get("_hfc_interaction_timeout_seconds"))
         if timeout_value is not None:
             data["timeout_seconds"] = timeout_value

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -521,15 +521,12 @@ def _render_interaction_elements(
         ]
         if choice_lines:
             if interaction.multi_select:
-                choice_lines += [
-                    "",
-                    "Reply with numbers separated by commas, the option text, or your own answer.",
-                ]
+                instruction = "Reply with numbers separated by commas or the option text."
             else:
-                choice_lines += [
-                    "",
-                    "Reply with the number, the option text, or your own answer.",
-                ]
+                instruction = "Reply with the number or the option text."
+            if interaction.allow_custom_input:
+                instruction = instruction[:-1] + ", or your own answer."
+            choice_lines += ["", instruction]
             elements.append(
                 {
                     "tag": "markdown",
@@ -543,16 +540,20 @@ def _render_interaction_elements(
         if interaction.multi_select:
             elements.append(_render_multi_select_form(interaction))
         else:
+            hint = "（单选）请选择"
+            if interaction.allow_custom_input:
+                hint += "，或输入自定义内容"
             elements.append(
                 {
                     "tag": "markdown",
                     "element_id": "interaction_hint",
-                    "content": "（单选）请选择，或输入自定义内容",
+                    "content": hint,
                 }
             )
             for index, option in enumerate(interaction.options):
                 elements.append(_render_choice_button(interaction, index, option))
-            elements.append(_render_other_form(interaction))
+            if interaction.allow_custom_input:
+                elements.append(_render_other_form(interaction))
         return elements
 
     if interaction.status == "completed":
@@ -669,39 +670,43 @@ def _render_multi_select_form(interaction: Any) -> Dict[str, Any]:
         }
         for index, option in enumerate(interaction.options, start=1)
     ]
+    elements = [
+        {
+            "tag": "multi_select_static",
+            "element_id": "hfc_multi",
+            "name": "hfc_multi",
+            "type": "default",
+            "width": "fill",
+            "required": False,
+            "placeholder": {
+                "tag": "plain_text",
+                "content": "请选择（可多选）",
+            },
+            "options": options,
+            "behaviors": [
+                {
+                    "type": "callback",
+                    "value": {"hfc_action": "interaction.noop"},
+                }
+            ],
+        }
+    ]
+    if interaction.allow_custom_input:
+        elements.append(_render_other_input())
+    elements.append(
+        {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "✅ 确认选择"},
+            "type": "primary",
+            "width": "fill",
+            "form_action_type": "submit",
+            "name": f"hfc_confirm_{interaction.callback_token}",
+        }
+    )
     return {
         "tag": "form",
         "name": "hfc_clarify_form",
-        "elements": [
-            {
-                "tag": "multi_select_static",
-                "element_id": "hfc_multi",
-                "name": "hfc_multi",
-                "type": "default",
-                "width": "fill",
-                "required": False,
-                "placeholder": {
-                    "tag": "plain_text",
-                    "content": "请选择（可多选）",
-                },
-                "options": options,
-                "behaviors": [
-                    {
-                        "type": "callback",
-                        "value": {"hfc_action": "interaction.noop"},
-                    }
-                ],
-            },
-            _render_other_input(),
-            {
-                "tag": "button",
-                "text": {"tag": "plain_text", "content": "✅ 确认选择"},
-                "type": "primary",
-                "width": "fill",
-                "form_action_type": "submit",
-                "name": f"hfc_confirm_{interaction.callback_token}",
-            },
-        ],
+        "elements": elements,
     }
 
 

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -863,6 +863,12 @@ async def _interaction_action(
     if not interaction_id:
         return web.json_response({"ok": False, "error": "invalid action"}, status=400)
 
+    interaction = session.active_interaction
+    if interaction is None:
+        return web.json_response(
+            {"ok": False, "error": "interaction not found"}, status=404
+        )
+    allowed_values = {option.value for option in interaction.options}
     form_value = _extract_form_value(payload)
     if mode == "confirm":
         # Multi-select form submit: action.form_value.hfc_multi is a list of
@@ -877,6 +883,14 @@ async def _interaction_action(
             raw = []
         selected = raw if isinstance(raw, list) else ([raw] if raw != "" else [])
         selected = [str(s).strip() for s in selected if str(s).strip()]
+        if any(item not in allowed_values for item in selected):
+            return web.json_response(
+                {"ok": False, "error": "invalid choice"}, status=400
+            )
+        if typed and not interaction.allow_custom_input:
+            return web.json_response(
+                {"ok": False, "error": "custom input not allowed"}, status=400
+            )
         if typed:
             if selected:
                 combined = selected + [f"[自定义] {typed}"]
@@ -891,6 +905,10 @@ async def _interaction_action(
     elif mode == "other":
         # Free-text 'Other' answer: action.form_value.hfc_other holds the
         # user's typed input.
+        if not interaction.allow_custom_input:
+            return web.json_response(
+                {"ok": False, "error": "custom input not allowed"}, status=400
+            )
         typed = str(form_value.get("hfc_other") or "").strip()
         if not typed:
             return web.json_response(
@@ -905,6 +923,10 @@ async def _interaction_action(
         choice_label = str(value.get("choice_label") or choice).strip()
         if not choice:
             return web.json_response({"ok": False, "error": "invalid action"}, status=400)
+        if not interaction.allow_custom_input and choice not in allowed_values:
+            return web.json_response(
+                {"ok": False, "error": "invalid choice"}, status=400
+            )
 
     user_name = _extract_operator_name(payload)
     data = {

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -59,6 +59,7 @@ class InteractionState:
     options: list[InteractionOption] = field(default_factory=list)
     callback_token: str = ""
     multi_select: bool = False
+    allow_custom_input: bool = False
     timeout_seconds: float = 300.0
     requested_at: float = field(default_factory=_now)
     choice: str = ""
@@ -419,14 +420,22 @@ def _interaction_from_event_data(data: dict[str, Any]) -> InteractionState:
     interaction_id = str(data.get("interaction_id") or "").strip()
     if not interaction_id:
         interaction_id = secrets.token_hex(8)
+    kind = str(data.get("kind") or "choice").strip() or "choice"
+    allow_custom_input = data.get("allow_custom_input")
+    if not isinstance(allow_custom_input, bool):
+        # Backward compatibility for interaction events emitted before the
+        # capability became explicit. Hermes clarify has always exposed an
+        # Other/free-text path; fixed-choice interactions have not.
+        allow_custom_input = kind == "clarify"
     return InteractionState(
         interaction_id=interaction_id,
-        kind=str(data.get("kind") or "choice").strip() or "choice",
+        kind=kind,
         prompt=str(data.get("prompt") or "").strip(),
         description=str(data.get("description") or "").strip(),
         options=_interaction_options(data.get("options")),
         callback_token=str(data.get("callback_token") or secrets.token_urlsafe(16)),
         multi_select=bool(data.get("multi_select", False)),
+        allow_custom_input=allow_custom_input,
         timeout_seconds=_safe_timeout_seconds(data.get("timeout_seconds")),
     )
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -7957,6 +7957,7 @@ async def test_interaction_request_renders_buttons_and_callback_resolves(client)
                 "kind": "approval",
                 "prompt": "允许执行命令吗？",
                 "description": "rm -rf /tmp/demo",
+                "allow_custom_input": False,
                 "options": [
                     {"label": "允许一次", "value": "once", "style": "primary"},
                     {"label": "拒绝", "value": "deny", "style": "danger"},
@@ -7979,6 +7980,23 @@ async def test_interaction_request_renders_buttons_and_callback_resolves(client)
         if element.get("tag") == "button"
     )
     action_value = button["behaviors"][0]["value"]
+
+    custom = await test_client.post(
+        "/card/actions",
+        json={
+            "event": {
+                "operator": {"open_id": "ou_bailey", "name": "Bailey"},
+                "context": {"open_chat_id": "oc_abc"},
+                "action": {
+                    "name": f"hfc_other_{action_value['token']}",
+                    "form_value": {"hfc_other": "please approve"},
+                },
+            }
+        },
+    )
+
+    assert custom.status == 400
+    assert (await custom.json())["error"] == "custom input not allowed"
 
     callback = await test_client.post(
         "/card/actions",

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -779,6 +779,7 @@ def test_build_interaction_event_reuses_active_card_message_id():
             {"label": "允许一次", "value": "once"},
             {"label": "拒绝", "value": "deny"},
         ],
+        allow_custom_input=False,
     )
 
     assert interaction["event"] == "interaction.requested"
@@ -787,6 +788,67 @@ def test_build_interaction_event_reuses_active_card_message_id():
     assert interaction["data"]["kind"] == "approval"
     assert interaction["data"]["prompt"] == "允许执行命令吗？"
     assert interaction["data"]["options"][0]["value"] == "once"
+    assert interaction["data"]["allow_custom_input"] is False
+
+
+def test_approval_and_clarify_publish_distinct_custom_input_capabilities(monkeypatch):
+    calls = []
+
+    def fake_request(local_vars, **kwargs):
+        calls.append((local_vars, kwargs))
+        choice = kwargs["options"][0]["value"]
+        if kwargs["kind"] == "approval" and kwargs["allow_custom_input"]:
+            choice = "future custom approval response"
+        return {
+            "ok": True,
+            "status": "completed",
+            "choice": choice,
+        }
+
+    monkeypatch.setattr(
+        hook_runtime,
+        "request_interaction_from_hermes_locals",
+        fake_request,
+    )
+
+    approval = hook_runtime.request_approval_choice_from_hermes_locals(
+        {"chat_id": "oc_abc"},
+        {
+            "command": "rm -rf /tmp/demo",
+            "description": "recursive delete",
+            "allow_session": False,
+            "allow_permanent": False,
+        },
+        interaction_id="approval-1",
+    )
+    clarify = hook_runtime.request_clarify_response_from_hermes_locals(
+        {"chat_id": "oc_abc"},
+        interaction_id="clarify-1",
+        question="请选择",
+        choices=["继续", "取消"],
+    )
+    future_approval = hook_runtime.request_approval_choice_from_hermes_locals(
+        {"chat_id": "oc_abc"},
+        {
+            "command": "future command",
+            "allow_custom_input": True,
+        },
+        interaction_id="approval-2",
+    )
+
+    assert approval == "once"
+    assert clarify == "继续"
+    assert future_approval == "future custom approval response"
+    approval_call = calls[0][1]
+    clarify_call = calls[1][1]
+    future_approval_call = calls[2][1]
+    assert approval_call["allow_custom_input"] is False
+    assert [option["value"] for option in approval_call["options"]] == [
+        "once",
+        "deny",
+    ]
+    assert clarify_call["allow_custom_input"] is True
+    assert future_approval_call["allow_custom_input"] is True
 
 
 def test_request_interaction_posts_event_and_polls_until_completed(monkeypatch):

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -521,6 +521,7 @@ def test_render_pending_interaction_as_buttons():
                 "kind": "approval",
                 "prompt": "允许执行命令吗？",
                 "description": "rm -rf /tmp/demo",
+                "allow_custom_input": False,
                 "options": [
                     {"label": "允许一次", "value": "once", "style": "primary"},
                     {"label": "拒绝", "value": "deny", "style": "danger"},
@@ -543,6 +544,41 @@ def test_render_pending_interaction_as_buttons():
     assert buttons[0]["behaviors"][0]["value"]["token"]
     assert "interaction_actions" not in str(card)
     assert "rm -rf /tmp/demo" in str(card)
+    assert "hfc_other" not in str(card)
+    assert "自定义" not in str(card)
+
+
+def test_render_clarify_custom_input_only_when_capability_is_enabled():
+    from hermes_feishu_card.events import SidecarEvent
+
+    session = CardSession(conversation_id="chat-1", message_id="msg-1", chat_id="oc_abc")
+    session.apply(
+        SidecarEvent(
+            schema_version="1",
+            event="interaction.requested",
+            conversation_id="chat-1",
+            message_id="msg-1",
+            chat_id="oc_abc",
+            platform="feishu",
+            sequence=1,
+            created_at=0.0,
+            data={
+                "interaction_id": "clarify-1",
+                "kind": "clarify",
+                "prompt": "请选择处理方式",
+                "allow_custom_input": True,
+                "options": [
+                    {"label": "继续", "value": "continue"},
+                    {"label": "取消", "value": "cancel"},
+                ],
+            },
+        )
+    )
+
+    card = render_card(session)
+
+    assert "hfc_other" in str(card)
+    assert "输入自定义内容" in str(card)
 
 
 def test_render_pending_interaction_as_text_choices_for_localhost_mode():

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -457,6 +457,7 @@ def test_session_tracks_pending_and_completed_interaction():
                 "kind": "approval",
                 "prompt": "允许执行命令吗？",
                 "description": "rm -rf /tmp/demo",
+                "allow_custom_input": False,
                 "options": [
                     {"label": "允许一次", "value": "once"},
                     {"label": "拒绝", "value": "deny", "style": "danger"},
@@ -469,6 +470,7 @@ def test_session_tracks_pending_and_completed_interaction():
     assert session.active_interaction.interaction_id == "approval-1"
     assert session.active_interaction.status == "pending"
     assert session.active_interaction.options[0].value == "once"
+    assert session.active_interaction.allow_custom_input is False
 
     assert session.apply(
         event(


### PR DESCRIPTION
## 背景

Hermes 的命令审批与 `clarify` 共用飞书交互卡片渲染链路，但两者的输入能力不同。现有实现默认给所有交互附加“自定义答案”输入框，导致审批卡可能提交 Hermes 审批解析器不支持的任意文本；同时审批选项固定展示，未遵循 Hermes 提供的会话级、永久授权与 smart-denied 能力标记。

## 改动

- 为 `interaction.requested` 增加显式的 `allow_custom_input` 能力字段：
  - `clarify` 默认允许自定义输入；
  - `approval` 默认只允许协议内的固定选择；
  - 旧事件缺少字段时按交互类型兼容推断。
- 审批选项根据 Hermes 的 `smart_denied`、`allow_session`、`allow_permanent` 动态生成，不再无条件展示全部授权范围。
- 审批结果只接受当前卡片声明的 `once` / `session` / `always` / `deny` 值；只有显式开放自定义输入时才接受其他结果。
- 单选、多选和文本回退渲染均按 `allow_custom_input` 决定是否显示自定义输入提示与表单。
- 服务端同时校验选项值与自定义输入能力，防止通过伪造回调绕过卡片 UI。
- 保留 v4.2.9 之后的一次性 callback token、chat/operator 校验和交互幂等安全边界。

## 用户影响

命令审批卡会与 Hermes 当前审批能力保持一致：只显示本次允许的授权范围，并且默认不再出现与审批协议无关的自由文本输入；`clarify` 的单选、多选和 Other 自定义答案能力保持不变。

## 验证

- 新增回归用例：5 项全部通过。
- 聚焦测试：828 项通过；另有 1 项既有环境依赖用例 `test_native_handoff_plan_fingerprint_fails_closed_without_loaded_helper` 失败，与本次改动无关。
- `git diff --check` 通过。
