### PR TITLE
feat(card): 交互卡片与完成通知支持 @ 提及发起人

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -49,6 +49,21 @@ card:
   # @mentions the initiating Feishu user. Card edits themselves do not notify.
   completion_notify:
     enabled: false
+    # Explicit @ mention toggle for the completion notification. Absent =
+    # fall back to the global mentions_in_cards switch (absent = enabled).
+    mention: true
+  # Global switch for @ mentions of the initiating Feishu user inside
+  # interaction cards (approval / clarify) and in the completion notification.
+  # Set to false to disable the feature entirely (this is the master OFF
+  # switch and wins over per-kind settings). Absent key = enabled.
+  # Per-kind overrides below (interaction_mentions) only apply when the
+  # global switch is not disabled.
+  mentions_in_cards: true
+  # Per-kind @ mention switches for interaction cards. Absent key falls back
+  # to mentions_in_cards (absent = enabled). Uncomment to configure:
+  # interaction_mentions:
+  #   clarify: true
+  #   approval: true
   # Optional role-based CardKit text sizes. Roles: body, reasoning, tool,
   # notice, footer. Values may be scalar or default/pc/mobile mappings.
   # card width/height are controlled by the Feishu/Lark client.

--- a/hermes_feishu_card/config.py
+++ b/hermes_feishu_card/config.py
@@ -44,6 +44,12 @@ DEFAULT_CONFIG: dict[str, dict[str, Any]] = {
         "max_tool_result_chars": 600,
         "table_overflow_mode": "compact",
         "completion_notify": {"enabled": False},
+        # Per-kind @ mention switches in interaction cards (clarify /
+        # approval). The default is UNSET (None): the resolving helpers fall
+        # back to the legacy global ``mentions_in_cards`` key (when present)
+        # and then to enabled. Injecting an explicit default mapping here
+        # would shadow ``mentions_in_cards: false`` after the config merge.
+        "interaction_mentions": None,
         "footer_fields": [
             "duration",
             "model",
@@ -155,6 +161,100 @@ def merge_card_config(
         else:
             resolved["text_sizes"] = copy.deepcopy(incoming_sizes)
     return resolved
+
+
+def _mention_switch_value(raw: object, *, path: str) -> bool | None:
+    """Normalize a mention switch to bool, or ``None`` when unset/malformed.
+
+    ``None`` keeps the caller on the next resolution step, so malformed
+    values degrade gracefully instead of crashing card rendering.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return _normalize_boolean(raw, path)
+        except ValueError:
+            return None
+    return None
+
+
+def card_interaction_mention_enabled(
+    card_config: Mapping[str, Any] | None, *, kind: str
+) -> bool:
+    """Whether interaction cards may @ mention the requester for a given kind.
+
+    Resolution order:
+
+    1. Legacy global ``card.mentions_in_cards`` when explicitly ``false``:
+       THE GLOBAL OFF SWITCH — it disables every @ mention regardless of
+       per-kind settings (so ``mentions_in_cards: false`` always wins).
+    2. ``card.interaction_mentions.<kind>`` when the mapping is present and
+       the key resolves to a boolean (explicit per-kind switch; an absent
+       kind falls through to the global / default).
+    3. Legacy global ``card.mentions_in_cards`` when explicitly ``true``.
+    4. Default: enabled for ``approval`` / ``clarify`` kinds, disabled for
+       anything else (defense in depth: callers should gate on kind too).
+    """
+    if not isinstance(card_config, Mapping):
+        return _default_interaction_mention(kind)
+    legacy = _mention_switch_value(
+        card_config.get("mentions_in_cards"),
+        path="card.mentions_in_cards",
+    )
+    if legacy is False:
+        return False
+    raw_mentions = card_config.get("interaction_mentions")
+    if isinstance(raw_mentions, Mapping) and kind in raw_mentions:
+        resolved = _mention_switch_value(
+            raw_mentions.get(kind),
+            path=f"card.interaction_mentions.{kind}",
+        )
+        if resolved is not None:
+            return resolved
+    if legacy is True:
+        return True
+    return _default_interaction_mention(kind)
+
+
+def _default_interaction_mention(kind: str) -> bool:
+    return kind in {"approval", "clarify"}
+
+
+def card_completion_mention_enabled(
+    card_config: Mapping[str, Any] | None,
+) -> bool:
+    """Whether the completion notification may @ mention the requester.
+
+    Resolution order:
+
+    1. Legacy global ``card.mentions_in_cards`` when explicitly ``false``:
+       THE GLOBAL OFF SWITCH.
+    2. ``card.completion_notify.mention`` when set and boolean (explicit).
+    3. Legacy global ``card.mentions_in_cards`` when explicitly ``true``.
+    4. Default: enabled (matches the pre-configuration behaviour).
+    """
+    if not isinstance(card_config, Mapping):
+        return True
+    legacy = _mention_switch_value(
+        card_config.get("mentions_in_cards"),
+        path="card.mentions_in_cards",
+    )
+    if legacy is False:
+        return False
+    notify = card_config.get("completion_notify")
+    if isinstance(notify, Mapping) and "mention" in notify:
+        resolved = _mention_switch_value(
+            notify.get("mention"),
+            path="card.completion_notify.mention",
+        )
+        if resolved is not None:
+            return resolved
+    if legacy is True:
+        return True
+    return True
 
 
 def _normalize_text_size_value(value: object, path: str) -> str:
@@ -334,6 +434,26 @@ def _normalize_card_config(value: object, *, path: str) -> None:
         value["table_overflow_mode"] = normalize_table_overflow_mode(
             value["table_overflow_mode"], path=f"{path}.table_overflow_mode"
         )
+    if "mentions_in_cards" in value and value["mentions_in_cards"] is not None:
+        value["mentions_in_cards"] = _normalize_boolean(
+            value["mentions_in_cards"], f"{path}.mentions_in_cards"
+        )
+    if "interaction_mentions" in value and value["interaction_mentions"] is not None:
+        raw_mentions = value["interaction_mentions"]
+        if not isinstance(raw_mentions, Mapping):
+            raise ValueError(f"{path}.interaction_mentions must be a mapping")
+        normalized = {}
+        for kind, raw in raw_mentions.items():
+            normalized[str(kind)] = _normalize_boolean(
+                raw, f"{path}.interaction_mentions.{kind}"
+            )
+        value["interaction_mentions"] = normalized
+    if "completion_notify" in value and isinstance(value["completion_notify"], dict):
+        notify = value["completion_notify"]
+        if "mention" in notify and notify["mention"] is not None:
+            notify["mention"] = _normalize_boolean(
+                notify["mention"], f"{path}.completion_notify.mention"
+            )
 
 
 def _merge_sections(config: dict[str, dict[str, Any]], loaded: dict[str, Any]) -> None:

--- a/hermes_feishu_card/render.py
+++ b/hermes_feishu_card/render.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from typing import Any, Dict, Literal, Optional
 
 from .card_limits import CardLimitInspection, inspect_card_limits
-from .session import CardSession
+from .session import CardSession, _exact_feishu_open_id
 from .status import StatusConfig, resolve_display_status
 from .text import (
     TableOverflowResult,
@@ -110,6 +110,7 @@ def render_card(
     text_sizes: Mapping[str, Any] | None = None,
     table_overflow_mode: str = "compact",
     interaction_profile_id: str = "default",
+    mentions_enabled: bool = True,
 ) -> Dict[str, Any]:
     return render_card_result(
         session,
@@ -125,6 +126,7 @@ def render_card(
         text_sizes=text_sizes,
         table_overflow_mode=table_overflow_mode,
         interaction_profile_id=interaction_profile_id,
+        mentions_enabled=mentions_enabled,
     ).card
 
 
@@ -142,6 +144,7 @@ def render_card_result(
     text_sizes: Mapping[str, Any] | None = None,
     table_overflow_mode: str = "compact",
     interaction_profile_id: str = "default",
+    mentions_enabled: bool = True,
 ) -> CardRenderResult:
     primary_text = _primary_text_for_session(session)
     table_overflow = transform_table_overflow(
@@ -162,6 +165,7 @@ def render_card_result(
         text_sizes=text_sizes,
         table_overflow_mode=table_overflow_mode,
         interaction_profile_id=interaction_profile_id,
+        mentions_enabled=mentions_enabled,
     )
     inspection = inspect_card_limits(card)
     if inspection.safe:
@@ -202,6 +206,7 @@ def _render_card_unchecked(
     text_sizes: Mapping[str, Any] | None = None,
     table_overflow_mode: str = "compact",
     interaction_profile_id: str = "default",
+    mentions_enabled: bool = True,
 ) -> Dict[str, Any]:
     used_text_size_roles: set[str] = set()
     status = _render_status(session, status_config=status_config)
@@ -234,6 +239,18 @@ def _render_card_unchecked(
         if runtime_summary
         else _runtime_header_title(session, configured_title)
     )
+    pending_interaction = session.active_interaction
+    if (
+        pending_interaction is not None
+        and pending_interaction.status == "pending"
+        and pending_interaction.kind in {"approval", "clarify"}
+    ):
+        prefix = (
+            "待审批："
+            if pending_interaction.kind == "approval"
+            else "待选择："
+        )
+        header_title = f"{prefix}{header_title}"
     main_role = "notice" if session.delivery_kind == "notice" else "body"
     elements = []
     if primary_text:
@@ -259,7 +276,13 @@ def _render_card_unchecked(
             used_text_size_roles=used_text_size_roles,
         )
         elements.extend(timeline_elements)
-    elements.extend(_render_interaction_elements(session, interaction_mode=interaction_mode))
+    elements.extend(
+        _render_interaction_elements(
+            session,
+            interaction_mode=interaction_mode,
+            mentions_enabled=mentions_enabled,
+        )
+    )
     if attachment_summary:
         elements.append(
             {
@@ -338,6 +361,7 @@ def _render_card_unchecked(
             session,
             header=header,
             profile_id=_normalize_interaction_profile_id(interaction_profile_id),
+            mentions_enabled=mentions_enabled,
         )
     return card
 
@@ -358,8 +382,15 @@ def render_legacy_interaction_callback_card(
     *,
     title: str = DEFAULT_TITLE,
     interaction_profile_id: str = "default",
+    mentions_enabled: bool = True,
 ) -> Dict[str, Any]:
-    """Render one interaction entirely on Feishu's legacy callback rail."""
+    """Render one interaction entirely on Feishu's legacy callback rail.
+
+    This is the dedicated legacy auxiliary renderer used for interaction
+    messages that are NOT the session's streaming card: the streaming card
+    (schema 2.0) keeps its stable owner, and the interaction replies on this
+    legacy rail instead of switching the session card's dialect.
+    """
     interaction = session.active_interaction
     if interaction is None:
         raise ValueError("active interaction is required")
@@ -367,22 +398,34 @@ def render_legacy_interaction_callback_card(
         "completed": "green",
         "failed": "red",
     }.get(interaction.status, "blue")
+    header_title = interaction.prompt or title
+    if (
+        interaction.status == "pending"
+        and interaction.kind in {"approval", "clarify"}
+    ):
+        prefix = "待审批：" if interaction.kind == "approval" else "待选择："
+        header_title = f"{prefix}{header_title}"
     header = {
         "template": template,
         "title": {
             "tag": "plain_text",
-            "content": interaction.prompt or title,
+            "content": header_title,
         },
     }
     return _render_legacy_callback_card(
         session,
         header=header,
         profile_id=_normalize_interaction_profile_id(interaction_profile_id),
+        mentions_enabled=mentions_enabled,
     )
 
 
 def _render_legacy_callback_card(
-    session: CardSession, *, header: Mapping[str, Any], profile_id: str
+    session: CardSession,
+    *,
+    header: Mapping[str, Any],
+    profile_id: str,
+    mentions_enabled: bool = True,
 ) -> Dict[str, Any]:
     """Render an interaction on Feishu's server-callback card rail.
 
@@ -424,7 +467,17 @@ def _render_legacy_callback_card(
     if description:
         elements.append({"tag": "markdown", "content": description})
 
+    mention = _interaction_mention_content(
+        session,
+        interaction,
+        mentions_enabled=mentions_enabled,
+    )
     if interaction.multi_select:
+        if mention:
+            hint = f"{mention} 请选择（可多选）"
+            if interaction.allow_custom_input:
+                hint += "，或输入自定义内容"
+            elements.append({"tag": "markdown", "content": hint})
         elements.append(
             _legacy_form(
                 _render_multi_select_form(interaction, profile_id=profile_id)
@@ -434,6 +487,8 @@ def _render_legacy_callback_card(
         hint = "请选择一个选项"
         if interaction.allow_custom_input:
             hint += "，或输入自定义内容"
+        if mention:
+            hint = f"{mention} {hint}"
         elements.append({"tag": "markdown", "content": hint})
         buttons = [
             _legacy_button(
@@ -670,14 +725,49 @@ def _render_main_content_elements(
     return elements
 
 
+def _interaction_mention_content(
+    session: CardSession,
+    interaction: Any,
+    *,
+    mentions_enabled: bool = True,
+) -> str:
+    """Return the in-card @ mention prefix for an approval/clarify card, or ``""``.
+
+    The @ mention of the requester / clarified user is returned as a bare
+    ``<at id=...>`` prefix (no trailing text) so callers can merge it into
+    the interaction hint line instead of rendering a separate mention row.
+    Only pending approval/clarify interactions are mentioned, only when the
+    per-kind mention flag is enabled, and only when the session carries a
+    valid Feishu open_id for the requester.
+    """
+    if not mentions_enabled:
+        return ""
+    if getattr(interaction, "status", "") != "pending":
+        return ""
+    if getattr(interaction, "kind", "") not in {"approval", "clarify"}:
+        return ""
+    open_id = _exact_feishu_open_id(getattr(session, "sender_open_id", ""))
+    if not open_id:
+        return ""
+    return f'<at id="{open_id}"></at>'
+
+
 def _render_interaction_elements(
-    session: CardSession, *, interaction_mode: str = "callback"
+    session: CardSession,
+    *,
+    interaction_mode: str = "callback",
+    mentions_enabled: bool = True,
 ) -> list[Dict[str, Any]]:
     interaction = session.active_interaction
     if interaction is None:
         return []
 
     elements: list[Dict[str, Any]] = []
+    mention = _interaction_mention_content(
+        session,
+        interaction,
+        mentions_enabled=mentions_enabled,
+    )
     if interaction.status == "pending" and interaction.description:
         elements.append(
             {
@@ -706,15 +796,41 @@ def _render_interaction_elements(
                     "content": "\n".join(choice_lines),
                 }
             )
+        if mention:
+            hint = (
+                f"{mention} 请选择（可多选）"
+                if interaction.multi_select
+                else f"{mention} 请选择一个选项"
+            )
+            elements.append(
+                {
+                    "tag": "markdown",
+                    "element_id": "interaction_hint",
+                    "content": hint,
+                }
+            )
         return elements
 
     if interaction.status == "pending":
         if interaction.multi_select:
+            if mention:
+                hint = f"{mention} 请选择（可多选）"
+                if interaction.allow_custom_input:
+                    hint += "，或输入自定义内容"
+                elements.append(
+                    {
+                        "tag": "markdown",
+                        "element_id": "interaction_hint",
+                        "content": hint,
+                    }
+                )
             elements.append(_render_multi_select_form(interaction))
         else:
             hint = "（单选）请选择"
             if interaction.allow_custom_input:
                 hint += "，或输入自定义内容"
+            if mention:
+                hint = f"{mention} {hint}"
             elements.append(
                 {
                     "tag": "markdown",

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -5535,14 +5535,25 @@ async def _maybe_send_completion_notify(
         if type(card_config) is dict
         else None
     )
+    # The @ mention is optional: when disabled (completion_notify.mention=false
+    # or the global mentions_in_cards off switch), the plain completion
+    # notification must be sent even without a (valid) sender open_id --
+    # system/background turns have no requester to mention. Only when the
+    # mention is enabled do we require and validate the sender open_id.
+    mention_enabled = card_completion_mention_enabled(card_config)
     if (
         type(notify_config) is not dict
         or notify_config.get("enabled") is not True
         or session.status != "completed"
         or session.delivery_kind != "chat"
         or session.completion_notify_state != "idle"
-        or re.fullmatch(r"ou_[A-Za-z0-9_-]{1,128}", session.sender_open_id)
-        is None
+        or (
+            mention_enabled
+            and re.fullmatch(
+                r"ou_[A-Za-z0-9_-]{1,128}", session.sender_open_id
+            )
+            is None
+        )
     ):
         return
     client = _client_for_bot(app, app[MESSAGE_BOT_IDS_KEY].get(session_key))
@@ -5555,7 +5566,7 @@ async def _maybe_send_completion_notify(
     suffix = f"（用时 {duration_text}）" if duration_text else ""
     mention_prefix = (
         f'<at user_id="{session.sender_open_id}"></at> '
-        if card_completion_mention_enabled(card_config)
+        if mention_enabled
         else ""
     )
     text = f"{mention_prefix}✅ 任务已完成{suffix}"

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -21,7 +21,13 @@ from typing import Any, Callable, Dict
 from aiohttp import ClientSession, ClientTimeout, web
 
 from .bots import RouteResult
-from .config import load_config, merge_card_config, resolve_operations_hermes_root
+from .config import (
+    card_completion_mention_enabled,
+    card_interaction_mention_enabled,
+    load_config,
+    merge_card_config,
+    resolve_operations_hermes_root,
+)
 from .delivery_policy import (
     CARD_DISPOSITION,
     ChatDeliveryDecision,
@@ -5547,10 +5553,12 @@ async def _maybe_send_completion_notify(
     session.completion_notify_state = "sending"
     duration_text = _format_duration(session.duration) if session.duration > 0 else ""
     suffix = f"（用时 {duration_text}）" if duration_text else ""
-    text = (
+    mention_prefix = (
         f'<at user_id="{session.sender_open_id}"></at> '
-        f"✅ 任务已完成{suffix}"
+        if card_completion_mention_enabled(card_config)
+        else ""
     )
+    text = f"{mention_prefix}✅ 任务已完成{suffix}"
     try:
         send_kwargs: dict[str, Any] = {
             "thread_id": _thread_id_for_event(event) or None,
@@ -6367,6 +6375,10 @@ def _render_session_card_result_for_app(
             else None
         ),
         table_overflow_mode=table_overflow_mode,
+        mentions_enabled=card_interaction_mention_enabled(
+            card_config,
+            kind=getattr(session.active_interaction, "kind", "") or "",
+        ),
     )
 
 
@@ -6376,7 +6388,7 @@ def _render_interaction_callback_card_for_app(
     *,
     session_key: str | None = None,
 ) -> dict[str, Any]:
-    _, _, title, interaction_profile_id = _session_card_render_context(
+    _, card_config, title, interaction_profile_id = _session_card_render_context(
         app,
         session,
         session_key=session_key,
@@ -6385,6 +6397,10 @@ def _render_interaction_callback_card_for_app(
         session,
         title=title,
         interaction_profile_id=interaction_profile_id,
+        mentions_enabled=card_interaction_mention_enabled(
+            card_config,
+            kind=getattr(session.active_interaction, "kind", "") or "",
+        ),
     )
 
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -7574,7 +7574,7 @@ async def test_v4_interaction_restores_cached_preview_on_stable_v2_card(client):
     assert len(feishu_client.sent) == 2
     waiting = feishu_client.sent[-1][1]
     assert "允许读取精确位置吗？" in str(waiting)
-    assert waiting["header"]["title"]["content"] == "允许读取精确位置吗？"
+    assert waiting["header"]["title"]["content"] == "待审批：允许读取精确位置吗？"
     button = interaction_buttons(waiting)[0]
     action_value = button["value"]
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -7897,6 +7897,94 @@ async def test_completion_notify_updates_card_then_mentions_once_when_enabled(
         await test_client.close()
 
 
+async def test_completion_notify_sends_plain_without_sender_when_mention_disabled(
+    tmp_path,
+):
+    """mention=false must send the plain completion notify even without a
+    sender_open_id (system/background turns have no requester to @)."""
+    feishu_client = FakeFeishuClient()
+    app = create_app(
+        feishu_client,
+        card_config={"completion_notify": {"enabled": True, "mention": False}},
+        native_handoff_store=NativeHandoffStore(tmp_path / "handoff-state"),
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        await test_client.post(
+            "/events",
+            json=event_payload(
+                "message.started",
+                0,
+                {
+                    # No sender_open_id: system / background turn.
+                    "reply_to_message_id": "",
+                },
+                thread_id="omt_thread",
+            ),
+        )
+        feishu_client.operations.clear()
+        completed_payload = event_payload(
+            "message.completed",
+            1,
+            {"answer": "done"},
+            thread_id="omt_thread",
+        )
+        first = await test_client.post("/events", json=completed_payload)
+        replay = await test_client.post("/events", json=completed_payload)
+
+        assert first.status == 200
+        assert replay.status == 200
+        assert feishu_client.texts == [
+            ("oc_abc", "✅ 任务已完成", "omt_thread", None)
+        ]
+        session = app[SESSIONS_KEY]["hermes-message-1"]
+        assert session.completion_notify_state == "sent"
+    finally:
+        await test_client.close()
+
+
+async def test_completion_notify_rejects_invalid_sender_when_mention_enabled(
+    tmp_path,
+):
+    """mention=true (default) still refuses to send when the sender_open_id
+    is present but invalid -- no plain fallback notification."""
+    feishu_client = FakeFeishuClient()
+    app = create_app(
+        feishu_client,
+        card_config={"completion_notify": {"enabled": True}},
+        native_handoff_store=NativeHandoffStore(tmp_path / "handoff-state"),
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        await test_client.post(
+            "/events",
+            json=event_payload(
+                "message.started",
+                0,
+                {"sender_open_id": "user_not_an_ou", "reply_to_message_id": ""},
+                thread_id="omt_thread",
+            ),
+        )
+        feishu_client.operations.clear()
+        completed_payload = event_payload(
+            "message.completed",
+            1,
+            {"answer": "done", "sender_open_id": "user_not_an_ou"},
+            thread_id="omt_thread",
+        )
+        await test_client.post("/events", json=completed_payload)
+
+        assert feishu_client.texts == []
+        session = app[SESSIONS_KEY]["hermes-message-1"]
+        assert session.completion_notify_state == "idle"
+    finally:
+        await test_client.close()
+
+
 async def test_completion_notify_preserves_reply_in_thread_without_thread_id(
     tmp_path,
 ):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -63,6 +63,9 @@ def test_load_config_missing_file_returns_defaults(tmp_path):
             "max_tool_result_chars": 600,
             "table_overflow_mode": "compact",
             "completion_notify": {"enabled": False},
+            # UNSET by default: resolving helpers fall back to the legacy
+            # ``mentions_in_cards`` key and then to enabled.
+            "interaction_mentions": None,
             "footer_fields": [
                 "duration",
                 "model",
@@ -297,6 +300,7 @@ card:
         "max_tool_result_chars": 600,
         "table_overflow_mode": "compact",
         "completion_notify": {"enabled": False},
+        "interaction_mentions": None,
         "footer_fields": [
             "duration",
             "model",

--- a/tests/unit/test_config_mentions.py
+++ b/tests/unit/test_config_mentions.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from hermes_feishu_card.config import (
+    card_completion_mention_enabled,
+    card_interaction_mention_enabled,
+    load_config,
+)
+
+
+CONFIG_ENV_VARS = (
+    "HERMES_FEISHU_CARD_HOST",
+    "HERMES_FEISHU_CARD_PORT",
+    "HERMES_FEISHU_CARD_ALLOW_NON_LOOPBACK",
+    "HERMES_FEISHU_CARD_SERVICE_MANAGER",
+    "HERMES_FEISHU_CARD_INTEGRITY_MODE",
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_config_env(monkeypatch):
+    for name in CONFIG_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_load_config_defaults_leave_mentions_unset_but_enabled(tmp_path):
+    config = load_config(tmp_path / "missing.yaml")
+
+    # Defaults must NOT inject a per-kind mapping: an injected mapping would
+    # shadow ``mentions_in_cards: false`` after the config merge.
+    assert config["card"]["interaction_mentions"] is None
+    assert config["card"]["completion_notify"] == {"enabled": False}
+    assert card_interaction_mention_enabled(config["card"], kind="clarify") is True
+    assert card_interaction_mention_enabled(config["card"], kind="approval") is True
+    assert card_completion_mention_enabled(config["card"]) is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: load_config() from a FULL YAML file, not isolated helpers.
+# ---------------------------------------------------------------------------
+
+
+def test_full_yaml_global_off_switch_disables_every_mention(tmp_path):
+    """``mentions_in_cards: false`` must disable clarify/approval/completion."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "card": {
+                    "mentions_in_cards": False,
+                    "completion_notify": {"enabled": True},
+                }
+            }
+        )
+    )
+
+    config = load_config(path)
+
+    assert config["card"]["mentions_in_cards"] is False
+    assert config["card"]["interaction_mentions"] is None
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="clarify") is False
+    )
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="approval") is False
+    )
+    assert card_completion_mention_enabled(config["card"]) is False
+
+
+def test_full_yaml_global_off_switch_wins_over_per_kind_true(tmp_path):
+    """The master OFF switch beats an explicit per-kind true."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "card": {
+                    "mentions_in_cards": False,
+                    "interaction_mentions": {"approval": True},
+                }
+            }
+        )
+    )
+
+    config = load_config(path)
+
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="approval") is False
+    )
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="clarify") is False
+    )
+
+
+def test_full_yaml_per_kind_off_without_global_key(tmp_path):
+    """Per-kind switches apply when the global key is absent."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"card": {"interaction_mentions": {"clarify": False, "approval": True}}}
+        )
+    )
+
+    config = load_config(path)
+
+    assert config["card"]["interaction_mentions"] == {
+        "clarify": False,
+        "approval": True,
+    }
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="clarify") is False
+    )
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="approval") is True
+    )
+
+
+def test_full_yaml_completion_notify_mention_override(tmp_path):
+    """completion_notify.mention overrides the default/global for the notify."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"card": {"completion_notify": {"enabled": True, "mention": False}}}
+        )
+    )
+
+    config = load_config(path)
+
+    assert config["card"]["completion_notify"] == {
+        "enabled": True,
+        "mention": False,
+    }
+    assert card_completion_mention_enabled(config["card"]) is False
+    # The notify switch does NOT leak into interaction mention resolution.
+    assert (
+        card_interaction_mention_enabled(config["card"], kind="clarify") is True
+    )
+
+
+def test_full_yaml_string_booleans_normalized(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "card": {
+                    "mentions_in_cards": "false",
+                    "interaction_mentions": {"clarify": "off"},
+                }
+            }
+        )
+    )
+
+    config = load_config(path)
+
+    assert config["card"]["mentions_in_cards"] is False
+    assert config["card"]["interaction_mentions"] == {"clarify": False}
+    assert card_completion_mention_enabled(config["card"]) is False
+
+
+def test_load_config_rejects_invalid_interaction_mentions_with_exact_path(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump({"card": {"interaction_mentions": {"clarify": "maybe"}}})
+    )
+
+    with pytest.raises(ValueError, match=r"card\.interaction_mentions\.clarify"):
+        load_config(path)
+
+
+def test_load_config_rejects_non_mapping_interaction_mentions(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump({"card": {"interaction_mentions": True}}))
+
+    with pytest.raises(ValueError, match=r"card\.interaction_mentions"):
+        load_config(path)
+
+
+def test_load_config_keeps_legacy_mentions_in_cards_normalized(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump({"card": {"mentions_in_cards": "off"}}))
+
+    config = load_config(path)
+
+    assert config["card"]["mentions_in_cards"] is False
+
+
+# ---------------------------------------------------------------------------
+# Isolated helper resolution.
+# ---------------------------------------------------------------------------
+
+
+def test_interaction_mention_enabled_defaults_true_for_missing_or_malformed():
+    assert card_interaction_mention_enabled(None, kind="clarify") is True
+    assert card_interaction_mention_enabled(None, kind="approval") is True
+    assert card_interaction_mention_enabled({}, kind="clarify") is True
+    assert card_interaction_mention_enabled({}, kind="approval") is True
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"clarify": None}}, kind="clarify"
+        )
+        is True
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"approval": "maybe"}}, kind="approval"
+        )
+        is True
+    )
+
+
+def test_interaction_mention_enabled_reads_explicit_boolean():
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"clarify": True}}, kind="clarify"
+        )
+        is True
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"approval": False}}, kind="approval"
+        )
+        is False
+    )
+
+
+def test_interaction_mention_enabled_parses_string_values():
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"clarify": "true"}}, kind="clarify"
+        )
+        is True
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"approval": "false"}}, kind="approval"
+        )
+        is False
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"approval": "off"}}, kind="approval"
+        )
+        is False
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"clarify": "yes"}}, kind="clarify"
+        )
+        is True
+    )
+
+
+def test_interaction_mention_enabled_kind_is_isolated():
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"clarify": False, "approval": True}},
+            kind="clarify",
+        )
+        is False
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"interaction_mentions": {"clarify": False, "approval": True}},
+            kind="approval",
+        )
+        is True
+    )
+
+
+def test_interaction_mention_enabled_honors_legacy_global_switch():
+    assert (
+        card_interaction_mention_enabled(
+            {"mentions_in_cards": False}, kind="approval"
+        )
+        is False
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"mentions_in_cards": True}, kind="clarify"
+        )
+        is True
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"mentions_in_cards": False, "interaction_mentions": {"approval": True}},
+            kind="approval",
+        )
+        is False
+    )
+
+
+def test_interaction_mention_enabled_unknown_kind_defaults_off():
+    assert (
+        card_interaction_mention_enabled({}, kind="slash_confirm") is False
+    )
+    assert (
+        card_interaction_mention_enabled(
+            {"mentions_in_cards": True}, kind="slash_confirm"
+        )
+        is True
+    )
+
+
+def test_completion_mention_enabled_defaults_true():
+    assert card_completion_mention_enabled(None) is True
+    assert card_completion_mention_enabled({}) is True
+    assert (
+        card_completion_mention_enabled(
+            {"completion_notify": {"mention": "maybe"}}
+        )
+        is True
+    )
+
+
+def test_completion_mention_enabled_reads_explicit_boolean():
+    assert (
+        card_completion_mention_enabled(
+            {"completion_notify": {"mention": True}}
+        )
+        is True
+    )
+    assert (
+        card_completion_mention_enabled(
+            {"completion_notify": {"mention": False}}
+        )
+        is False
+    )
+
+
+def test_completion_mention_enabled_honors_legacy_global_switch():
+    assert (
+        card_completion_mention_enabled({"mentions_in_cards": False}) is False
+    )
+    assert (
+        card_completion_mention_enabled({"mentions_in_cards": True}) is True
+    )
+    assert (
+        card_completion_mention_enabled(
+            {"mentions_in_cards": False, "completion_notify": {"mention": True}}
+        )
+        is False
+    )

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -179,7 +179,7 @@ def test_pending_interaction_has_priority_over_compaction_phase():
 
     card = render_card(session, title="研发助手")
 
-    assert card["header"]["title"]["content"] == "允许继续执行吗？"
+    assert card["header"]["title"]["content"] == "待审批：允许继续执行吗？"
     assert "正在压缩上下文" not in str(card["header"])
 
 
@@ -259,7 +259,7 @@ def test_v4_waiting_prompt_moves_to_header_without_body_duplication():
         if item.get("tag") == "markdown"
     )
 
-    assert card["header"]["title"]["content"] == "允许覆盖文件吗？"
+    assert card["header"]["title"]["content"] == "待审批：允许覆盖文件吗？"
     assert "subtitle" not in card["header"]
     assert str(card).count("允许覆盖文件吗？") == 1
     assert "目标文件：report.html" in str(card)

--- a/tests/unit/test_render_approval_mentions.py
+++ b/tests/unit/test_render_approval_mentions.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from hermes_feishu_card.render import render_card, render_card_result
+from hermes_feishu_card.session import CardSession, InteractionState
+
+SENDER_OU = "ou_abc123DEF_xyz"
+EXPECTED_MENTION = f'<at id="{SENDER_OU}"></at> 请选择一个选项'
+
+
+def _approval_session(
+    *, sender_open_id: str = SENDER_OU, kind: str = "approval"
+) -> CardSession:
+    session = CardSession(conversation_id="c", message_id="m", chat_id="oc")
+    session.sender_open_id = sender_open_id
+    session.active_interaction = InteractionState(
+        interaction_id="approval-1",
+        kind=kind,
+        prompt="需要授权后继续执行",
+        description="```\nrm -rf /\n```",
+    )
+    return session
+
+
+def _body_elements(card: dict) -> list[dict]:
+    if "body" in card:
+        return card["body"]["elements"]
+    return card["elements"]
+
+
+def _mention_elements(card: dict) -> list[dict]:
+    return [
+        element
+        for element in _body_elements(card)
+        if isinstance(element, dict)
+        and element.get("tag") == "markdown"
+        and "<at id=" in str(element.get("content", ""))
+    ]
+
+
+def test_approval_legacy_callback_card_contains_mention():
+    """Default callback-mode approval card embeds the @ mention inside the card."""
+    session = _approval_session()
+
+    card = render_card(session, title="研发助手")
+
+    mentions = _mention_elements(card)
+    assert len(mentions) == 1
+    assert mentions[0]["content"] == EXPECTED_MENTION
+
+
+def test_approval_legacy_callback_card_title_prefix():
+    session = _approval_session()
+
+    card = render_card(session, title="研发助手")
+
+    assert card["header"]["title"]["content"] == "待审批：需要授权后继续执行"
+
+
+def test_approval_mention_absent_when_config_disabled():
+    session = _approval_session()
+
+    card = render_card(session, title="研发助手", mentions_enabled=False)
+
+    assert _mention_elements(card) == []
+
+
+def test_approval_mention_absent_without_sender_open_id():
+    session = _approval_session(sender_open_id="")
+
+    card = render_card(session, title="研发助手")
+
+    assert _mention_elements(card) == []
+
+
+def test_approval_mention_absent_with_invalid_sender_open_id():
+    session = _approval_session(sender_open_id="user_1234")
+
+    card = render_card(session, title="研发助手")
+
+    assert _mention_elements(card) == []
+
+
+def test_approval_mention_scoped_to_approval_kind_only():
+    """kind outside approval/clarify (e.g. slash) gets no mention."""
+    session = _approval_session(kind="slash")
+
+    card = render_card(session, title="研发助手")
+
+    assert _mention_elements(card) == []
+
+
+def test_approval_mention_absent_after_completion():
+    session = _approval_session()
+    interaction = session.active_interaction
+    assert interaction is not None
+    interaction.status = "completed"
+    interaction.choice = "once"
+    interaction.choice_label = "允许一次"
+
+    card = render_card(session, title="研发助手")
+
+    assert _mention_elements(card) == []
+
+
+def test_approval_mention_present_in_text_mode_interaction_elements():
+    """text interaction mode also renders the mention (non-legacy path)."""
+    session = _approval_session()
+    session.answer_text = "需要授权"
+
+    card = render_card(session, title="研发助手", interaction_mode="text")
+
+    mentions = _mention_elements(card)
+    assert len(mentions) == 1
+    assert mentions[0]["content"] == EXPECTED_MENTION
+
+
+def test_render_card_result_legacy_disposition_contains_mention():
+    session = _approval_session()
+
+    result = render_card_result(session, title="研发助手")
+
+    assert result.disposition == "card"
+    mentions = _mention_elements(result.card)
+    assert len(mentions) == 1
+    assert mentions[0]["content"] == EXPECTED_MENTION

--- a/tests/unit/test_render_clarify_mention.py
+++ b/tests/unit/test_render_clarify_mention.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from hermes_feishu_card.render import render_card
+from hermes_feishu_card.session import CardSession, InteractionState, InteractionOption
+
+
+def _clarify_session(
+    open_id: str = "ou_clarify_123",
+    kind: str = "clarify",
+    status: str = "pending",
+    multi_select: bool = False,
+) -> CardSession:
+    session = CardSession(conversation_id="c", message_id="m", chat_id="oc")
+    session.sender_open_id = open_id
+    session.active_interaction = InteractionState(
+        interaction_id="clarify-1",
+        kind=kind,
+        prompt="选哪个？",
+        options=[
+            InteractionOption(label="A", value="A"),
+            InteractionOption(label="B", value="B"),
+        ],
+        status=status,
+        multi_select=multi_select,
+    )
+    return session
+
+
+def _card_elements(card: dict) -> list[dict]:
+    if isinstance(card.get("body"), dict):
+        return card["body"].get("elements", [])
+    return card.get("elements", [])
+
+
+def _card_text(card: dict) -> str:
+    return "\n".join(str(element) for element in _card_elements(card))
+
+
+def test_clarify_pending_legacy_card_includes_mention():
+    # Default interaction_mode == "callback" -> legacy card rail is the
+    # production clarify card path.
+    session = _clarify_session()
+
+    card = render_card(session)
+
+    elements = _card_elements(card)
+    assert elements[0] == {
+        "tag": "markdown",
+        "content": '<at id="ou_clarify_123"></at> 请选择一个选项',
+    }
+
+
+def test_clarify_mention_disabled_by_config_flag():
+    session = _clarify_session()
+
+    card = render_card(session, mentions_enabled=False)
+
+    assert "<at" not in _card_text(card)
+
+
+def test_clarify_mention_absent_without_sender_open_id():
+    session = _clarify_session(open_id="")
+
+    card = render_card(session)
+
+    assert "<at" not in _card_text(card)
+
+
+def test_clarify_mention_absent_invalid_open_id():
+    session = _clarify_session(open_id="om_invalid")
+
+    card = render_card(session)
+
+    assert "<at" not in _card_text(card)
+
+
+def test_clarify_mention_absent_for_non_clarify_kind():
+    # kind=approval is handled by the sibling task through the same shared
+    # helper; use a kind excluded from both to prove the kind gate works.
+    session = _clarify_session(kind="slash_confirm")
+
+    card = render_card(session)
+
+    assert "<at" not in _card_text(card)
+
+
+def test_clarify_mention_absent_when_completed():
+    session = _clarify_session(status="completed")
+    interaction = session.active_interaction
+    assert interaction is not None
+    interaction.choice = "A"
+    interaction.choice_label = "A"
+
+    card = render_card(session)
+
+    assert "<at" not in _card_text(card)
+
+
+def test_clarify_mention_in_text_mode_card_uses_v2_element():
+    session = _clarify_session()
+
+    card = render_card(session, interaction_mode="text")
+
+    elements = _card_elements(card)
+    mention_elements = [
+        element
+        for element in elements
+        if element.get("element_id") == "interaction_hint"
+    ]
+    assert len(mention_elements) == 1
+    assert (
+        mention_elements[0]["content"]
+        == '<at id="ou_clarify_123"></at> 请选择一个选项'
+    )
+
+
+def test_clarify_mention_multiselect_legacy_precedes_form():
+    session = _clarify_session(multi_select=True)
+
+    card = render_card(session)
+
+    elements = _card_elements(card)
+    assert (
+        elements[0]["content"]
+        == '<at id="ou_clarify_123"></at> 请选择（可多选）'
+    )
+    assert any(
+        isinstance(element, dict) and element.get("tag") == "form"
+        for element in elements
+    )

--- a/tests/unit/test_render_mentions.py
+++ b/tests/unit/test_render_mentions.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from hermes_feishu_card.render import render_card, render_card_result
+from hermes_feishu_card.session import CardSession, InteractionState
+
+
+def _pending_approval_session() -> CardSession:
+    session = CardSession(conversation_id="c", message_id="m", chat_id="oc")
+    session.active_interaction = InteractionState(
+        interaction_id="approval-1",
+        kind="approval",
+        prompt="允许继续执行吗？",
+    )
+    return session
+
+
+def test_render_accepts_mentions_enabled_kwarg_with_default():
+    session = CardSession(conversation_id="c", message_id="m", chat_id="oc")
+    session.answer_text = "答案"
+
+    card = render_card(session, mentions_enabled=True)
+
+    assert card["header"]["title"]["content"] == "Hermes Agent"
+
+
+def test_render_mentions_enabled_false_keeps_pending_approval_card():
+    session = _pending_approval_session()
+
+    card = render_card(session, title="研发助手", mentions_enabled=False)
+
+    assert card["header"]["title"]["content"] == "待审批：允许继续执行吗？"
+
+
+def test_render_mentions_enabled_true_keeps_pending_approval_card():
+    session = _pending_approval_session()
+
+    card = render_card(session, title="研发助手", mentions_enabled=True)
+
+    assert card["header"]["title"]["content"] == "待审批：允许继续执行吗？"
+
+
+def test_render_mentions_enabled_false_completed_interaction_still_renders():
+    session = _pending_approval_session()
+    interaction = session.active_interaction
+    assert interaction is not None
+    interaction.status = "completed"
+    interaction.choice = "1"
+    interaction.choice_label = "继续执行"
+
+    card = render_card(session, mentions_enabled=False)
+
+    assert "继续执行" in result_text(card)
+
+
+def test_render_card_result_plumbs_mentions_enabled_to_legacy_callback_card():
+    session = _pending_approval_session()
+
+    result = render_card_result(session, mentions_enabled=False)
+
+    assert result.disposition == "card"
+    assert result.card["header"]["title"]["content"] == "待审批：允许继续执行吗？"
+
+
+def result_text(card: dict) -> str:
+    if "body" in card:
+        elements = card["body"]["elements"]
+    else:
+        elements = card["elements"]
+    parts = []
+    for element in elements:
+        parts.append(str(element))
+    return "\n".join(parts)


### PR DESCRIPTION
**背景**：通过飞书卡片发起交互（clarify 选择 / approval 审批）或任务完成时，卡片与通知不会 @ 提及发起人，用户容易错过待处理事项。

**改动**：

- `card` 新增配置，按类型独立控制 @ 提醒：`interaction_mentions.clarify / approval`（默认双开）、`completion_notify.mention`，旧键 `mentions_in_cards` 保留兜底；
- 交互卡（clarify/approval）卡片内 @ 提及发起人，与提示合并为一行（如 `@用户 请选择一个选项，或输入自定义内容`）；
- 交互卡标题加 `待选择：` / `待审批：` 前缀，推送可辨识；
- 补充示例配置与单元测试。

**兼容性**：未配置时默认为 clarify 开、approval 开、完成通知 @ 开；无效值回退默认。

**验证**：单元测试通过；飞书端到端确认标题前缀、@ 同行渲染与点击回传正常。