### PR TITLE
fix: unblock persistent sidecar enable on v4.3.0

### DIFF
--- a/docs/fix-plan-v4.3.0.md
+++ b/docs/fix-plan-v4.3.0.md
@@ -1,0 +1,71 @@
+# v4.3.0 已知问题与修复方案
+
+> 记录 v4.3.0 在 `enable`（persistent systemd service）路径暴露的 3 个 bug，以及对应修复方案。
+> 发现场景：Hermes Agent v0.20.4（v2026.8.18）上从 4.0.20 升级到 4.3.0，`enable` 反复失败后定位。
+> 补丁与单测已落地（2026-08-19），下方"修复后验证清单"记录了实际验证状态。
+
+## Bug 1 — Python 身份格式校验与产出不一致
+
+- **位置**：`hermes_feishu_card/persistent_service.py:295-305`（校验）↔ `hermes_feishu_card/server.py:7100-7111`（产出）
+- **现象**：任何走 `enable` / `persistent_sidecar_matches` 的路径抛 `ValueError: Python identity is invalid`
+- **根因**：`python_executable_identity()` 有意返回域分隔前缀 `python-sha256:`（14 字符 + 64 hex = 78 字符），但 `_normalize_inputs` 的格式校验从 `_valid_digest`（persistent_service.py:595-596，用于 unit/manifest 哈希，格式正确勿改）复制而来，写成 `sha256:` + 71 字符
+- **修复**（persistent_service.py:295-301，校验改为接受实际产出格式）：
+
+```python
+    _hfc_identity_prefix = "python-sha256:"
+    if (
+        type(expected_python_identity) is not str
+        or not expected_python_identity.startswith(_hfc_identity_prefix)
+        or len(expected_python_identity) != len(_hfc_identity_prefix) + 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in expected_python_identity[len(_hfc_identity_prefix):]
+        )
+    ):
+        raise ValueError("Python identity is invalid")
+```
+
+- **依据**：身份是"域分隔"的（docstring 写明 path-free, domain-separated identity），应改校验而非产出；`_health_matches_expected_identity`（process.py:853）只做等值比较，两侧同函数计算，前缀不影响正确性
+
+## Bug 2 — `WorkingDirectory=` 被错误地加引号
+
+- **位置**：`hermes_feishu_card/persistent_service.py:337`（`_render_unit`）
+- **现象**：生成的 unit `Loaded: bad-setting`，`systemd-analyze verify` 报 `WorkingDirectory= path is not absolute`，`enable --now` 失败
+- **根因**：用 `_systemd_quote`（persistent_service.py:581，为 ExecStart 参数设计：加引号 + 转义 `\` `"` `%`）渲染 `WorkingDirectory=`，但 systemd 的 `WorkingDirectory=` **不做 shell 词法解析、不接受引号**，引号被当作路径的一部分
+- **修复**（persistent_service.py:337，去掉引号；`%` 是 systemd specifier，转义为 `%%` 防展开）：
+
+```python
+        f"WorkingDirectory={inputs['state_dir'].replace('%', '%%')}\n"
+```
+
+- **依据**：`WorkingDirectory=` 取值是字面路径（仅做 `%` specifier 展开）；`Environment=` / `ExecStart=` 行保留 `_systemd_quote` 不变（那两处支持引号）
+
+## Bug 3 — 健康检查对无 token 的 sidecar 永远失败
+
+- **位置**：`hermes_feishu_card/persistent_service.py:267`（检查）↔ `hermes_feishu_card/server.py:812`（产出）
+- **现象**：`enable` 创建单元并启动后，健康检查 5 秒超时，触发 rollback 回滚
+- **根因**：`_health_matches` 要求 `health.get("process_token_hash") == ""`，但 `server.py:812` 只在 `process_token` 非空时写入该字段；enable 生成的单元**不带 `--token`** → 字段缺失 → `.get()` 返回 `None` → `None == ""` 恒 False。而 `process_token_hash(None)`（process.py:34）的语义正是返回 `""`（无 token）
+- **修复**（server.py:811-813，健康端点始终发出该字段）：
+
+```python
+    process_token = request.app[PROCESS_TOKEN_KEY]
+    response["process_token_hash"] = _full_diagnostic_hash(process_token)
+```
+
+- **依据**：`_full_diagnostic_hash("")` / `(None)` 均返回 `""`，无 token 时端点报 `process_token_hash: ""`，与 `_health_matches` 匹配，也与 `_record_matches_health` / `_health_matches_token`（process.py:829/842）对无 token 记录的语义对齐
+- **备选（最小改法，不推荐）**：persistent_service.py:267 改为 `in ("", None)`；能解锁 enable 但健康端点契约仍不一致
+
+## 部署侧注意（非代码 bug）
+
+- 符号链接 home（如 `/home/<user>` → `/data00/home/<user>`）会触发 v4.3.0 的 state 目录安全检查（`_state_dir_security_error`）拒绝 enable——属刻意的安全设计，需设 `HERMES_FEISHU_CARD_STATE_DIR` 指向无符号链接路径
+- 旧版 sidecar 留下的过期 `sidecar.pid` 会挡 `enable`（`invalid pidfile exists; stop refused`），确认进程死亡后移除即可
+
+## 修复后验证清单
+
+- [x] `python3 -m py_compile hermes_feishu_card/persistent_service.py hermes_feishu_card/server.py`
+- [ ] `python3 -m hermes_feishu_card.cli enable --config <config> --hermes-dir <hermes> --yes` → `enable ok`（需 Linux systemd 环境）
+- [ ] `systemctl --user is-active hermes-feishu-card-sidecar.service` → `active`（需 Linux systemd 环境）
+- [ ] `python3 -m hermes_feishu_card.cli doctor --config <config> --hermes-dir <hermes> --explain` → `compatibility full`、`Install state: installed`（需 Linux systemd 环境）
+- [x] 补单测：`_normalize_inputs` 接受 `python-sha256:` 前缀（同步改现有 fixture）；`_render_unit` 输出 `WorkingDirectory=` 不带引号；token-less 健康响应含 `process_token_hash: ""`
+- [x] 回归：`tests/unit/test_persistent_service.py`、`tests/integration/test_server.py`、`tests/unit/test_process.py`、`tests/integration/test_cli_process.py`、`tests/integration/test_cli_install.py`、`tests/unit/test_manifest.py` 全绿（`test_private_repair_is_exactly_once_under_concurrent_confirmation` 为既有并发 flaky，与本次改动无关）
+

