### PR TITLE
feat: 任务完成时发送 @ 发起人通知消息

### DIFF
--- a/hermes_feishu_card/config.py
+++ b/hermes_feishu_card/config.py
@@ -43,6 +43,7 @@ DEFAULT_CONFIG: dict[str, dict[str, Any]] = {
         "max_reasoning_chars": 1200,
         "max_tool_result_chars": 600,
         "table_overflow_mode": "compact",
+        "completion_notify": {"enabled": True},
         "footer_fields": [
             "duration",
             "model",

--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -276,6 +276,57 @@ class FeishuClient:
             json_body={"content": content},
         )
 
+    async def send_text_message(
+        self,
+        chat_id: str,
+        text: str,
+        thread_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+    ) -> str:
+        """Send a plain text message (may contain @ mention markup).
+
+        Returns the created message_id. Raises FeishuAPIError on failure.
+        """
+        if not isinstance(chat_id, str) or not chat_id.strip():
+            raise ValueError("chat_id is required")
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("text must be a non-empty string")
+
+        token = await self._tenant_token()
+        content = json.dumps({"text": text}, ensure_ascii=False)
+        if reply_to_message_id:
+            body = await self._request_json(
+                "POST",
+                f"/im/v1/messages/{quote(reply_to_message_id, safe='')}/reply",
+                token=token,
+                json_body={
+                    "msg_type": "text",
+                    "content": content,
+                    "reply_in_thread": bool(thread_id),
+                },
+            )
+        else:
+            receive_id_type = "chat_id"
+            body = await self._request_json(
+                "POST",
+                "/im/v1/messages",
+                token=token,
+                params={"receive_id_type": receive_id_type},
+                json_body={
+                    "receive_id": chat_id,
+                    "msg_type": "text",
+                    "content": content,
+                },
+            )
+        data = body.get("data")
+        if not isinstance(data, dict) or not isinstance(data.get("message_id"), str):
+            raise FeishuAPIError(
+                "Feishu send response missing message_id",
+                retryable=False,
+                outcome="unknown",
+            )
+        return data["message_id"]
+
     async def _tenant_token(self) -> str:
         now = time.time()
         if self._tenant_access_token and now < self._tenant_access_token_expires_at:

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -8584,6 +8584,11 @@ def _event_data(
             "tokens": _completion_tokens(local_vars, answer),
             "context": _completion_context(local_vars),
         })
+        sender_open_id = _command_operator(local_vars, source_obj, local_vars.get("event"))
+        if not sender_open_id:
+            sender_open_id = _hfc_resume_operator_open_id(local_vars.get("event"))
+        if sender_open_id:
+            data["sender_open_id"] = sender_open_id
         delivery_kind = _first_string(local_vars, ("delivery_kind",))
         if delivery_kind:
             data["delivery_kind"] = delivery_kind
@@ -8601,6 +8606,11 @@ def _event_data(
             value = _first_string(local_vars, (source_key,)) or _first_attr_string(message_obj, (source_key,))
             if value:
                 data[data_key] = value
+        sender_open_id = _command_operator(local_vars, source_obj, local_vars.get("event"))
+        if not sender_open_id:
+            sender_open_id = _hfc_resume_operator_open_id(local_vars.get("event"))
+        if sender_open_id:
+            data["sender_open_id"] = sender_open_id
         reply_aliases = (
             "reply_to_message_id",
             "quote_message_id",

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -77,6 +77,7 @@ from .render import (
     _is_initial_loading,
     render_card_result,
     render_terminal_limit_handoff_card,
+    _format_duration,
 )
 from .process import state_dir
 from .session import CardSession
@@ -4763,6 +4764,18 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                     handoff_identity,
                     handoff_record,
                 )
+            if (
+                updated
+                and is_terminal
+                and event.event == "message.completed"
+                and render_result.disposition == "card"
+            ):
+                await _maybe_send_completion_notify(
+                    request.app,
+                    session_key,
+                    latest_session,
+                    event,
+                )
             return updated
 
         if is_terminal:
@@ -4819,6 +4832,58 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             _session_key(event),
         )
     return web.json_response(response_payload), post_lock_task
