### PR TITLE
fix(feishu): honour proxy environment for remote Feishu endpoints

### DIFF
--- a/hermes_feishu_card/feishu_client.py
+++ b/hermes_feishu_card/feishu_client.py
@@ -6,6 +6,7 @@ import math
 import time
 from dataclasses import dataclass
 from hashlib import sha256
+from ipaddress import ip_address
 from numbers import Real
 from typing import Any, Dict, Literal, Optional, Union
 from urllib.parse import quote, urlparse
@@ -20,6 +21,22 @@ _SEND_MAX_ATTEMPTS = 3
 _SEND_RETRY_DELAYS_SECONDS = (0.4, 1.2)
 _MAX_RETRY_AFTER_SECONDS = 2.0
 _sleep = asyncio.sleep
+
+
+def _should_bypass_proxy(base_url: str) -> bool:
+    host = (urlparse(base_url).hostname or "").strip().lower()
+    if host == "localhost":
+        return True
+    try:
+        address = ip_address(host)
+    except ValueError:
+        return False
+    return (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address.is_unspecified
+    )
 
 
 def _safe_api_code(value: Any) -> int | str | None:
@@ -131,6 +148,11 @@ class FeishuClientConfig:
 class FeishuClient:
     def __init__(self, config: FeishuClientConfig):
         self.config = config
+        # A remote Feishu endpoint may only be reachable through HTTP(S)_PROXY,
+        # which aiohttp ignores unless the session trusts the environment.  A
+        # loopback or intranet endpoint must stay direct, matching how the
+        # sidecar's own urllib callers bypass the proxy.
+        self._trust_env = not _should_bypass_proxy(config.base_url)
         self._tenant_access_token: str | None = None
         self._tenant_access_token_expires_at = 0.0
 
@@ -370,7 +392,9 @@ class FeishuClient:
 
         timeout = aiohttp.ClientTimeout(total=float(self.config.timeout_seconds))
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with aiohttp.ClientSession(
+                timeout=timeout, trust_env=self._trust_env
+            ) as session:
                 async with session.request(
                     method,
                     url,

--- a/tests/unit/test_feishu_client.py
+++ b/tests/unit/test_feishu_client.py
@@ -1,5 +1,6 @@
 import json
 
+import aiohttp
 import pytest
 
 from hermes_feishu_card.card_limits import CardLimitExceeded, serialize_card_json
@@ -262,3 +263,75 @@ async def test_update_rejects_unsafe_card_before_token_or_network():
 
     with pytest.raises(CardLimitExceeded, match="json_bytes"):
         await client.update_card_message("om_test", oversized)
+
+
+async def _captured_session_kwargs(monkeypatch, base_url=None):
+    captured: dict[str, object] = {}
+
+    class _FakeResponse:
+        status = 200
+        headers: dict[str, str] = {}
+
+        async def json(self, content_type=None):
+            return {"code": 0, "data": {}}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    class _FakeSession:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        def request(self, *args, **kwargs):
+            return _FakeResponse()
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _FakeSession)
+    overrides = {"base_url": base_url} if base_url is not None else {}
+    client = FeishuClient(
+        FeishuClientConfig(app_id="cli_a", app_secret="sec", **overrides)
+    )
+
+    await client._request_json("POST", "/im/v1/messages")
+
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_request_json_trusts_proxy_environment_for_remote_endpoint(monkeypatch):
+    """Hosts without direct egress reach open.feishu.cn only via HTTP(S)_PROXY.
+
+    aiohttp ignores the proxy environment unless the session opts in with
+    trust_env, so without it every card delivery times out and the hook reports
+    an unknown outcome.
+    """
+
+    captured = await _captured_session_kwargs(monkeypatch)
+
+    assert captured.get("trust_env") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://127.0.0.1:8080/open-apis",
+        "http://localhost:8080/open-apis",
+        "http://10.1.2.3/open-apis",
+        "http://[::1]:8080/open-apis",
+    ],
+)
+async def test_request_json_bypasses_proxy_for_local_endpoint(monkeypatch, base_url):
+    """A loopback or intranet endpoint must not be routed through the proxy."""
+
+    captured = await _captured_session_kwargs(monkeypatch, base_url=base_url)
+
+    assert captured.get("trust_env") is False


### PR DESCRIPTION
## 问题

在没有直连外网、只能通过 `HTTP_PROXY`/`HTTPS_PROXY` 出网的机器上，sidecar 的每一次飞书 API 调用都会超时，卡片完全发不出去。用户侧的表现是飞书里反复收到：

> ⚠️ 一条运行提示的卡片投递结果无法确认，请稍后查看 /hfc status。

`/hfc status` 里可以看到 100% 的投递失败：

```
feishu_send_attempts: 113
feishu_send_successes: 0
feishu_send_failures: 111
feishu_send_unknown_outcomes: 111
notice_uncertain_warnings: 12
events_applied: 0
events_rejected: 109
```

`diagnostics.last_send_error` 为 `{"outcome": "unknown", "error_kind": "FeishuAPIError"}`。

## 根因

`FeishuClient._request_json()` 用 `aiohttp.ClientSession(timeout=timeout)` 建会话。**aiohttp 默认不读 `HTTP_PROXY`/`HTTPS_PROXY` 环境变量**，必须显式传 `trust_env=True`。因此在这类机器上请求直连 `open.feishu.cn` 并超时，抛出 `outcome="unknown"`，hook 就发出上面那条灰色提示；随后 `server.py` 里 `if not delivery.delivered: metrics.events_rejected += 1` 把后续事件一并拒掉，所以 `events_applied` 恒为 0。

最小复现（在一台需要走代理出网的机器上）：

```python
# trust_env=False -> TimeoutError after 15.9s
# trust_env=True  -> HTTP 200 in 0.2s
async with aiohttp.ClientSession(timeout=timeout, trust_env=trust) as s:
    await s.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", json=payload)
```

## 修复

只对**远端** endpoint 信任代理环境；loopback / 内网 `base_url` 保持直连。

这与仓库现有约定一致 —— `hook_runtime.py`、`runtime_control.py`、`process.py` 里的 urllib 调用方都已经用 `_NO_PROXY_OPENER` 对本地地址绕过代理；`server.py` 的 runtime-interaction 回环回调也显式写了 `trust_env=False`。只有飞书客户端这条真正的出网路径漏了对代理环境的处理。

无条件 `trust_env=True` 是不行的：那会把测试用/自建的 `127.0.0.1` endpoint 也塞进代理（本地验证时确实打挂了 `tests/integration/test_feishu_client_http.py` 的 26 个用例），所以按 host 判断。`trust_env` 同时会遵守 `NO_PROXY`。

## 测试

- 新增 `tests/unit/test_feishu_client.py::test_request_json_trusts_proxy_environment_for_remote_endpoint`
- 新增 `tests/unit/test_feishu_client.py::test_request_json_bypasses_proxy_for_local_endpoint`（参数化覆盖 `127.0.0.1` / `localhost` / `10.x` / `[::1]`）
- `tests/unit/test_feishu_client.py` + `tests/integration/test_feishu_client_http.py`：80 passed
- 全量 `tests/unit`、`tests/integration`：与打补丁前的失败集合完全一致（本机环境相关的既有失败，与本改动无关）

## 线上验证

在出问题的那台机器上装了本补丁并重启 sidecar：用 sidecar 进程自身的环境 + 已安装的客户端代码调用 `tenant_access_token`，0.22s 返回成功（修复前每次都是 30s 超时）。
