### PR TITLE
docs: add ScrapingAnt affiliate disclosure

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -16,6 +16,7 @@
 Hermes Feishu Streaming Card turns Hermes Agent Gateway replies in Feishu/Lark into one continuously updated interactive card. Reasoning, tool calls, final answers, approvals, choices, system notices, and runtime stats stay inside cards instead of spilling into scattered native gray text messages.<br><br>It targets the real pain points of running Hermes inside Feishu: missing or out-of-order streaming text, long tables/code blocks rendered as raw Markdown, invisible tool progress, manual approval replies, frozen topic timelines, multi-bot/profile troubleshooting, and uncertain hook compatibility after Hermes upgrades.
 ![Hermes Feishu card command interaction, command result feedback, and tool timeline showcase](docs/assets/feishu-card-showcase-v385.png)
 
+<h2>Optional web scraping service</h2><p>If an Agent workflow needs to retrieve public webpages affected by anti-bot restrictions, <a href="https://scrapingant.com/?ref=zwq4ngy">ScrapingAnt</a> is an optional web scraping service to consider. Its Web Scraping API includes 10,000 free API credits every month with no credit card required; it is not required by this plugin.</p><blockquote>Disclosure: This is an affiliate link. A qualifying first paid subscription may earn this project a commission.</blockquote>
 ## V4 Live Agent States
 
 | Running | Waiting for user |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 Hermes 飞书流式卡片插件把 Hermes Agent Gateway 的飞书/Lark 回复变成一张持续更新的交互式卡片。思考过程、工具调用、最终答案、授权确认、选项选择、系统提示和运行统计会收束在卡片内，而不是散落成多条灰色原生消息。<br><br>它面向真实飞书使用场景：流式内容漏字/乱序、长表格和代码块变成 raw markdown、工具过程不可见、approval/clarify 需要手工回复、话题里卡片不更新、多 bot / 多 profile 难排查，以及 Hermes 升级后 hook 兼容不确定。
 ![Hermes 飞书卡片命令交互、结果反馈与工具 timeline 展示](docs/assets/feishu-card-showcase-v385.png)
 
+<h2>可选网页抓取服务</h2><p>如果 Agent 工作流需要获取受反爬限制的公开网页，可了解 <a href="https://scrapingant.com/?ref=zwq4ngy">ScrapingAnt</a> 这项可选网页抓取服务。其 Web Scraping API 每月提供 10,000 个免费 API credits，无需信用卡；它不是本插件的必需依赖。</p><blockquote>说明：以上链接为 Affiliate link；符合条件的首次付费订阅可能为本项目带来佣金。</blockquote>
 ## V4 实时 Agent 状态
 
 | 运行中 | 等待用户 |


### PR DESCRIPTION
## Summary

- add a concise Chinese and English ScrapingAnt optional-service note before the V4 live Agent status section
- disclose the exact affiliate relationship and keep the dedicated link unchanged
- keep ScrapingAnt optional and explicitly separate from plugin requirements
- preserve the existing README line budget by using equivalent one-line semantic HTML

## Verification

- docs/package: 94 passed
- git diff --check: passed
- README.md: 281 lines, within the enforced 281-line limit
- README.en.md: 285 lines
- diff scope: README.md and README.en.md only