+
+
+async def _maybe_send_completion_notify(
+    app: web.Application,
+    session_key: str,
+    session: CardSession,
+    event: SidecarEvent,
+) -> None:
+    """Send an @-mention completion notice after the card finished updating.
+
+    Feishu does not push notifications for card edits (verified 2026-08-18:
+    PATCHing a card to add an <at> mention does not notify the user), so a
+    completed long-running task needs a fresh text message that mentions the
+    initiating user. Controlled by ``card.completion_notify.enabled``
+    (default: enabled). Sends at most once per session.
+    """
+    try:
+        if session.completion_notify_sent:
+            return
+        if session.status != "completed":
+            return
+        sender_open_id = session.sender_open_id
+        if not sender_open_id:
+            return
+        card_config = app[SESSION_CARD_CONFIGS_KEY].get(session_key, {})
+        notify_config = card_config.get("completion_notify")
+        if isinstance(notify_config, dict) and notify_config.get("enabled") is False:
+            return
+        if notify_config is False:
+            return
+        bot_id = app[MESSAGE_BOT_IDS_KEY].get(session_key)
+        client = _client_for_bot(app, bot_id)
+        duration_text = (
+            _format_duration(session.duration) if (session.duration or 0) > 0 else ""
+        )
+        suffix = f"（用时 {duration_text}）" if duration_text else ""
+        text = f'<at user_id="{sender_open_id}"></at> ✅ 任务已完成{suffix}'
+        reply_to = session.reply_to_message_id or _reply_to_message_id_for_event(event)
+        await client.send_text_message(
+            event.chat_id,
+            text,
+            thread_id=_thread_id_for_event(event),
+            reply_to_message_id=reply_to or None,
+        )
+        session.completion_notify_sent = True
+        logger.info(
+            "completion notify sent to %s (session %s)",
+            sender_open_id,
+            session_key,
+        )
+    except Exception as exc:
+        logger.warning("completion notify send failed: %s", exc)
 
 
 def _post_terminal_cleanup(

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -110,6 +110,8 @@ class CardSession:
     active_interaction: InteractionState | None = None
     delivery_kind: str = "chat"
     reply_to_message_id: str = ""
+    sender_open_id: str = ""
+    completion_notify_sent: bool = False
     notice_title: str = ""
     notice_level: str = "info"
     terminal_disposition: str = ""
@@ -264,6 +266,9 @@ class CardSession:
             delivery_kind = event.data.get("delivery_kind")
             if isinstance(delivery_kind, str) and delivery_kind.strip():
                 self.delivery_kind = delivery_kind.strip()
+            sender_open_id = event.data.get("sender_open_id")
+            if isinstance(sender_open_id, str) and sender_open_id.strip():
+                self.sender_open_id = sender_open_id.strip()
             reply_to_message_id = event.data.get("reply_to_message_id")
             if isinstance(reply_to_message_id, str):
                 self.reply_to_message_id = reply_to_message_id
@@ -319,6 +324,9 @@ class CardSession:
             self.latest_tool_preview = ""
             if completed_answer.strip():
                 self.answer_text = completed_answer
+            sender_open_id = event.data.get("sender_open_id")
+            if isinstance(sender_open_id, str) and sender_open_id.strip():
+                self.sender_open_id = sender_open_id.strip()
             delivery_kind = event.data.get("delivery_kind")
             if isinstance(delivery_kind, str) and delivery_kind.strip():
                 self.delivery_kind = delivery_kind.strip()

--- a/tests/integration/test_feishu_client_http.py
+++ b/tests/integration/test_feishu_client_http.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import pytest
 import subprocess
 import sys
@@ -151,6 +152,60 @@ async def test_send_card_replies_in_thread_when_reply_anchor_present(feishu_api)
     assert "你好" in reply_request[2]["content"]
     assert reply_request[2]["uuid"] == "hfc_" + "a" * 40
     assert reply_request[3]["Authorization"] == "Bearer tenant-token-1"
+
+
+async def test_send_text_message_posts_text_with_mention(feishu_api):
+    test_client, requests, token_calls = feishu_api
+    client = FeishuClient(
+        FeishuClientConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            base_url=str(test_client.make_url("/")),
+        )
+    )
+
+    message_id = await client.send_text_message(
+        "oc_abc",
+        '<at user_id="ou_sender"></at> ✅ 任务已完成',
+    )
+
+    assert message_id == "om_message_1"
+    assert token_calls() == 1
+    send_request = requests[1]
+    assert send_request[0] == "send"
+    assert send_request[1] == "chat_id"
+    assert send_request[2]["receive_id"] == "oc_abc"
+    assert send_request[2]["msg_type"] == "text"
+    payload = json.loads(send_request[2]["content"])
+    assert payload["text"] == '<at user_id="ou_sender"></at> ✅ 任务已完成'
+
+
+async def test_send_text_message_replies_in_thread_when_anchor_present(feishu_api):
+    test_client, requests, token_calls = feishu_api
+    client = FeishuClient(
+        FeishuClientConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            base_url=str(test_client.make_url("/")),
+        )
+    )
+
+    message_id = await client.send_text_message(
+        "oc_abc",
+        '<at user_id="ou_sender"></at> ✅ 任务已完成',
+        thread_id="omt_thread",
+        reply_to_message_id="om_user_message",
+    )
+
+    assert message_id == "om_reply_1"
+    assert token_calls() == 1
+    reply_request = requests[1]
+    assert reply_request[0] == "reply"
+    assert reply_request[1] == "om_user_message"
+    assert reply_request[2]["msg_type"] == "text"
+    assert reply_request[2]["reply_in_thread"] is True
+    payload = json.loads(reply_request[2]["content"])
+    assert "任务已完成" in payload["text"]
 
 
 @pytest.mark.parametrize("delivery_uuid", ["", "   ", "x" * 51, 123])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -62,6 +62,7 @@ def test_load_config_missing_file_returns_defaults(tmp_path):
             "max_reasoning_chars": 1200,
             "max_tool_result_chars": 600,
             "table_overflow_mode": "compact",
