### PR TITLE
test: isolate legacy pid reuse detection

### DIFF
--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -1704,6 +1704,7 @@ def test_start_sidecar_refuses_live_pid_record_when_health_is_unavailable(
         lambda: {"pid": 1234, "token": "owned", "manager": "detached"},
     )
     monkeypatch.setattr(process, "pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(process, "_pid_is_hfc_runner", lambda _pid: None)
     monkeypatch.setattr(
         process.subprocess,
         "Popen",


### PR DESCRIPTION
## Summary
- make the live-owned-pid refusal test independent of the runner's real /proc/1234 state
- preserve the separate explicit non-HFC PID reuse recovery test

## Root cause
The release rerun's Python 3.11 runner happened to have a non-HFC process at PID 1234. The test mocked pid_is_running but not _pid_is_hfc_runner, so production correctly treated the legacy PID as reused and the test entered an unintended launch path.

## Verification
- python -m pytest tests/unit/test_process.py::test_start_sidecar_refuses_live_pid_record_when_health_is_unavailable tests/unit/test_process.py::test_start_sidecar_recovers_legacy_pid_reused_by_non_hfc_process -q
- 2 passed
- git diff --check