### PR TITLE
fix: accept session-scoped delivery filter anchors

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -1783,13 +1783,7 @@ def _find_exact_base_patch_locations(tree, lines):
     )
     filter_media = _unique_exact_base_node(
         method_nodes,
-        lambda node: _is_exact_assignment_call(
-            node,
-            targets=("media_files",),
-            owner="self",
-            function="filter_media_delivery_paths",
-            args=("media_files",),
-        ),
+        _is_exact_media_filter_assignment,
     )
     extract_images = _unique_exact_base_node(
         method_nodes,
@@ -1821,13 +1815,7 @@ def _find_exact_base_patch_locations(tree, lines):
     )
     filter_local = _unique_exact_base_node(
         method_nodes,
-        lambda node: _is_exact_assignment_call(
-            node,
-            targets=("local_files",),
-            owner="self",
-            function="filter_local_delivery_paths",
-            args=("local_files",),
-        ),
+        _is_exact_local_filter_assignment,
     )
     recovered = _unique_exact_base_node(
         method_nodes,
@@ -2075,6 +2063,50 @@ def _call_function(call):
     if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
         return func.value.id, func.attr
     return None, None
+
+
+def _is_exact_delivery_filter_assignment(
+    node,
+    *,
+    target: str,
+    function: str,
+) -> bool:
+    if _assignment_target_names(node) != (target,):
+        return False
+    call = _assignment_value(node)
+    if not isinstance(call, ast.Call):
+        return False
+    owner, actual_function = _call_function(call)
+    if (
+        owner != "self"
+        or actual_function != function
+        or len(call.args) != 1
+        or not _same_expression(call.args[0], target)
+    ):
+        return False
+    if not call.keywords:
+        return True
+    return (
+        len(call.keywords) == 1
+        and call.keywords[0].arg == "session_key"
+        and _same_expression(call.keywords[0].value, "session_key")
+    )
+
+
+def _is_exact_media_filter_assignment(node) -> bool:
+    return _is_exact_delivery_filter_assignment(
+        node,
+        target="media_files",
+        function="filter_media_delivery_paths",
+    )
+
+
+def _is_exact_local_filter_assignment(node) -> bool:
+    return _is_exact_delivery_filter_assignment(
+        node,
+        target="local_files",
+        function="filter_local_delivery_paths",
+    )
 
 
 def _is_exact_assignment_call(node, *, targets, owner, function, args):

--- a/tests/integration/test_cli_install.py
+++ b/tests/integration/test_cli_install.py
@@ -190,6 +190,31 @@ def make_exact_020_hermes(tmp_path):
     return hermes_dir
 
 
+def make_exact_2026_8_25_hermes(tmp_path):
+    hermes_dir = copy_hermes(tmp_path)
+    (hermes_dir / "VERSION").write_text("v2026.8.25\n", encoding="utf-8")
+    source = EXACT_BASE_V020_FIXTURE.read_text(encoding="utf-8")
+    source = source.replace(
+        "media_files = self.filter_media_delivery_paths(media_files)",
+        (
+            "media_files = self.filter_media_delivery_paths("
+            "media_files, session_key=session_key)"
+        ),
+        1,
+    ).replace(
+        "local_files = self.filter_local_delivery_paths(local_files)",
+        (
+            "local_files = self.filter_local_delivery_paths("
+            "local_files, session_key=session_key)"
+        ),
+        1,
+    )
+    target = base_path(hermes_dir)
+    target.parent.mkdir(parents=True)
+    target.write_text(source, encoding="utf-8")
+    return hermes_dir
+
+
 def cron_path(hermes_dir):
     return hermes_dir / "cron" / "scheduler.py"
 
@@ -1645,6 +1670,32 @@ def test_install_and_restore_020_manages_awaited_ledger_contract(tmp_path):
 
     assert cli.main(["restore", "--hermes-dir", str(hermes_dir), "--yes"]) == 0
     assert run_py(hermes_dir).read_bytes() == run_original
+    assert base_path(hermes_dir).read_bytes() == base_original
+
+
+def test_install_accepts_2026_8_25_session_scoped_delivery_filters(
+    tmp_path, capsys
+):
+    hermes_dir = make_exact_2026_8_25_hermes(tmp_path)
+    base_original = base_path(hermes_dir).read_bytes()
+
+    assert cli.main(["install", "--hermes-dir", str(hermes_dir), "--yes"]) == 0
+    patched = base_path(hermes_dir).read_text(encoding="utf-8")
+    assert patcher.EXACT_BASE_NO_TEXT_PATCH_BEGIN in patched
+    assert patcher.EXACT_BASE_FINAL_DELIVERY_PATCH_BEGIN in patched
+
+    assert cli.main(
+        [
+            "doctor",
+            "--config",
+            str(hermes_dir / "config.yaml"),
+            "--hermes-dir",
+            str(hermes_dir),
+        ]
+    ) == 0
+    assert "exact_delivery_contract: ready" in capsys.readouterr().out
+
+    assert cli.main(["restore", "--hermes-dir", str(hermes_dir), "--yes"]) == 0
     assert base_path(hermes_dir).read_bytes() == base_original
 
 

--- a/tests/unit/test_installer_detection.py
+++ b/tests/unit/test_installer_detection.py
@@ -758,6 +758,36 @@ def test_detect_020_accepts_awaited_to_thread_delivery_contract(tmp_path):
     assert result.capabilities["exact_base_delivery"] is True
 
 
+def test_detect_accepts_session_scoped_delivery_filter_contract(tmp_path):
+    _write_hermes_root(tmp_path, version="v2026.8.25")
+    source = EXACT_BASE_V020_FIXTURE.read_text(encoding="utf-8")
+    source = source.replace(
+        "media_files = self.filter_media_delivery_paths(media_files)",
+        (
+            "media_files = self.filter_media_delivery_paths("
+            "media_files, session_key=session_key)"
+        ),
+        1,
+    ).replace(
+        "local_files = self.filter_local_delivery_paths(local_files)",
+        (
+            "local_files = self.filter_local_delivery_paths("
+            "local_files, session_key=session_key)"
+        ),
+        1,
+    )
+    base_py = tmp_path / "gateway" / "platforms" / "base.py"
+    base_py.parent.mkdir(parents=True, exist_ok=True)
+    base_py.write_text(source, encoding="utf-8")
+
+    result = detect_hermes(tmp_path)
+
+    assert result.supported is True
+    assert result.base_required is True
+    assert result.base_hook_strategy == "exact_base_delivery"
+    assert result.capabilities["exact_base_delivery"] is True
+
+
 def test_detect_source_stripped_exact_ledger_requires_valid_base_contract(tmp_path):
     _write_hermes_root(tmp_path, version=None)
     base_py = _write_exact_base(tmp_path)

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -2164,6 +2164,40 @@ def test_apply_base_patch_accepts_020_awaited_to_thread_ledger_calls():
     assert patcher.remove_base_patch(patched) == source
 
 
+def test_apply_base_patch_accepts_session_scoped_delivery_filters():
+    source = _EXACT_BASE_SOURCE.replace(
+        "media_files = self.filter_media_delivery_paths(media_files)",
+        (
+            "media_files = self.filter_media_delivery_paths("
+            "media_files, session_key=session_key)"
+        ),
+        1,
+    ).replace(
+        "local_files = self.filter_local_delivery_paths(local_files)",
+        (
+            "local_files = self.filter_local_delivery_paths("
+            "local_files, session_key=session_key)"
+        ),
+        1,
+    )
+    media_only_source = _EXACT_BASE_SOURCE.replace(
+        "media_files = self.filter_media_delivery_paths(media_files)",
+        (
+            "media_files = self.filter_media_delivery_paths("
+            "media_files, session_key=session_key)"
+        ),
+        1,
+    )
+
+    for candidate in (media_only_source, source):
+        patched = patcher.apply_base_patch(candidate)
+
+        no_text = patched.index(patcher.EXACT_BASE_NO_TEXT_PATCH_BEGIN)
+        send_guard = patched.index("if text_content and not _tts_caption_delivered:")
+        assert no_text < send_guard
+        assert patcher.remove_base_patch(patched) == candidate
+
+
 def test_apply_base_patch_rejects_unawaited_to_thread_ledger_calls():
     source = EXACT_BASE_V020_FIXTURE.read_text(encoding="utf-8").replace(
         "await asyncio.to_thread(mark_attempting, _obligation_id)",
@@ -2196,6 +2230,20 @@ def test_base_patch_round_trip_is_byte_identical_for_newlines(content):
         _EXACT_BASE_SOURCE.replace(
             "media_files = self.filter_media_delivery_paths(media_files)",
             "media_files = list(media_files)",
+        ),
+        _EXACT_BASE_SOURCE.replace(
+            "media_files = self.filter_media_delivery_paths(media_files)",
+            (
+                "media_files = self.filter_media_delivery_paths("
+                "media_files, session_key=\"different\")"
+            ),
+        ),
+        _EXACT_BASE_SOURCE.replace(
+            "local_files = self.filter_local_delivery_paths(local_files)",
+            (
+                "local_files = self.filter_local_delivery_paths("
+                "local_files, unexpected=session_key)"
+            ),
         ),
         _EXACT_BASE_SOURCE.replace(
             "text_content = _strip_media_directives(text_content).strip()",


### PR DESCRIPTION
## Bug Description

Hermes core commit `82b32f32ef` passes the current session identity into the media delivery path filter:

```python
media_files = self.filter_media_delivery_paths(
    media_files, session_key=session_key
)
```

HFC's exact `BasePlatformAdapter` contract only accepted the previous positional-only call shape, so `apply_base_patch` rejected Hermes v2026.8.25 and doctor reported `exact_delivery_contract: missing_or_unsupported`.

Fixes #240

## Root Cause

The exact AST matcher used the generic no-keyword call validator for both delivery path filters. That validator correctly rejected arbitrary source drift, but it also rejected Hermes' new, intentional `session_key=session_key` keyword.

The same upstream hardening applies to `filter_local_delivery_paths`, so the patch covers both sibling filters while keeping the accepted syntax narrow.

## Fix

- Add a dedicated exact matcher for delivery-filter assignments.
- Continue accepting the legacy call with no keywords.
- Accept only one new keyword with the exact form `session_key=session_key`.
- Reject renamed keywords, different values, extra keywords, and unrelated calls.
- Add patcher, detection, and install/doctor/restore regressions.

## How to Verify

1. Use a Hermes Base fixture whose media and local delivery filters receive `session_key=session_key`.
2. Run HFC install and confirm both exact Base hooks are applied.
3. Run doctor and confirm `exact_delivery_contract: ready`.
4. Restore and confirm `base.py` is byte-identical to the original.

## Test Plan

- [x] Regression tests failed against the pre-fix production code.
- [x] Direct regression and fail-closed matrix: `12 passed`.
- [x] Patcher/detection/install focused suite on Python 3.11: `456 passed, 1 skipped, 3 deselected`.
- [x] Same focused suite on Python 3.12: `456 passed, 1 skipped, 3 deselected`.
- [x] Real Hermes `82b32f32ef` `gateway/platforms/base.py`: patch + exact round-trip passed.
- [x] `git diff --check` passed.
- [x] Independent review found no security or logic blockers.

## Full-suite note

The repository full suite is not clean in this machine environment before or after the patch. It has unrelated fixture/state prerequisites (notably a hard-coded `/private/tmp/hermes-agent-v2026.8.3-v430-audit` source root, nested-venv creation on this Debian image, and state-directory symlink checks). The affected patcher/detection/install matrix above is green on both Python 3.11 and 3.12.

## Risk Assessment

Low — the change only broadens two exact AST anchors to the single upstream keyword form while retaining fail-closed behavior for every other keyword/value/call shape.