+            "completion_notify": {"enabled": True},
             "footer_fields": [
                 "duration",
                 "model",
@@ -295,6 +296,7 @@ card:
         "max_reasoning_chars": 1200,
         "max_tool_result_chars": 600,
         "table_overflow_mode": "compact",
+        "completion_notify": {"enabled": True},
         "footer_fields": [
             "duration",
             "model",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -66,6 +66,41 @@ def test_started_message_uses_feishu_message_id_as_native_reply_anchor():
     assert session.reply_to_message_id == "om_user_message"
 
 
+def test_started_message_records_sender_open_id():
+    session = CardSession(
+        conversation_id="chat-1", message_id="om_user_message", chat_id="oc_abc"
+    )
+
+    assert session.apply(
+        event(
+            "message.started",
+            0,
+            {"sender_open_id": "ou_sender"},
+            message_id="om_user_message",
+        )
+    )
+
+    assert session.sender_open_id == "ou_sender"
+
+
+def test_completed_message_records_sender_open_id_when_started_missing():
+    session = CardSession(
+        conversation_id="chat-1", message_id="om_user_message", chat_id="oc_abc"
+    )
+
+    assert session.apply(
+        event(
+            "message.completed",
+            1,
+            {"answer": "done", "sender_open_id": "ou_sender"},
+            message_id="om_user_message",
+        )
+    )
+
+    assert session.sender_open_id == "ou_sender"
+    assert session.status == "completed"
+
+
 def test_rejects_duplicate_and_stale_sequence():
     session = CardSession(conversation_id="chat-1", message_id="msg-1", chat_id="oc_abc")
     assert session.apply(event("thinking.delta", 2, {"text": "新"}))


### PR DESCRIPTION
## 背景

卡片是`先发后编辑`的流式更新（先发 loading 卡，不断 PATCH 更新内容）。如果任务跑得比较久，用户没有一直盯着会话，就无法感知任务是否完成。

实测验证：**编辑卡片补 @ 不触发任何通知**（PATCH 后服务端 mentions 字段会更新，但客户端不会弹通知）。所以要提醒用户只能发一条**新的**消息。

## 改动

| 文件 | 内容 |
|------|------|
| `hook_runtime.py` | message.started / message.completed 事件携带 `sender_open_id`；`_command_operator` 提取失败时回退 `_hfc_resume_operator_open_id`（兼容 Hermes MessageEvent 的 `source.user_id` 结构，MessageEvent 没有 sender_id 属性） |
| `session.py` | CardSession 新增 `sender_open_id` 记录 + `completion_notify_sent` 去重标记 |
| `feishu_client.py` | 新增 `send_text_message`（text 消息，支持 @ 标记，reply 或直发） |
| `server.py` | 卡片更新成功后调用 `_maybe_send_completion_notify` 发完成通知；失败仅告警不影响主流程 |
| `config.py` | 默认配置 `card.completion_notify.enabled: true` |
| tests | 新增 6 个用例：session sender_open_id 存储 ×2、send_text_message 直发/线程回复 ×2、config 默认值 ×2 |

## 行为

任务完成且卡片更新成功后，向发起人发送：

> @用户 ✅ 任务已完成（用时 45s）

- 开关：`card.completion_notify.enabled`（默认开启）
- 单会话最多发一次（幂等标记）
- 无发起人（cron/notice 等）自动跳过
- 发送失败仅记日志，不影响卡片更新

## 验证

- `tests/unit/` 全量：1747 passed（2 个既有环境相关失败与本次无关，上游 main 同样失败）
- 线上实测：任务完成后收到 `@何之洲 ✅ 任务已完成` 通知 ✅