--- a/hermes_feishu_card/persistent_service.py
+++ b/hermes_feishu_card/persistent_service.py
@@ -292,11 +292,15 @@ def _normalize_inputs(
         or any(character in expected_package_version for character in "\r\n\0")
     ):
         raise ValueError("package version is invalid")
+    _hfc_identity_prefix = "python-sha256:"
     if (
         type(expected_python_identity) is not str
-        or not expected_python_identity.startswith("sha256:")
-        or len(expected_python_identity) != 71
-        or any(character not in "0123456789abcdef" for character in expected_python_identity[7:])
+        or not expected_python_identity.startswith(_hfc_identity_prefix)
+        or len(expected_python_identity) != len(_hfc_identity_prefix) + 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in expected_python_identity[len(_hfc_identity_prefix):]
+        )
     ):
         raise ValueError("Python identity is invalid")
     return {
@@ -334,7 +338,7 @@ def _render_unit(inputs: Mapping[str, str]) -> bytes:
         "[Service]\n"
         "Type=simple\n"
         f"Environment={_systemd_quote(state_assignment)}\n"
-        f"WorkingDirectory={_systemd_quote(inputs['state_dir'])}\n"
+        f"WorkingDirectory={inputs['state_dir'].replace('%', '%%')}\n"
         f"ExecStart={exec_start}\n"
         "Restart=on-failure\n"
         "RestartSec=2s\n"

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -808,8 +808,7 @@ async def _health(request: web.Request) -> web.Response:
         "native_handoffs": _safe_native_handoff_diagnostics(request.app),
     }
     process_token = request.app[PROCESS_TOKEN_KEY]
