### PR TITLE
fix: preserve Feishu reply_in_thread placement

### DIFF
--- a/docs/event-protocol.en.md
+++ b/docs/event-protocol.en.md
@@ -24,6 +24,8 @@ The minimal Hermes hook sends message lifecycle events to the sidecar. The hook 
 
 All events keep the required `conversation_id`, `message_id`, and `chat_id` fields. From V3.6.4, events may also carry an optional `thread_id`; when it represents a Feishu `om_` / `omt_` thread context, the sidecar uses the Feishu reply API to create the initial card in the same thread where the user sent the message. Later updates still PATCH the created card message.
 
+When Hermes only has the intent to create a thread from the current message and no concrete `thread_id` yet, the hook may send `data.reply_in_thread=true` together with `data.reply_to_message_id`. The sidecar keeps this intent in the current `CardSession`, so later approval/clarify cards and deferred runtime-admission deliveries continue using the same reply API and anchor instead of falling back to the chat top level.
+
 `turn_id` is optional and provides the stable identity of one Agent turn. `message_id` remains the identity of the current event, stream, or reply, while `data.reply_to_message_id` is only the Feishu reply anchor. When `turn_id` is present, session ownership, event ordering, delivery policy, and native handoff use it and never let a `reply_to_message_id` alias change the owning turn.
 
 When `turn_id` is absent, the sidecar preserves the legacy fallback: `message_id` is the turn identity and later stream events may still use a `reply_to_message_id` alias to reach an existing active session.

--- a/docs/event-protocol.md
+++ b/docs/event-protocol.md
@@ -24,6 +24,8 @@ Hermes 最小 hook 向 sidecar 发送消息生命周期事件。第二阶段 hoo
 
 所有事件都保留 `conversation_id`、`message_id` 和 `chat_id` 三个必填字段。V3.6.4 起，事件还可以携带可选 `thread_id` 字段；当它是飞书 `om_` / `omt_` thread 上下文时，sidecar 会在创建初始卡片时使用飞书 reply API，把卡片发回用户所在的同一 thread。后续更新仍然 PATCH 这条已创建的卡片消息。
 
+当 Hermes 只有“从当前消息创建 thread”的意图、尚未拿到 `thread_id` 时，hook 可以同时发送 `data.reply_in_thread=true` 与 `data.reply_to_message_id`。sidecar 会把该意图保存在当前 `CardSession`，因此后续 approval/clarify 交互卡以及 runtime-admission 延迟投递仍使用同一 reply API 和锚点，不会回落到群聊顶层。
+
 `turn_id` 是可选字段，用来稳定标识一次 Agent turn；`message_id` 保留当前事件、stream 或 reply identity，`data.reply_to_message_id` 只表示飞书回复锚点。当 `turn_id` 存在时，session ownership、事件排序、delivery policy 和 native handoff 都使用 `turn_id`，不会通过 `reply_to_message_id` alias 改写所属 turn。
 
 缺少 `turn_id` 时，sidecar 保持兼容：以 `message_id` 作为 turn identity，并继续允许后续 stream 事件通过 `reply_to_message_id` alias 路由到已有 active session。

