### PR TITLE
fix(feishu): fall back unanchored topic creates to chat

### DIFF
--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -146,11 +146,11 @@ class FeishuClient:
         if not isinstance(card, dict):
             raise TypeError("card must be a dict")
 
-        receive_id = chat_id
-        if thread_id and not reply_to_message_id:
-            receive_id = thread_id
         return {
-            "receive_id": receive_id,
+            # Feishu's create API does not accept thread_id as a receive target.
+            # Topic placement requires the reply API and a message anchor; when
+            # no anchor exists, deliver to the parent chat instead.
+            "receive_id": chat_id,
             "msg_type": "interactive",
             "content": serialize_card_for_delivery(card),
         }
@@ -221,12 +221,11 @@ class FeishuClient:
                         },
                     )
                 else:
-                    receive_id_type = "thread_id" if thread_id else "chat_id"
                     body = await self._request_json(
                         "POST",
                         "/im/v1/messages",
                         token=token,
-                        params={"receive_id_type": receive_id_type},
+                        params={"receive_id_type": "chat_id"},
                         json_body=payload,
                     )
                 data = body.get("data")

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -5754,17 +5754,26 @@ async def _hfc_send_raw_message_with_native_handoff_route(self: Any, **kwargs: A
     original = getattr(type(self), "_hfc_original_send_raw_message", None)
     if not callable(original):
         raise RuntimeError("original Feishu raw send unavailable")
-    if _HFC_NATIVE_HANDOFF_SEND_TRACKER.get() is None:
-        return await original(self, **kwargs)
     metadata = kwargs.get("metadata")
     thread_id = _metadata_thread_id(metadata if isinstance(metadata, dict) else None)
+    send_kwargs = kwargs
+    if thread_id and not kwargs.get("reply_to"):
+        # Feishu's create API accepts chat_id but not thread_id. Preserve the
+        # logical topic binding for native-handoff identity/UUID derivation,
+        # while making the actual unanchored create fall back to the parent chat.
+        send_kwargs = dict(kwargs)
+        send_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        send_metadata.pop("thread_id", None)
+        send_kwargs["metadata"] = send_metadata
+    if _HFC_NATIVE_HANDOFF_SEND_TRACKER.get() is None:
+        return await original(self, **send_kwargs)
     if thread_id:
         route = "thread-reply" if kwargs.get("reply_to") else "thread-create"
     else:
         route = "reply" if kwargs.get("reply_to") else "create"
     token = _HFC_NATIVE_HANDOFF_ROUTE.set(route)
     try:
-        return await original(self, **kwargs)
+        return await original(self, **send_kwargs)
     finally:
         _HFC_NATIVE_HANDOFF_ROUTE.reset(token)
 

--- a/tests/integration/test_feishu_client_http.py
+++ b/tests/integration/test_feishu_client_http.py
@@ -154,6 +154,33 @@ async def test_send_card_replies_in_thread_when_reply_anchor_present(feishu_api)
     assert reply_request[3]["Authorization"] == "Bearer tenant-token-1"
 
 
+async def test_send_card_without_reply_anchor_falls_back_to_chat_create(feishu_api):
+    test_client, requests, token_calls = feishu_api
+    client = FeishuClient(
+        FeishuClientConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            base_url=str(test_client.make_url("/")),
+        )
+    )
+
+    result = await client.send_card_delivery(
+        "oc_abc",
+        {"schema": "2.0", "body": "topic notice"},
+        thread_id="omt_thread",
+        delivery_uuid="hfc_" + "a" * 40,
+    )
+
+    assert result.message_id == "om_message_1"
+    assert result.retry_count == 0
+    assert token_calls() == 1
+    send_request = requests[1]
+    assert send_request[0] == "send"
+    assert send_request[1] == "chat_id"
+    assert send_request[2]["receive_id"] == "oc_abc"
+    assert send_request[2]["uuid"] == "hfc_" + "a" * 40
+
+
 async def test_send_text_message_posts_text_with_mention(feishu_api):
     test_client, requests, token_calls = feishu_api
     client = FeishuClient(

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -9006,6 +9006,37 @@ class _NativeAckRaisingAdapter(_NativeAckAdapter):
         raise RuntimeError("adapter escaped")
 
 
+@pytest.mark.asyncio
+async def test_adapter_thread_create_without_reply_anchor_falls_back_to_chat_create():
+    adapter = _NativeAckAdapter()
+    runner = SimpleNamespace(adapters={"feishu": adapter})
+    assert hook_runtime.install_feishu_command_card_adapter_methods(runner)
+
+    result = await adapter.send(
+        "oc_native",
+        "topic notice",
+        metadata={"thread_id": "omt_topic", "trace": "preserved"},
+    )
+
+    assert result.success is True
+    assert adapter.raw_calls == [
+        ("{\"text\": \"topic\"}", "text", "create", "random-create"),
+        ("{\"text\": \" noti\"}", "text", "create", "random-create"),
+        ("{\"text\": \"ce\"}", "text", "create", "random-create"),
+    ]
+
+    adapter.raw_calls.clear()
+    reply_result = await adapter.send(
+        "oc_native",
+        "reply",
+        reply_to="om_parent",
+        metadata={"thread_id": "omt_topic"},
+    )
+
+    assert reply_result.success is True
+    assert adapter.raw_calls[-1][2] == "thread"
+
+
 def _install_native_ack_context(
     adapter,
     content,
@@ -9078,6 +9109,33 @@ def _install_native_ack_context(
     )
     assert registered is (descriptor["expires_at"] > time.time())
     return descriptor
+
+
+@pytest.mark.asyncio
+async def test_native_handoff_thread_create_uses_chat_fallback_with_stable_uuid():
+    content = "same"
+    adapter = _NativeAckAdapter()
+    _install_native_ack_context(adapter, content, thread_id="omt_topic")
+
+    first = await adapter.send(
+        "oc_native",
+        content,
+        metadata={"thread_id": "omt_topic"},
+    )
+    first_call = adapter.raw_calls[-1]
+    adapter.raw_calls.clear()
+    second = await adapter.send(
+        "oc_native",
+        content,
+        metadata={"thread_id": "omt_topic"},
+    )
+    second_call = adapter.raw_calls[-1]
+
+    assert first.success is True
+    assert second.success is True
+    assert first_call[2] == "create"
+    assert first_call[3] != "random-create"
+    assert first_call[3] == second_call[3]
 
 
 def test_exact_native_handoff_rejects_old_sidecar_v1_descriptor():
@@ -9398,7 +9456,7 @@ async def test_native_handoff_uses_canonical_create_routes_and_format_scoped_uui
     thread_uuid = thread_adapter.raw_calls[-1][3]
 
     assert create_uuid == canonical_create_uuid
-    assert thread_adapter.raw_calls[-1][2] == "thread"
+    assert thread_adapter.raw_calls[-1][2] == "create"
     assert create_uuid != thread_uuid
 
     fallback = _NativeAckPostFallbackAdapter(


### PR DESCRIPTION
## Summary

- stop passing receive_id_type=thread_id to the Feishu create-message API;
- keep anchored topic delivery on the reply API with reply_in_thread;
- make unanchored Hermes adapter topic sends fall back to parent chat create while preserving logical native-handoff identity and stable UUID retries;
- add HTTP and runtime regressions for chat fallback, anchored replies, and native-handoff stability.

## Verification

- Feishu client/runtime focused unit: 559 passed;
- Feishu HTTP/server integration: 359 passed;
- disposable normal-wheel full suite: 3283 passed, 5 skipped in 574.09s;
- built sdist/wheel; package/distribution 4.3.5 imported from isolated site-packages with one Hermes plugin entrypoint and 24 provenance slices;
- git diff --check passed.

## Scope

No real Feishu message was sent by the maintainer in this run. The issue reporter supplied a direct API reproduction of 99992402 and successful chat_id/reply controls. Warning throttling is intentionally not included in this protocol fix.

Closes #237.