-    if process_token:
-        response["process_token_hash"] = _full_diagnostic_hash(process_token)
+    response["process_token_hash"] = _full_diagnostic_hash(process_token)
 
     # Multi-profile stats
     boundary = request.app.get(FEISHU_CLIENT_KEY)

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1608,6 +1608,30 @@ async def test_health_reports_package_and_domain_separated_python_identity_witho
     assert identity != hashlib.sha256(executable.encode("utf-8")).hexdigest()
 
 
+async def test_health_reports_empty_process_token_hash_when_no_token():
+    app = create_app(FakeFeishuClient())
+    request = make_mocked_request("GET", "/health", app=app)
+    response = await sidecar_server._health(request)
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["process_token_hash"] == ""
+
+
+async def test_health_reports_hashed_process_token_without_echoing_it():
+    process_token = "private-process-token"
+    app = create_app(FakeFeishuClient(), process_token=process_token)
+    request = make_mocked_request("GET", "/health", app=app)
+    response = await sidecar_server._health(request)
+    body = json.loads(response.body)
+
+    assert response.status == 200
+    assert body["process_token_hash"] == (
+        hashlib.sha256(process_token.encode("utf-8")).hexdigest()
+    )
+    assert process_token not in json.dumps(body)
+
+
 async def test_shutdown_control_requires_matching_process_token_and_never_echoes_it(
     monkeypatch,
 ):

--- a/tests/unit/test_persistent_service.py
+++ b/tests/unit/test_persistent_service.py
@@ -45,7 +45,7 @@ def _healthy():
         "process_pid": 4321,
         "process_token_hash": "",
         "package_version": "4.3.0",
-        "python_identity": "sha256:" + "a" * 64,
+        "python_identity": "python-sha256:" + "a" * 64,
     }
 
 
@@ -68,7 +68,7 @@ def test_enable_refuses_missing_linger_without_mutation(monkeypatch, tmp_path):
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     )
 
     assert result == "failed: systemd user linger is disabled; run loginctl enable-linger"
@@ -110,7 +110,7 @@ def test_enable_writes_bound_unit_and_manifest_then_starts(monkeypatch, tmp_path
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     )
 
     assert result == "enabled"
@@ -123,6 +123,8 @@ def test_enable_writes_bound_unit_and_manifest_then_starts(monkeypatch, tmp_path
     unit_text = unit.read_text(encoding="utf-8")
     assert "[Install]\nWantedBy=default.target" in unit_text
     assert "Restart=on-failure" in unit_text
+    assert 'WorkingDirectory="' not in unit_text
+    assert "\nWorkingDirectory=/" in unit_text
     assert "--managed-pidfile" not in unit_text
     assert "--token" not in unit_text
     assert str(python) in unit_text
@@ -134,7 +136,7 @@ def test_enable_writes_bound_unit_and_manifest_then_starts(monkeypatch, tmp_path
     assert payload["protocol"] == "hfc-systemd-user-service-v1"
     assert payload["unit_sha256"].startswith("sha256:")
     assert payload["expected_package_version"] == "4.3.0"
-    assert payload["expected_python_identity"] == "sha256:" + "a" * 64
+    assert payload["expected_python_identity"] == "python-sha256:" + "a" * 64
 
 
 def test_enable_is_idempotent_for_exact_active_unit(monkeypatch, tmp_path):
@@ -157,7 +159,7 @@ def test_enable_is_idempotent_for_exact_active_unit(monkeypatch, tmp_path):
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     )
     assert persistent_service.enable_persistent_sidecar(**kwargs) == "enabled"
     first_unit = unit.read_bytes()
@@ -193,7 +195,7 @@ def test_enable_rolls_back_owned_files_when_systemctl_fails(monkeypatch, tmp_pat
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     )
 
     assert result == "failed: persistent systemd user service could not be enabled"
@@ -227,7 +229,7 @@ def test_enable_preserves_ownership_when_failed_start_cannot_be_stopped(
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     )
 
     assert result == "failed: persistent systemd user service could not be enabled"
@@ -253,7 +255,7 @@ def test_disable_refuses_unit_drift_without_systemctl_or_deletion(monkeypatch, t
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     ) == "enabled"
     unit.write_text(unit.read_text(encoding="utf-8") + "# user drift\n", encoding="utf-8")
     commands = []
@@ -294,7 +296,7 @@ def test_disable_stops_removes_and_reloads_exact_owned_unit(monkeypatch, tmp_pat
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     ) == "enabled"
     commands.clear()
 
@@ -319,7 +321,7 @@ def test_enable_refuses_non_user_service_manager(monkeypatch, tmp_path, manager)
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     ) == "failed: persistent service requires service.manager=auto or systemd-user"
 
 
@@ -337,7 +339,7 @@ def test_enable_refuses_active_unowned_transient_unit(monkeypatch, tmp_path):
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     ) == "failed: an unmanaged sidecar unit is active; stop it before enable"
     assert not state.exists()
     assert not unit.exists()