--- a/docs/wiki/event-flow.md
+++ b/docs/wiki/event-flow.md
@@ -156,6 +156,7 @@ sidecar 仍应创建 session 并发送初始卡片，不能把整条流计入 `e
 关键规则：
 
 - 首张卡片通常锚定用户 topic message id。
+- 尚无 `thread_id` 但 Hermes 明确要求从当前消息建 thread 时，hook 发送 `reply_in_thread=true` 和真实 reply anchor；sidecar 将该 placement 固定在 session 上，后续普通交互、重复交互和 runtime-admission 交互都继续留在同一 thread。
 - hook runtime 从真实入站 `event.message_id` 绑定可选 `turn_id`，同一轮后续事件继续携带这个稳定值；`message_id` 仍可表示 Hermes 内部 streaming/reply identity。
 - `reply_to_message_id` 只决定飞书回复锚点，不决定 session ownership。
 - sidecar 对显式 `turn_id` 启用 canonical turn hard fence：session、sequence、policy 与 native handoff 都使用 `turn_id`，绝不查询 reply alias。

--- a/docs/wiki/feishu-acceptance.md
+++ b/docs/wiki/feishu-acceptance.md
@@ -2,6 +2,13 @@
 
 自动化测试不能完全证明 Feishu/Lark 客户端体验。涉及卡片 UX、topic、系统提示、命令卡片的版本，发布前需要真实飞书 smoke。
 
+## 首回复建 thread 候选验收
+
+- 在测试群顶层发送一条触发消息，让 Hermes 在尚无 `thread_id` 时请求 `reply_in_thread`；首张 schema 2.0 流式卡必须出现在该消息新建的 thread 中，主群不得出现 top-level fallback 卡。
+- 在同一 turn 依次触发普通 approval/clarify 和 runtime-admission interaction；每张辅助 legacy 交互卡都必须留在同一 thread，原 schema 2.0 卡继续作为唯一 stream PATCH owner。
+- 连续触发两轮 interaction，并受控让第一轮交互卡发送失败后重试；session 的 reply anchor 与 thread placement 不得被后续 event message identity 覆盖，重试也不得降级为主群新卡。
+- 记录前后脱敏 counters，要求 `feishu_send_failures`、`feishu_update_failures` 和 `last_route_error` 不新增；不得保存真实 chat/message/user id、callback token、回答正文或私人截图。
+
 ## V4.3.2 Issue #227 卡片方言双轨验收
 
 - 在同一 turn 记录脱敏前后 counters，发起一次 direct choice clarify 和一次 custom-input form clarify；每轮只发送一张辅助 legacy 交互卡，原 schema 2.0 streaming card 必须保持为后续 PATCH owner。

--- a/docs/wiki/maintenance-guide.md
+++ b/docs/wiki/maintenance-guide.md
@@ -29,7 +29,7 @@
 高风险点：
 
 - 字段名必须贴合 Hermes 变量：`source`、`event`、`response`、`agent_result`、`event_message_id` 等。
-- Feishu topic 场景必须保留 `source.message_id` 和 `reply_to_message_id`。
+- Feishu topic 场景必须保留 `source.message_id` 和 `reply_to_message_id`；首回复建 thread 的 `reply_in_thread` 意图还必须进入 `CardSession`，并通过普通交互与 `RuntimeInteractionDeliveryReservation` 的所有新卡发送路径继续传递。
 - `message.started` 必须从真实入站 `event.message_id` 绑定 `turn_id`；同一 `source` 的 stream/tool/terminal 回调复用这个 immutable identity。显式 `turn_id` 是 canonical turn hard fence，不能被 `message_id` 或 `reply_to_message_id` alias 覆盖；无法在 `source` 绑定私有属性时保持 legacy fail-open。
 - stable tool lifecycle 与 legacy progress callback 不能同时投递同一调用；wrapper 检测必须读取 agent 当前实际 callback，显式 fallback 标记仅用于卡片路径未接受时恢复原生进度。
 - 已识别 `system.notice` 必须按 sidecar 结果分流：已有卡片异步更新的 `accepted` 与独立卡首次投递的 `delivered` 抑制原生文本，`not_sent` 回退原始通知文本，`unknown` 只尝试固定通用提示且不重复原始通知文本；`accepted` 必须同时带有 `applied=true`，不可解析响应一律视为 `unknown`。

--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -287,6 +287,7 @@ class FeishuClient:
         text: str,
         thread_id: Optional[str] = None,
         reply_to_message_id: Optional[str] = None,
+        reply_in_thread: bool = False,
     ) -> str:
         if not isinstance(chat_id, str) or not chat_id.strip():
             raise ValueError("chat_id is required")
@@ -303,7 +304,7 @@ class FeishuClient:
                 json_body={
                     "msg_type": "text",
                     "content": content,
-                    "reply_in_thread": bool(thread_id),
+                    "reply_in_thread": bool(thread_id) or reply_in_thread,
                 },
             )
         else:

--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -162,12 +162,14 @@ class FeishuClient:
         thread_id: Optional[str] = None,
         reply_to_message_id: Optional[str] = None,
         delivery_uuid: Optional[str] = None,
+        reply_in_thread: bool = False,
     ) -> str:
         result = await self.send_card_delivery(
             chat_id,
             card,
             thread_id=thread_id,
             reply_to_message_id=reply_to_message_id,
+            reply_in_thread=reply_in_thread,
             delivery_uuid=delivery_uuid,
         )
         return result.message_id
@@ -179,7 +181,10 @@ class FeishuClient:
         thread_id: Optional[str] = None,
         reply_to_message_id: Optional[str] = None,
         delivery_uuid: Optional[str] = None,
+        reply_in_thread: bool = False,
     ) -> FeishuSendResult:
+        if reply_in_thread and not reply_to_message_id:
+            raise ValueError("reply_to_message_id is required for reply_in_thread")
         if delivery_uuid is not None:
             if not isinstance(delivery_uuid, str) or not delivery_uuid.strip():
                 raise ValueError("delivery_uuid must be a non-empty string")
@@ -207,7 +212,7 @@ class FeishuClient:
                         json_body={
                             "msg_type": payload["msg_type"],
                             "content": payload["content"],
-                            "reply_in_thread": bool(thread_id),
+                            "reply_in_thread": bool(thread_id or reply_in_thread),
                             **(
                                 {"uuid": delivery_uuid}
                                 if delivery_uuid is not None

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -9346,16 +9346,56 @@ def _event_data(
             value = _first_string(local_vars, (source_key,)) or _first_attr_string(message_obj, (source_key,))
             if value:
                 data[data_key] = value
+        reply_in_thread = (
+            _truthy_value(local_vars.get("reply_in_thread"))
+            or _truthy_value(getattr(source_obj, "reply_in_thread", None))
+            or _truthy_value(getattr(message_obj, "reply_in_thread", None))
+            or _truthy_value(getattr(local_vars.get("event"), "reply_in_thread", None))
+        )
+        if reply_in_thread:
+            data["reply_in_thread"] = True
         reply_aliases = (
             "reply_to_message_id",
             "quote_message_id",
             "parent_message_id",
         )
         canonical_reply_id = (
-            _first_string(local_vars, reply_aliases)
+            _first_string(data, ("reply_to_message_id",))
+            or _first_string(local_vars, reply_aliases)
             or _first_attr_string(message_obj, reply_aliases)
             or _first_attr_string(local_vars.get("event"), reply_aliases)
         )
+        if not canonical_reply_id and reply_in_thread:
+            canonical_reply_id = (
+                _first_string(
+                    local_vars,
+                    ("reply_thread_anchor_message_id",),
+                )
+                or _first_attr_string(
+                    source_obj,
+                    ("reply_thread_anchor_message_id", "reply_to_message_id"),
+                )
+                or _first_attr_string(
+                    local_vars.get("event"),
+                    ("reply_thread_anchor_message_id", "reply_to_message_id"),
+                )
+                or _first_attr_string(
+                    message_obj,
+                    ("reply_thread_anchor_message_id", "reply_to_message_id"),
+                )
+                or _first_string(
+                    local_vars,
+                    ("message_id", "event_message_id"),
+                )
+                or _first_attr_string(
+                    source_obj,
+                    ("message_id", "event_message_id"),
+                )
+                or _first_attr_string(
+                    local_vars.get("event"),
+                    ("message_id",),
+                )
+            )
         if canonical_reply_id:
             data["reply_to_message_id"] = canonical_reply_id
         for reply_key in reply_aliases:
@@ -10056,6 +10096,14 @@ def _finite_float(value: Any) -> float | None:
     if not math.isfinite(number):
         return None
     return number
+
+
+def _truthy_value(value: Any) -> bool:
+    if value is True or value == 1:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
 
 
 def _fallback_message_id(

--- a/hermes_feishu_card/runner.py
+++ b/hermes_feishu_card/runner.py
@@ -45,6 +45,7 @@ class NoopFeishuClient:
         card: dict[str, Any],
         thread_id: str | None = None,
         reply_to_message_id: str | None = None,
+        reply_in_thread: bool = False,
     ) -> str:
         raise FeishuAPIError(
             "Feishu delivery is disabled in no-op mode",

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -295,6 +295,7 @@ class RuntimeInteractionDeliveryReservation:
     bot_id: str | None
     thread_id: str | None
     reply_to_message_id: str | None
+    reply_in_thread: bool
     predecessor_message_id: str
     delivery_key: str
 
@@ -4452,6 +4453,12 @@ def _thread_id_for_event(event: SidecarEvent) -> str | None:
 def _reply_to_message_id_for_event(event: SidecarEvent) -> str | None:
     data = event.data if isinstance(event.data, dict) else {}
     reply_to = data.get("reply_to_message_id")
+    if (
+        _reply_in_thread_for_event(event)
+        and isinstance(reply_to, str)
+        and reply_to.startswith("om_")
+    ):
+        return reply_to
     if _thread_id_for_event(event):
         if isinstance(reply_to, str) and reply_to.startswith("om_"):
             return reply_to
@@ -4463,6 +4470,16 @@ def _reply_to_message_id_for_event(event: SidecarEvent) -> str | None:
     if isinstance(reply_to, str) and reply_to.startswith("om_"):
         return reply_to
     return None
+
+
+def _reply_in_thread_for_event(event: SidecarEvent) -> bool:
+    data = event.data if isinstance(event.data, dict) else {}
+    value = data.get("reply_in_thread")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
 
 
 async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tuple[web.Response, Any]:
@@ -4862,6 +4879,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 route.bot_id,
                 thread_id=_thread_id_for_event(event),
                 reply_to_message_id=_reply_to_message_id_for_event(event),
+                reply_in_thread=_reply_in_thread_for_event(event),
                 delivery_key=session_key,
                 delivery_kind=_delivery_kind(event) or "chat",
             )
@@ -5030,6 +5048,7 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                     route.bot_id,
                     thread_id=_thread_id_for_event(event),
                     reply_to_message_id=_reply_to_message_id_for_event(event),
+                    reply_in_thread=_reply_in_thread_for_event(event),
                     delivery_key=session_key,
                     delivery_kind=_delivery_kind(event)
                     or ("notice" if event.event == "system.notice" else "chat"),
@@ -5212,8 +5231,15 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             interaction.interaction_id if interaction is not None else "pending"
         )
         bot_id = message_bot_ids.get(session_key)
+        sticky_reply_to_message_id = (
+            session.reply_to_message_id
+            if session.reply_in_thread
+            and session.reply_to_message_id.startswith("om_")
+            else ""
+        )
         reply_to_message_id = (
-            _reply_to_message_id_for_event(incoming_event)
+            sticky_reply_to_message_id
+            or _reply_to_message_id_for_event(incoming_event)
             or session.reply_to_message_id
             or None
         )
@@ -5247,6 +5273,10 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
                 bot_id=bot_id,
                 thread_id=_thread_id_for_event(incoming_event),
                 reply_to_message_id=reply_to_message_id,
+                reply_in_thread=(
+                    _reply_in_thread_for_event(incoming_event)
+                    or session.reply_in_thread
+                ),
                 predecessor_message_id=feishu_message_id,
                 delivery_key=f"{session_key}:interaction:{interaction_id}",
             )
@@ -5261,6 +5291,10 @@ async def _apply_event_locked(request: web.Request, event: SidecarEvent) -> tupl
             bot_id,
             thread_id=_thread_id_for_event(incoming_event),
             reply_to_message_id=reply_to_message_id,
+            reply_in_thread=(
+                _reply_in_thread_for_event(incoming_event)
+                or session.reply_in_thread
+            ),
             delivery_key=f"{session_key}:interaction:{interaction_id}",
             delivery_kind="interaction",
         )
@@ -5651,6 +5685,7 @@ async def _complete_runtime_interaction_delivery(
         reservation.bot_id,
         thread_id=reservation.thread_id,
         reply_to_message_id=reservation.reply_to_message_id,
+        reply_in_thread=reservation.reply_in_thread,
         delivery_key=reservation.delivery_key,
         delivery_kind="interaction",
     )
@@ -6508,6 +6543,7 @@ async def _send_card(
     bot_id: str | None,
     thread_id: str | None = None,
     reply_to_message_id: str | None = None,
+    reply_in_thread: bool = False,
     delivery_key: str = "",
     delivery_kind: str = "chat",
 ) -> CardDeliveryResult:
@@ -6518,6 +6554,7 @@ async def _send_card(
         bot_id,
         thread_id=thread_id,
         reply_to_message_id=reply_to_message_id,
+        reply_in_thread=reply_in_thread,
         delivery_key=delivery_key,
         delivery_kind=delivery_kind,
     )
@@ -6530,11 +6567,21 @@ async def _send_card_for_app(
     bot_id: str | None,
     thread_id: str | None = None,
     reply_to_message_id: str | None = None,
+    reply_in_thread: bool = False,
     delivery_key: str = "",
     delivery_kind: str = "chat",
 ) -> CardDeliveryResult:
     metrics: SidecarMetrics = app[METRICS_KEY]
     metrics.feishu_send_attempts += 1
+    if reply_in_thread and not reply_to_message_id:
+        result = CardDeliveryResult(
+            message_id=None,
+            outcome="not_sent",
+            error_kind="ReplyThreadAnchorMissing",
+        )
+        metrics.feishu_send_failures += 1
+        _record_send_error(app, result, bot_id=bot_id)
+        return result
     if app[NOOP_MODE_KEY]:
         result = CardDeliveryResult(
             message_id=None,
@@ -6556,22 +6603,24 @@ async def _send_card_for_app(
     try:
         send_delivery = getattr(client, "send_card_delivery", None)
         if callable(send_delivery):
-            send_result = await send_delivery(
-                chat_id,
-                card,
-                thread_id=thread_id,
-                reply_to_message_id=reply_to_message_id,
-                delivery_uuid=delivery_uuid,
-            )
+            send_kwargs: dict[str, Any] = {
+                "thread_id": thread_id,
+                "reply_to_message_id": reply_to_message_id,
+                "delivery_uuid": delivery_uuid,
+            }
+            if reply_in_thread:
+                send_kwargs["reply_in_thread"] = True
+            send_result = await send_delivery(chat_id, card, **send_kwargs)
             message_id = str(getattr(send_result, "message_id", "") or "")
             retry_count = int(getattr(send_result, "retry_count", 0) or 0)
         else:
-            message_id = await client.send_card(
-                chat_id,
-                card,
-                thread_id=thread_id,
-                reply_to_message_id=reply_to_message_id,
-            )
+            send_kwargs = {
+                "thread_id": thread_id,
+                "reply_to_message_id": reply_to_message_id,
+            }
+            if reply_in_thread:
+                send_kwargs["reply_in_thread"] = True
+            message_id = await client.send_card(chat_id, card, **send_kwargs)
             retry_count = 0
         if not isinstance(message_id, str) or not message_id:
             raise FeishuAPIError(

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -5552,12 +5552,13 @@ async def _maybe_send_completion_notify(
         f"✅ 任务已完成{suffix}"
     )
     try:
-        await send_text(
-            session.chat_id,
-            text,
-            thread_id=_thread_id_for_event(event) or None,
-            reply_to_message_id=session.reply_to_message_id or None,
-        )
+        send_kwargs: dict[str, Any] = {
+            "thread_id": _thread_id_for_event(event) or None,
+            "reply_to_message_id": session.reply_to_message_id or None,
+        }
+        if session.reply_in_thread:
+            send_kwargs["reply_in_thread"] = True
+        await send_text(session.chat_id, text, **send_kwargs)
     except asyncio.CancelledError:
         session.completion_notify_state = "idle"
         raise

--- a/hermes_feishu_card/session.py
+++ b/hermes_feishu_card/session.py
@@ -36,6 +36,14 @@ def _now() -> float:
     return time.time()
 
 
+def _truthy_flag(value: Any) -> bool:
+    if value is True or value == 1:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
+
+
 def _exact_feishu_open_id(value: object) -> str:
     return (
         value
@@ -139,6 +147,7 @@ class CardSession:
     active_interaction: InteractionState | None = None
     delivery_kind: str = "chat"
     reply_to_message_id: str = ""
+    reply_in_thread: bool = False
     sender_open_id: str = ""
     completion_notify_state: str = "idle"
     notice_title: str = ""
@@ -197,6 +206,8 @@ class CardSession:
         if self.status in {"completed", "failed"}:
             return False
         self.last_sequence = max(self.last_sequence, event.sequence)
+        if _truthy_flag(event.data.get("reply_in_thread")):
+            self.reply_in_thread = True
 
         self.display_status = event.display_status
         self.display_status_source = "explicit" if event.display_status else "session"

--- a/tests/integration/test_feishu_client_http.py
+++ b/tests/integration/test_feishu_client_http.py
@@ -208,6 +208,32 @@ async def test_send_text_message_replies_in_thread_when_anchor_present(feishu_ap
     assert "任务已完成" in json.loads(reply_request[2]["content"])["text"]
 
 
+async def test_send_text_message_can_create_thread_without_thread_id(feishu_api):
+    test_client, requests, token_calls = feishu_api
+    client = FeishuClient(
+        FeishuClientConfig(
+            app_id="cli_test",
+            app_secret="s",
+            base_url=str(test_client.make_url("/")),
+        )
+    )
+
+    message_id = await client.send_text_message(
+        "oc_abc",
+        '<at user_id="ou_sender"></at> ✅ 任务已完成',
+        reply_to_message_id="om_user_message",
+        reply_in_thread=True,
+    )
+
+    assert message_id == "om_reply_1"
+    assert token_calls() == 1
+    reply_request = requests[1]
+    assert reply_request[0] == "reply"
+    assert reply_request[1] == "om_user_message"
+    assert reply_request[2]["msg_type"] == "text"
+    assert reply_request[2]["reply_in_thread"] is True
+
+
 @pytest.mark.parametrize("delivery_uuid", ["", "   ", "x" * 51, 123])
 async def test_send_card_delivery_rejects_invalid_uuid(feishu_api, delivery_uuid):
     test_client, _, _ = feishu_api

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -158,6 +158,7 @@ async def test_after_eof_runs_once_on_successful_repeated_write_eof(monkeypatch)
 class FakeFeishuClient:
     def __init__(self):
         self.sent = []
+        self.sent_reply_in_thread = []
         self.updated = []
         self.texts = []
         self.operations = []
@@ -168,12 +169,20 @@ class FakeFeishuClient:
         self.update_error_message = "update unavailable"
         self.update_delay = 0.0
 
-    async def send_card(self, chat_id, card, thread_id=None, reply_to_message_id=None):
+    async def send_card(
+        self,
+        chat_id,
+        card,
+        thread_id=None,
+        reply_to_message_id=None,
+        reply_in_thread=False,
+    ):
         if self.send_delay:
             await asyncio.sleep(self.send_delay)
         if self.fail_send:
             raise RuntimeError("send unavailable")
         self.sent.append((chat_id, card, thread_id, reply_to_message_id))
+        self.sent_reply_in_thread.append(reply_in_thread)
         return f"feishu-message-{len(self.sent)}"
 
     async def update_card_message(self, message_id, card):
@@ -210,12 +219,14 @@ class DialectAwareFeishuClient(FakeFeishuClient):
         card,
         thread_id=None,
         reply_to_message_id=None,
+        reply_in_thread=False,
     ):
         message_id = await super().send_card(
             chat_id,
             card,
             thread_id,
             reply_to_message_id,
+            reply_in_thread,
         )
         self.dialects[message_id] = (
             "v2" if card.get("schema") == "2.0" else "legacy"
@@ -2693,7 +2704,14 @@ async def test_hfc_command_request_returns_before_slow_feishu_send():
             self.started = asyncio.Event()
             self.release = asyncio.Event()
 
-        async def send_card(self, chat_id, card, thread_id=None, reply_to_message_id=None):
+        async def send_card(
+            self,
+            chat_id,
+            card,
+            thread_id=None,
+            reply_to_message_id=None,
+            reply_in_thread=False,
+        ):
             self.started.set()
             await self.release.wait()
             return await super().send_card(
@@ -2701,6 +2719,7 @@ async def test_hfc_command_request_returns_before_slow_feishu_send():
                 card,
                 thread_id=thread_id,
                 reply_to_message_id=reply_to_message_id,
+                reply_in_thread=reply_in_thread,
             )
 
     feishu_client = BlockingFeishuClient()
@@ -7575,6 +7594,44 @@ async def test_v4_interaction_restores_cached_preview_on_stable_v2_card(client):
     assert feishu_client.updated[-1][0] == "feishu-message-1"
 
 
+async def test_interaction_promotion_preserves_session_thread_placement(client):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {
+                "reply_in_thread": True,
+                "reply_to_message_id": "om_explicit_anchor",
+            },
+            message_id="om_runtime_identity",
+            turn_id="turn-placement",
+        ),
+    )
+    requested = await test_client.post(
+        "/events",
+        json=event_payload(
+            "interaction.requested",
+            1,
+            {
+                "interaction_id": "approval-session-placement",
+                "kind": "approval",
+                "prompt": "是否继续？",
+                "options": [{"label": "继续", "value": "yes"}],
+            },
+            message_id="om_interaction_identity",
+            turn_id="turn-placement",
+        ),
+    )
+
+    assert started.status == 200
+    assert requested.status == 200
+    assert feishu_client.sent_reply_in_thread == [True, True]
+    assert feishu_client.sent[-1][3] == "om_explicit_anchor"
+
+
 async def test_interaction_promotion_finalizes_predecessor_snapshot(client):
     test_client, feishu_client = client
 
@@ -8078,6 +8135,53 @@ async def test_message_started_sends_card_as_thread_reply(client):
     assert feishu_client.sent[0][0] == "oc_abc"
     assert feishu_client.sent[0][2] == "omt_thread"
     assert feishu_client.sent[0][3] == "om_user_message"
+    assert feishu_client.sent_reply_in_thread == [False]
+
+
+async def test_message_started_can_create_thread_from_reply_in_thread_flag(client):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {
+                "reply_in_thread": True,
+                "reply_to_message_id": "om_explicit_anchor",
+            },
+            conversation_id="conversation-1",
+            message_id="om_runtime_identity",
+        ),
+    )
+
+    assert started.status == 200
+    assert await started.json() == DELIVERED_RESPONSE
+    assert len(feishu_client.sent) == 1
+    assert feishu_client.sent[0][0] == "oc_abc"
+    assert feishu_client.sent[0][2] is None
+    assert feishu_client.sent[0][3] == "om_explicit_anchor"
+    assert feishu_client.sent_reply_in_thread == [True]
+
+
+async def test_message_started_does_not_fall_back_to_top_level_without_thread_anchor(
+    client,
+):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_in_thread": True},
+            conversation_id="conversation-1",
+            message_id="runtime-identity-without-feishu-anchor",
+        ),
+    )
+
+    assert started.status == 502
+    assert len(feishu_client.sent) == 0
 
 
 async def test_message_started_uses_user_message_as_normal_chat_reply_anchor(client):
@@ -8702,6 +8806,10 @@ async def test_runtime_interaction_keeps_v2_owner_and_never_patches_legacy_card(
             json=event_payload(
                 "message.started",
                 0,
+                {
+                    "reply_in_thread": True,
+                    "reply_to_message_id": "om_user_message",
+                },
                 turn_id="turn-runtime",
                 created_at=time.time(),
             ),
@@ -8717,6 +8825,7 @@ async def test_runtime_interaction_keeps_v2_owner_and_never_patches_legacy_card(
             "feishu-message-1": "v2",
             "feishu-message-2": "legacy",
         }
+        assert feishu_client.sent_reply_in_thread == [True, True]
         action_value = interaction_buttons(feishu_client.sent[-1][1])[0]["value"]
 
         callback = await test_client.post(
@@ -9167,7 +9276,17 @@ async def test_runtime_interaction_concurrent_same_and_conflicting_actions_compl
 async def test_repeated_interactions_keep_one_v2_owner_and_fresh_legacy_cards(client):
     test_client, feishu_client = client
 
-    await test_client.post("/events", json=event_payload("message.started", 0))
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {
+                "reply_in_thread": True,
+                "reply_to_message_id": "om_user_message",
+            },
+        ),
+    )
     for sequence, interaction_id in ((1, "choice-1"), (2, "choice-2")):
         requested = await test_client.post(
             "/events",
@@ -9191,6 +9310,7 @@ async def test_repeated_interactions_keep_one_v2_owner_and_fresh_legacy_cards(cl
         assert interaction_buttons(newest_card)
 
     assert feishu_client.sent[1][1] != feishu_client.sent[2][1]
+    assert feishu_client.sent_reply_in_thread == [True, True, True]
     snapshots = [
         card
         for message_id, card in feishu_client.updated
@@ -9404,12 +9524,25 @@ async def test_interaction_promotion_failure_restores_session_for_retry(client):
         },
     )
 
-    await test_client.post("/events", json=event_payload("message.started", 0))
+    await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {
+                "reply_in_thread": True,
+                "reply_to_message_id": "om_user_message",
+            },
+        ),
+    )
     feishu_client.fail_send = True
     failed = await test_client.post("/events", json=payload)
 
     assert failed.status == 502
     assert len(feishu_client.sent) == 1
+    assert test_client.app[sidecar_server.SESSIONS_KEY][
+        "hermes-message-1"
+    ].reply_in_thread is True
 
     feishu_client.fail_send = False
     retried = await test_client.post("/events", json=payload)
@@ -9417,6 +9550,7 @@ async def test_interaction_promotion_failure_restores_session_for_retry(client):
     assert retried.status == 200
     assert (await retried.json())["applied"] is True
     assert len(feishu_client.sent) == 2
+    assert feishu_client.sent_reply_in_thread == [True, True]
 
 
 def test_interaction_operator_name_never_falls_back_to_feishu_ids():

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -161,6 +161,7 @@ class FakeFeishuClient:
         self.sent_reply_in_thread = []
         self.updated = []
         self.texts = []
+        self.texts_reply_in_thread = []
         self.operations = []
         self.fail_send = False
         self.fail_text = False
@@ -200,10 +201,12 @@ class FakeFeishuClient:
         text,
         thread_id=None,
         reply_to_message_id=None,
+        reply_in_thread=False,
     ):
         if self.fail_text:
             raise RuntimeError("text send unavailable")
         self.texts.append((chat_id, text, thread_id, reply_to_message_id))
+        self.texts_reply_in_thread.append(reply_in_thread)
         self.operations.append("text")
         return f"feishu-text-{len(self.texts)}"
 
@@ -7890,6 +7893,58 @@ async def test_completion_notify_updates_card_then_mentions_once_when_enabled(
         ]
         session = app[SESSIONS_KEY]["hermes-message-1"]
         assert session.completion_notify_state == "sent"
+    finally:
+        await test_client.close()
+
+
+async def test_completion_notify_preserves_reply_in_thread_without_thread_id(
+    tmp_path,
+):
+    feishu_client = FakeFeishuClient()
+    app = create_app(
+        feishu_client,
+        card_config={"completion_notify": {"enabled": True}},
+        native_handoff_store=NativeHandoffStore(tmp_path / "handoff-state"),
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        started = await test_client.post(
+            "/events",
+            json=event_payload(
+                "message.started",
+                0,
+                {
+                    "sender_open_id": "ou_sender-01",
+                    "reply_in_thread": True,
+                    "reply_to_message_id": "om_user_message",
+                },
+            ),
+        )
+        completed = await test_client.post(
+            "/events",
+            json=event_payload(
+                "message.completed",
+                1,
+                {
+                    "answer": "done",
+                    "sender_open_id": "ou_sender-01",
+                },
+            ),
+        )
+
+        assert started.status == 200
+        assert completed.status == 200
+        assert feishu_client.texts == [
+            (
+                "oc_abc",
+                '<at user_id="ou_sender-01"></at> ✅ 任务已完成',
+                None,
+                "om_user_message",
+            )
+        ]
+        assert feishu_client.texts_reply_in_thread == [True]
     finally:
         await test_client.close()
 

--- a/tests/unit/test_feishu_client.py
+++ b/tests/unit/test_feishu_client.py
@@ -147,6 +147,69 @@ def test_build_message_payload_keeps_chat_id_for_thread_reply_anchor():
     assert json.loads(payload["content"]) == card
 
 
+@pytest.mark.asyncio
+async def test_send_card_uses_reply_api_for_reply_in_thread_without_thread_id(monkeypatch):
+    cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
+    client = FeishuClient(cfg)
+    card = {"schema": "2.0", "header": {"title": "hello"}}
+    calls = []
+
+    async def fake_token():
+        return "tenant-token"
+
+    async def fake_request(method, path, *, token=None, params=None, json_body=None):
+        calls.append(
+            {
+                "method": method,
+                "path": path,
+                "token": token,
+                "params": params,
+                "json_body": json_body,
+            }
+        )
+        return {"code": 0, "data": {"message_id": "om_card"}}
+
+    monkeypatch.setattr(client, "_tenant_token", fake_token)
+    monkeypatch.setattr(client, "_request_json", fake_request)
+
+    message_id = await client.send_card(
+        "oc_abc",
+        card,
+        reply_to_message_id="om_user_message",
+        reply_in_thread=True,
+    )
+
+    assert message_id == "om_card"
+    assert calls == [
+        {
+            "method": "POST",
+            "path": "/im/v1/messages/om_user_message/reply",
+            "token": "tenant-token",
+            "params": None,
+            "json_body": {
+                "msg_type": "interactive",
+                "content": json.dumps(card, ensure_ascii=False),
+                "reply_in_thread": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_card_rejects_reply_in_thread_without_reply_anchor(monkeypatch):
+    cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
+    client = FeishuClient(cfg)
+    card = {"schema": "2.0", "header": {"title": "hello"}}
+
+    async def unexpected_token():
+        raise AssertionError("token lookup must not run without a reply anchor")
+
+    monkeypatch.setattr(client, "_tenant_token", unexpected_token)
+
+    with pytest.raises(ValueError, match="reply_to_message_id"):
+        await client.send_card("oc_abc", card, reply_in_thread=True)
+
+
 def test_build_message_payload_preserves_non_ascii_content():
     cfg = FeishuClientConfig(app_id="cli_a", app_secret="sec")
     client = FeishuClient(cfg)

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -1535,6 +1535,28 @@ def test_build_stream_event_carries_topic_reply_anchor_from_source_message_id():
     assert payload["data"]["reply_to_message_id"] == "om_topic_user"
 
 
+def test_build_started_event_carries_reply_in_thread_anchor_from_source():
+    class ThreadReplySourceObject:
+        platform = "feishu"
+        chat_id = "oc_source"
+        reply_in_thread = True
+        reply_thread_anchor_message_id = "om_trigger"
+
+    payload = hook_runtime.build_event(
+        "message.started",
+        {
+            "source": ThreadReplySourceObject(),
+            "session_id": "agent:main:feishu:group:oc_source:u_user",
+            "message_id": "om_runtime_identity",
+        },
+    )
+
+    assert payload["chat_id"] == "oc_source"
+    assert payload["thread_id"] == ""
+    assert payload["data"]["reply_in_thread"] is True
+    assert payload["data"]["reply_to_message_id"] == "om_trigger"
+
+
 def test_build_tool_event_carries_arguments_duration_and_error():
     payload = hook_runtime.build_event(
         "tool.updated",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -72,6 +72,35 @@ def test_started_message_uses_feishu_message_id_as_native_reply_anchor():
     assert session.reply_to_message_id == "om_user_message"
 
 
+def test_reply_in_thread_placement_is_sticky_within_session():
+    session = CardSession(
+        conversation_id="chat-1", message_id="om_user_message", chat_id="oc_abc"
+    )
+
+    assert session.apply(
+        event(
+            "message.started",
+            0,
+            {"reply_in_thread": "true"},
+            message_id="om_user_message",
+        )
+    )
+    assert session.apply(
+        event(
+            "interaction.requested",
+            1,
+            {
+                "interaction_id": "placement-choice",
+                "prompt": "是否继续？",
+                "options": [{"label": "继续", "value": "yes"}],
+            },
+            message_id="om_user_message",
+        )
+    )
+
+    assert session.reply_in_thread is True
+
+
 @pytest.mark.parametrize(
     ("sender_open_id", "expected"),
     (


### PR DESCRIPTION
## Summary

- preserve an explicit Feishu `reply_in_thread` intent when Hermes has a reply anchor but no concrete `thread_id` yet
- keep that placement sticky for the current `CardSession`, including repeated approval/clarify cards and runtime-admission delivery reservations
- keep enabled completion-notification text replies in the same newly created thread
- send the initial card through Feishu's reply API with `reply_in_thread=true` without changing v4.3.2's stable schema 2.0 stream owner / legacy interaction-card rails
- document the event contract and maintenance invariant

Follow-up to #61 and #63.

## Root cause

Hermes can expose `reply_in_thread=true` and the triggering message id before Feishu provides a concrete `thread_id`. The existing delivery path inferred `reply_in_thread` only from a non-empty `thread_id`, so the first card could fall back to the group top level. Even when the first event carried the placement intent, later interaction events did not repeat it, and the deferred runtime-admission reservation did not retain it.

## Changes

### Gateway hook and event contract

- extract `reply_in_thread` from Hermes locals/source/message/event data
- retain a real explicit reply anchor when the flag is set before `thread_id` exists, even when the current event has a different internal message identity

### Sidecar session and delivery

- persist the placement flag in `CardSession`
- forward it through initial card creation, ordinary/repeated interaction sends, retry rollback, and `RuntimeInteractionDeliveryReservation`
- forward the sticky flag through completion-notification text delivery while omitting the new keyword on the default false path
- prefer the sticky explicit anchor over later event identities and refuse a missing-anchor request instead of creating a top-level fallback card
- pass the optional keyword only when true so existing compatible clients remain callable on the default path

### Feishu client

- add the optional flag after the existing arguments to preserve positional compatibility
- map a concrete `thread_id` or explicit flag to `/im/v1/messages/{message_id}/reply` with `reply_in_thread=true`

## TDD / Verification

RED was observed before implementation for:

- Feishu reply API delivery without a pre-existing `thread_id`
- Gateway extraction of `reply_in_thread` plus the triggering message anchor
- sticky session placement across a later interaction event
- initial sidecar delivery in a newly created thread
- ordinary interaction promotion retaining session placement
- runtime-admission interaction delivery retaining reservation placement
- explicit reply anchors remaining authoritative when event identities differ
- missing-anchor requests failing before token lookup or top-level delivery
- enabled completion notification with an anchor, `reply_in_thread=true`, and no concrete `thread_id`

Verification:

- direct reply/thread regressions: `10 passed`
- focused hook/client/session/runner/server/docs suites, including Feishu HTTP client coverage: `1118 passed`
- review follow-up completion-notify regressions: `2 passed`; focused client/server suites: `390 passed`
- full isolated suite excluding the separately isolated native-capability file: `3233 passed, 5 skipped`
- isolated native-capability suite: `29 passed`
- `git diff --check`: passed
- Python compile check for all changed runtime modules: passed
- added-line security scan: no hardcoded secret, shell injection, eval/exec, or unsafe pickle findings

## Compatibility and scope

- preserves v4.3.2's schema 2.0 streaming owner and legacy callback-card rail
- does not change interaction tokens, callback validation, PATCH ownership, delivery UUID semantics, package metadata, installer recovery, or release versioning
- does not include local deployment automation or unrelated compatibility patches

## Real Feishu status

No new controlled real-client smoke was run for this PR. The automated coverage exercises the Feishu reply request body, first delivery, repeated interactions, retry rollback, and runtime-admission path; a real Feishu topic/thread smoke remains useful reviewer acceptance evidence.
