### PR TITLE
feat: 交互完成后 hover 显示原问题和选项

### DIFF
--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -560,8 +560,20 @@ def _render_interaction_elements(
         choice = interaction.choice_label or interaction.choice or "已完成"
         user = f" by {interaction.user_name}" if interaction.user_name else ""
         content = f"已选择：{choice}{user}"
-    else:
-        content = interaction.error or "交互请求失败"
+        original_hover = _render_interaction_original_hover(interaction, content)
+        if original_hover is not None:
+            elements.append(original_hover)
+        else:
+            elements.append(
+                {
+                    "tag": "markdown",
+                    "element_id": "interaction_result",
+                    "content": content,
+                }
+            )
+        return elements
+
+    content = interaction.error or "交互请求失败"
     elements.append(
         {
             "tag": "markdown",
@@ -584,6 +596,53 @@ def _interaction_callback_value(
     }
     value.update(extra)
     return value
+
+
+_HOVER_ORDINALS = ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩"]
+
+
+def _render_interaction_original_hover(
+    interaction: Any, content: str
+) -> Dict[str, Any] | None:
+    """Render the '已选择' line as a borderless text-style button whose PC
+    hover tooltip shows the original question + options — looks like plain
+    text, no button chrome, no extra card space. The tooltip is plain_text
+    (forced single line by Feishu), so emoji prefixes keep it readable."""
+    lines: list[str] = []
+    question = _hover_plain_line(interaction.description or interaction.prompt)
+    if question:
+        lines.append(f"❓ {question}")
+    options = list(interaction.options or [])
+    if options:
+        option_texts: list[str] = []
+        for index, option in enumerate(options, start=1):
+            label = _hover_plain_line(getattr(option, "label", None) or "")
+            if label:
+                ordinal = (
+                    _HOVER_ORDINALS[index - 1]
+                    if index <= len(_HOVER_ORDINALS)
+                    else f"{index}."
+                )
+                option_texts.append(f"{ordinal} {label}")
+        if option_texts:
+            lines.append("📋 " + "  ".join(option_texts))
+    if not lines:
+        return None
+    tooltip = "\n".join(lines)
+    if len(tooltip) > 500:
+        tooltip = tooltip[:497].rstrip() + "…"
+    return {
+        "tag": "button",
+        "element_id": "interaction_hover",
+        "type": "text",
+        "size": "small",
+        "text": {"tag": "plain_text", "content": content},
+        "hover_tips": {"tag": "plain_text", "content": tooltip},
+    }
+
+
+def _hover_plain_line(text: Any) -> str:
+    return " ".join(str(text or "").strip().split())
 
 
 def _render_choice_button(

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -681,9 +681,25 @@ def test_render_completed_interaction_replaces_buttons_with_choice():
 
     card = render_card(session)
 
-    assert not any(element.get("tag") == "button" for element in card["body"]["elements"])
+    # No interactive choice buttons remain after completion...
+    assert not any(
+        element.get("tag") == "button" and element.get("behaviors")
+        for element in card["body"]["elements"]
+    )
     assert "已选择：允许一次" in str(card)
     assert "Bailey" in str(card)
+    # ...but the '已选择' line is rendered as a borderless text-style button
+    # whose PC hover tooltip keeps the original question + options reachable
+    hover = next(
+        element
+        for element in card["body"]["elements"]
+        if element.get("element_id") == "interaction_hover"
+    )
+    assert hover["tag"] == "button"
+    assert hover["type"] == "text"
+    assert hover["text"]["content"] == "已选择：允许一次 by Bailey"
+    assert hover["hover_tips"]["tag"] == "plain_text"
+    assert hover["hover_tips"]["content"] == "❓ 允许执行命令吗？\n📋 ① 允许一次"
 
 
 def test_render_completed_card_shows_attachment_summary():


### PR DESCRIPTION
## 背景

选择卡片（clarify / approval / 多选）完成后，卡片只显示「已选择：XXX」，原问题和完整选项列表不可见。用户希望不占用卡片空间、以 hover 方式查看原题。

## 实现

将「已选择：XXX」这一行渲染为 **`type="text"` 的无边框按钮**（黑色字体、无边框无底色，外观与普通文本一致），并配置 `hover_tips` —— PC 端鼠标悬停该行时弹出 tooltip 显示原问题 + 完整选项。

关键点：

- **为什么用 button 而不是 interactive_container**：`interactive_container` 的 `hover_tips` 字段文档有写（"Tooltip text when the user hovers the cursor over the interactive container on the PC"），但实测客户端不生效（字段被 API 接受但不显示）。`button.hover_tips` 实测有效。
- **tooltip 无法换行**：`hover_tips` 内容为 `plain_text`，飞书渲染强制单行（`\n` 被折叠成空格）。为保证可读性，采用 emoji 分段：`❓ 问题` + `📋 ① 选项A  ② 选项B  ③ 选项C`（选项 >10 个回退 `11.` 序号）。
- 问题文本取 `interaction.description or interaction.prompt`（真实 clarify 事件的 question 在 prompt 字段）。
- 无原题信息（无问题且无选项）时退回普通 markdown 行，不渲染 hover 按钮。
- hover 按钮不配置 `behaviors`（纯展示，点击无行为）。

## 测试

- `tests/unit/test_render.py::test_render_completed_interaction_replaces_buttons_with_choice`：更新断言，验证完成态无交互按钮、hover 按钮结构与 tooltip 内容。
- 全量 `tests/unit/test_render.py`：91 passed。