@@ -383,7 +385,7 @@ def test_cli_enable_uses_verified_runtime_binding(monkeypatch, tmp_path, capsys)
     monkeypatch.setattr(
         cli,
         "_resolve_start_runtime_identity",
-        lambda root: (python, "sha256:" + "a" * 64),
+        lambda root: (python, "python-sha256:" + "a" * 64),
     )
     monkeypatch.setattr(
         cli,
@@ -412,7 +414,7 @@ def test_cli_enable_uses_verified_runtime_binding(monkeypatch, tmp_path, capsys)
             "hermes_dir": hermes,
             "python_executable": python,
             "expected_package_version": cli.PACKAGE_VERSION,
-            "expected_python_identity": "sha256:" + "a" * 64,
+            "expected_python_identity": "python-sha256:" + "a" * 64,
         }
     ]
 
@@ -432,7 +434,7 @@ def test_cli_start_noops_for_exact_persistent_service(monkeypatch, tmp_path, cap
     monkeypatch.setattr(
         cli,
         "_resolve_start_runtime_identity",
-        lambda root: (python, "sha256:" + "b" * 64),
+        lambda root: (python, "python-sha256:" + "b" * 64),
     )
     monkeypatch.setattr(cli, "persistent_sidecar_matches", lambda **kwargs: True)
     monkeypatch.setattr(
@@ -477,7 +479,7 @@ def test_active_requires_exact_owned_unit_and_systemd_state(monkeypatch, tmp_pat
         hermes_dir=hermes,
         python_executable=python,
         expected_package_version="4.3.0",
-        expected_python_identity="sha256:" + "a" * 64,
+        expected_python_identity="python-sha256:" + "a" * 64,
     ) == "enabled"
 
     assert persistent_service.persistent_sidecar_active() is True


### PR DESCRIPTION
Three bugs on the persistent systemd `enable` path caused it to fail repeatedly after upgrading from 4.0.20 to 4.3.0:

- Bug 1: `_normalize_inputs` validated the Python identity against the digest format (`sha256:` + 71 chars) instead of the domain-separated `python-sha256:` prefix that `python_executable_identity()` produces, so every `enable`/`persistent_sidecar_matches` path raised ValueError.
- Bug 2: `WorkingDirectory=` was rendered through `_systemd_quote`, but systemd does not shell-parse that setting, so the quotes broke the unit (`WorkingDirectory= path is not absolute`).
- Bug 3: the health endpoint only emitted `process_token_hash` when a token was set, but token-less `enable` units left the field absent, so the health check compared `None == ""` and always failed into rollback.

Tests updated: existing persistent-service fixtures now use the real `python-sha256:` identity, the unit render asserts an unquoted WorkingDirectory, and new health tests cover token-less and tokened `process_token_hash`. Adds docs/fix-plan-v4.3.0.md with the analysis.