### PR TITLE
fix: preserve Feishu topic follow-up cards

### DIFF
--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -9803,6 +9803,8 @@ def _event_data(
                 value = _first_attr_string(local_vars.get("event"), (reply_key,))
             if value:
                 data[reply_key] = value
+        if local_vars.get("redirect_followup") is True:
+            data["redirect_followup"] = True
         return data
     return {}
 

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -9246,6 +9246,11 @@ def build_cron_event(local_vars: dict[str, Any]) -> dict[str, Any] | None:
     origin_platform = str(origin.get("platform") or "").strip().lower()
     origin_chat_id = origin.get("chat_id") if origin_platform == "feishu" else ""
     origin_thread_id = origin.get("thread_id") if origin_platform == "feishu" else ""
+    origin_message_id = (
+        str(origin.get("message_id") or "").strip()
+        if origin_platform == "feishu"
+        else ""
+    )
     chat_id = str(
         resolved_chat_id
         or _deliver_chat_id(job.get("deliver"))
@@ -9288,6 +9293,11 @@ def build_cron_event(local_vars: dict[str, Any]) -> dict[str, Any] | None:
         "data": {
             "answer": content,
             "delivery_kind": "cron",
+            **(
+                {"reply_to_message_id": origin_message_id}
+                if origin_message_id
+                else {}
+            ),
             "profile_id": profile_id,
             "profile_source": profile_source,
             "attachments": attachments,

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -5858,8 +5858,17 @@ async def _hfc_send_raw_message_with_native_handoff_route(self: Any, **kwargs: A
         raise RuntimeError("original Feishu raw send unavailable")
     metadata = kwargs.get("metadata")
     thread_id = _metadata_thread_id(metadata if isinstance(metadata, dict) else None)
+    reply_to = str(kwargs.get("reply_to") or "").strip()
+    if not reply_to and thread_id:
+        metadata_reply_to = _metadata_reply_to(
+            metadata if isinstance(metadata, dict) else None
+        )
+        if metadata_reply_to:
+            kwargs = dict(kwargs)
+            kwargs["reply_to"] = metadata_reply_to
+            reply_to = metadata_reply_to
     send_kwargs = kwargs
-    if thread_id and not kwargs.get("reply_to"):
+    if thread_id and not reply_to:
         # Feishu's create API accepts chat_id but not thread_id. Preserve the
         # logical topic binding for native-handoff identity/UUID derivation,
         # while making the actual unanchored create fall back to the parent chat.
@@ -5870,9 +5879,9 @@ async def _hfc_send_raw_message_with_native_handoff_route(self: Any, **kwargs: A
     if _HFC_NATIVE_HANDOFF_SEND_TRACKER.get() is None:
         return await original(self, **send_kwargs)
     if thread_id:
-        route = "thread-reply" if kwargs.get("reply_to") else "thread-create"
+        route = "thread-reply" if reply_to else "thread-create"
     else:
-        route = "reply" if kwargs.get("reply_to") else "create"
+        route = "reply" if reply_to else "create"
     token = _HFC_NATIVE_HANDOFF_ROUTE.set(route)
     try:
         return await original(self, **send_kwargs)

--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -22,6 +22,10 @@ COMPLETE_PATCH_BEGIN = "# HERMES_FEISHU_CARD_COMPLETE_PATCH_BEGIN"
 COMPLETE_PATCH_END = "# HERMES_FEISHU_CARD_COMPLETE_PATCH_END"
 QUEUED_COMPLETE_PATCH_BEGIN = "# HERMES_FEISHU_CARD_QUEUED_COMPLETE_PATCH_BEGIN"
 QUEUED_COMPLETE_PATCH_END = "# HERMES_FEISHU_CARD_QUEUED_COMPLETE_PATCH_END"
+QUEUED_FOLLOWUP_PATCH_BEGIN = "# HERMES_FEISHU_CARD_QUEUED_FOLLOWUP_PATCH_BEGIN"
+QUEUED_FOLLOWUP_PATCH_END = "# HERMES_FEISHU_CARD_QUEUED_FOLLOWUP_PATCH_END"
+REDIRECT_PATCH_BEGIN = "# HERMES_FEISHU_CARD_REDIRECT_PATCH_BEGIN"
+REDIRECT_PATCH_END = "# HERMES_FEISHU_CARD_REDIRECT_PATCH_END"
 TOOL_PATCH_BEGIN = "# HERMES_FEISHU_CARD_TOOL_PATCH_BEGIN"
 TOOL_PATCH_END = "# HERMES_FEISHU_CARD_TOOL_PATCH_END"
 STABLE_TOOL_PATCH_BEGIN = "# HERMES_FEISHU_CARD_STABLE_TOOL_PATCH_BEGIN"
@@ -149,7 +153,9 @@ def apply_patch(
     content = _apply_start_patch(content, strategy=strategy)
     content = _apply_complete_patch(content, strategy=strategy)
     content = _apply_queued_complete_patch(content)
+    content = _apply_queued_followup_patch(content)
     if strategy == "gateway_run_013_plus":
+        content = _apply_redirect_patch(content)
         content = _apply_cron_patch(content)
         content = _apply_command_card_startup_patch(content)
         content = _apply_native_redelivery_patch(content)
@@ -426,6 +432,90 @@ def _apply_queued_complete_patch(content: str) -> str:
         indent = _leading_whitespace(_strip_line_ending(line))
         newline = _line_ending(line) or _detect_newline(content)
         hook = _render_queued_complete_hook_block(indent, newline)
+        return "".join(lines[:index] + hook + lines[index:])
+
+    current_target = "if _intentional_silence:"
+    for index, line in enumerate(lines):
+        if _strip_line_ending(line).strip() != current_target:
+            continue
+        lookback = lines[max(0, index - 48) : index]
+        if not any("first_response = _delivery_result.get(" in item for item in lookback):
+            continue
+        if not any("_delivery_result = response if isinstance(response, dict)" in item for item in lookback):
+            continue
+        indent = _leading_whitespace(_strip_line_ending(line))
+        newline = _line_ending(line) or _detect_newline(content)
+        hook = _render_queued_complete_hook_block(indent, newline)
+        return "".join(lines[:index] + hook + lines[index:])
+    return content
+
+
+def _apply_queued_followup_patch(content: str) -> str:
+    owned_block = _find_simple_marker_block(
+        content,
+        QUEUED_FOLLOWUP_PATCH_BEGIN,
+        QUEUED_FOLLOWUP_PATCH_END,
+        "queued follow-up patch markers",
+    )
+    if owned_block is not None:
+        lines = content.splitlines(keepends=True)
+        begin_index, end_index = owned_block
+        indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
+        newline = _line_ending(lines[begin_index]) or _detect_newline(content)
+        expected = _render_queued_followup_hook_block(indent, newline)
+        if lines[begin_index : end_index + 1] == expected:
+            return content
+        return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
+
+    tree = _parse_content(content)
+    target = None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target_node = node.targets[0]
+        if isinstance(target_node, ast.Name) and target_node.id == "followup_result":
+            target = node
+            break
+    if target is None or target.lineno is None or target.end_lineno is None:
+        return content
+    lines = content.splitlines(keepends=True)
+    insert_at = target.lineno - 1
+    indent = _leading_whitespace(_strip_line_ending(lines[insert_at]))
+    newline = _line_ending(lines[insert_at]) or _detect_newline(content)
+    hook = _render_queued_followup_hook_block(indent, newline)
+    return "".join(lines[:insert_at] + hook + lines[insert_at:])
+
+
+def _apply_redirect_patch(content: str) -> str:
+    owned_block = _find_simple_marker_block(
+        content,
+        REDIRECT_PATCH_BEGIN,
+        REDIRECT_PATCH_END,
+        "redirect patch markers",
+    )
+    if owned_block is not None:
+        lines = content.splitlines(keepends=True)
+        begin_index, end_index = owned_block
+        indent = _leading_whitespace(_strip_line_ending(lines[begin_index]))
+        newline = _line_ending(lines[begin_index]) or _detect_newline(content)
+        expected = _render_redirect_hook_block(indent, newline)
+        if lines[begin_index : end_index + 1] == expected:
+            return content
+        return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
+
+    lines = content.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        stripped = _strip_line_ending(line).strip()
+        if stripped not in {"if not steered and not redirected:", "if not redirected:"}:
+            continue
+        lookback = lines[max(0, index - 80) : index]
+        if not any("running_agent.redirect(" in item for item in lookback):
+            continue
+        if not any("redirected = False" in item for item in lookback):
+            continue
+        indent = _leading_whitespace(_strip_line_ending(line))
+        newline = _line_ending(line) or _detect_newline(content)
+        hook = _render_redirect_hook_block(indent, newline)
         return "".join(lines[:index] + hook + lines[index:])
     return content
 
@@ -731,6 +821,20 @@ def remove_patch(content: str) -> str:
         STATUS_PATCH_END,
         _render_status_hook_block,
         "status callback patch markers",
+    )
+    content = _remove_simple_owned_patch(
+        content,
+        QUEUED_FOLLOWUP_PATCH_BEGIN,
+        QUEUED_FOLLOWUP_PATCH_END,
+        _render_queued_followup_hook_block,
+        "queued follow-up patch markers",
+    )
+    content = _remove_simple_owned_patch(
+        content,
+        REDIRECT_PATCH_BEGIN,
+        REDIRECT_PATCH_END,
+        _render_redirect_hook_block,
+        "redirect patch markers",
     )
     content = _remove_simple_owned_patch(
         content,
@@ -2933,6 +3037,68 @@ def _render_queued_complete_hook_block(indent: str, newline: str):
         f"{deeper_indent}    _already_streamed = True{newline}",
         *_render_hook_exception_handler(indent, newline),
         f"{indent}{QUEUED_COMPLETE_PATCH_END}{newline}",
+    ]
+
+
+def _render_queued_followup_hook_block(indent: str, newline: str):
+    inner_indent = _child_indent(indent)
+    deeper_indent = _child_indent(inner_indent)
+    deepest_indent = _child_indent(deeper_indent)
+    return [
+        f"{indent}{QUEUED_FOLLOWUP_PATCH_BEGIN}{newline}",
+        f"{indent}try:{newline}",
+        (
+            f"{inner_indent}from hermes_feishu_card.hook_runtime "
+            f"import emit_from_hermes_locals_async as _hfc_emit_async{newline}"
+        ),
+        f"{inner_indent}if pending_event is not None:{newline}",
+        f"{deeper_indent}_hfc_followup_message_id = str(getattr(pending_event, \"message_id\", \"\") or \"\"){newline}",
+        f"{deeper_indent}_hfc_original_message_id = str(event_message_id or getattr(pending_event, \"reply_to_message_id\", \"\") or \"\"){newline}",
+        f"{deeper_indent}_hfc_was_interrupted = bool(locals().get(\"was_interrupted\")){newline}",
+        f"{deeper_indent}if _hfc_was_interrupted and _hfc_original_message_id:{newline}",
+        (
+            f"{deepest_indent}await _hfc_emit_async({{"
+            f"\"source\": source, \"chat_id\": getattr(source, \"chat_id\", None), "
+            f"\"message_id\": _hfc_original_message_id, \"error\": \"用户已打断当前任务\"}}, event_name=\"message.failed\"){newline}"
+        ),
+        f"{deeper_indent}if _hfc_followup_message_id:{newline}",
+        (
+            f"{deepest_indent}await _hfc_emit_async({{"
+            f"\"source\": next_source, \"event\": pending_event, \"message\": pending_event, "
+            f"\"chat_id\": getattr(next_source, \"chat_id\", None), "
+            f"\"message_id\": _hfc_followup_message_id, "
+            f"\"reply_to_message_id\": _hfc_original_message_id or getattr(pending_event, \"reply_to_message_id\", \"\") or _hfc_followup_message_id, "
+            f"\"redirect_followup\": True}}, event_name=\"message.started\"){newline}"
+        ),
+        *_render_hook_exception_handler(indent, newline),
+        f"{indent}{QUEUED_FOLLOWUP_PATCH_END}{newline}",
+    ]
+
+
+def _render_redirect_hook_block(indent: str, newline: str):
+    inner_indent = _child_indent(indent)
+    deeper_indent = _child_indent(inner_indent)
+    deepest_indent = _child_indent(deeper_indent)
+    return [
+        f"{indent}{REDIRECT_PATCH_BEGIN}{newline}",
+        f"{indent}try:{newline}",
+        (
+            f"{inner_indent}from hermes_feishu_card.hook_runtime "
+            f"import emit_from_hermes_locals_async as _hfc_emit_async{newline}"
+        ),
+        f"{inner_indent}if bool(locals().get(\"redirected\")):{newline}",
+        f"{deeper_indent}_hfc_redirect_message_id = str(getattr(event, \"message_id\", \"\") or \"\"){newline}",
+        f"{deeper_indent}if _hfc_redirect_message_id:{newline}",
+        (
+            f"{deepest_indent}await _hfc_emit_async({{"
+            f"\"source\": event.source, \"event\": event, \"message\": event, "
+            f"\"chat_id\": getattr(event.source, \"chat_id\", None), "
+            f"\"message_id\": _hfc_redirect_message_id, "
+            f"\"reply_to_message_id\": getattr(event, \"reply_to_message_id\", \"\") or _hfc_redirect_message_id, "
+            f"\"redirect_followup\": True}}, event_name=\"message.started\"){newline}"
+        ),
+        *_render_hook_exception_handler(indent, newline),
+        f"{indent}{REDIRECT_PATCH_END}{newline}",
     ]
 
 

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -4871,7 +4871,13 @@ async def _apply_event_locked(
         # where a new message arrives with its own explicit message_id (e.g.
         # after /stop or a generation-bump interrupt).
         await _abandon_stale_sessions_for_chat(
-            request.app, event.chat_id, session_key, event,
+            request.app,
+            event.chat_id,
+            session_key,
+            event,
+            alias_to_session_key=(
+                session_key if _is_redirect_followup_event(event) else None
+            ),
         )
         session = CardSession(
             conversation_id=event.conversation_id,
@@ -4963,7 +4969,13 @@ async def _apply_event_locked(
             # card would be stuck at "生成中" forever.
             if not _is_independent_notice_event(event):
                 await _abandon_stale_sessions_for_chat(
-                    request.app, event.chat_id, session_key, event,
+                    request.app,
+                    event.chat_id,
+                    session_key,
+                    event,
+                    alias_to_session_key=(
+                        session_key if _is_redirect_followup_event(event) else None
+                    ),
                 )
             session = CardSession(
                 conversation_id=event.conversation_id,
@@ -6262,6 +6274,11 @@ def _is_independent_notice_event(event: SidecarEvent) -> bool:
     return scope == "independent" or delivery_kind == "notice"
 
 
+def _is_redirect_followup_event(event: SidecarEvent) -> bool:
+    data = event.data if isinstance(event.data, dict) else {}
+    return event.event == "message.started" and data.get("redirect_followup") is True
+
+
 def _is_compaction_session_start(event: SidecarEvent) -> bool:
     if event.event != "system.notice":
         return False
@@ -6851,6 +6868,8 @@ async def _abandon_stale_sessions_for_chat(
     chat_id: str,
     new_session_key: str,
     event: "SidecarEvent",
+    *,
+    alias_to_session_key: str | None = None,
 ) -> None:
     """Mark stale active sessions for the same chat+conversation as completed.
 
@@ -6902,6 +6921,8 @@ async def _abandon_stale_sessions_for_chat(
         sess.refresh_display_status_source(
             StatusConfig.from_mapping(card_config.get("status"))
         )
+        if alias_to_session_key:
+            app[SESSION_ALIASES_KEY][key] = alias_to_session_key
         logger.info(
             "Abandoning stale session %s (chat_hash=%s, ans=%d chars) "
             "— new session %s is taking over",

--- a/hermes_feishu_card/server.py
+++ b/hermes_feishu_card/server.py
@@ -136,6 +136,7 @@ FEISHU_CLIENT_KEY = web.AppKey("feishu_client", Any)
 SESSIONS_KEY = web.AppKey("sessions", dict)
 FEISHU_MESSAGE_IDS_KEY = web.AppKey("feishu_message_ids", dict)
 SESSION_ALIASES_KEY = web.AppKey("session_aliases", dict)
+REDIRECT_SESSION_ALIASES_KEY = web.AppKey("redirect_session_aliases", dict)
 CARD_SUMMARIES_KEY = web.AppKey("card_summaries", dict)
 CARD_SUMMARY_SESSION_KEYS_KEY = web.AppKey("card_summary_session_keys", dict)
 INTERACTION_RESULTS_KEY = web.AppKey("interaction_results", dict)
@@ -491,6 +492,7 @@ def create_app(
     app[SESSIONS_KEY] = {}
     app[FEISHU_MESSAGE_IDS_KEY] = {}
     app[SESSION_ALIASES_KEY] = {}
+    app[REDIRECT_SESSION_ALIASES_KEY] = {}
     # TODO: replace this short-lived in-process index with bounded shared storage.
     app[CARD_SUMMARIES_KEY] = {}
     app[CARD_SUMMARY_SESSION_KEYS_KEY] = {}
@@ -4380,6 +4382,14 @@ def _active_session_key(app: web.Application, session_key: str) -> str | None:
 def _resolve_session_key(app: web.Application, event: SidecarEvent) -> str:
     direct_key = _session_key(event)
     if event.turn_id:
+        if event.event == "message.started":
+            return direct_key
+        redirect_aliases: Dict[str, str] = app.get(REDIRECT_SESSION_ALIASES_KEY) or {}
+        redirect_key = redirect_aliases.get(direct_key)
+        if redirect_key:
+            active_key = _active_session_key(app, redirect_key)
+            if active_key is not None:
+                return active_key
         return direct_key
     active_key = _active_session_key(app, direct_key)
     if active_key is not None:
@@ -4405,7 +4415,11 @@ def _register_session_aliases(
     canonical_key: str,
 ) -> None:
     aliases: Dict[str, str] = app[SESSION_ALIASES_KEY]
-    keys = {_session_key(event), *_session_alias_keys_for_event(event)}
+    keys = {
+        _session_key(event),
+        _session_key_for_message_id(event, event.message_id),
+        *_session_alias_keys_for_event(event),
+    }
     for alias_key in keys:
         if alias_key and alias_key != canonical_key:
             aliases[alias_key] = canonical_key
@@ -4429,10 +4443,12 @@ def _cleanup_failed_session_state(
     if sessions.get(session_key) is not None:
         return
 
-    aliases: Dict[str, str] = app[SESSION_ALIASES_KEY]
-    for alias_key, canonical_key in tuple(aliases.items()):
-        if canonical_key == session_key and aliases.get(alias_key) == session_key:
-            aliases.pop(alias_key, None)
+    for aliases_key in (SESSION_ALIASES_KEY, REDIRECT_SESSION_ALIASES_KEY):
+        aliases: Dict[str, str] = app.get(aliases_key) or {}
+        for alias_key, canonical_key in tuple(aliases.items()):
+            if canonical_key == session_key and aliases.get(alias_key) == session_key:
+                aliases.pop(alias_key, None)
+        aliases.pop(session_key, None)
 
     owned_state = (
         (CARD_SUMMARIES_KEY, CARD_SUMMARY_SESSION_KEYS_KEY),
@@ -6854,6 +6870,12 @@ def _reset_session_for_new_turn(app: web.Application, session_key: str) -> None:
     app[FEISHU_MESSAGE_IDS_KEY].pop(session_key, None)
     app[MESSAGE_BOT_IDS_KEY].pop(session_key, None)
     app[SESSION_CARD_CONFIGS_KEY].pop(session_key, None)
+    for aliases_key in (SESSION_ALIASES_KEY, REDIRECT_SESSION_ALIASES_KEY):
+        aliases: Dict[str, str] = app.get(aliases_key) or {}
+        aliases.pop(session_key, None)
+        for alias_key, canonical_key in tuple(aliases.items()):
+            if canonical_key == session_key:
+                aliases.pop(alias_key, None)
     controllers: Dict[str, FlushController] = app[FLUSH_CONTROLLERS_KEY]
     controller = controllers.pop(session_key, None)
     if controller is not None:
@@ -6898,7 +6920,7 @@ async def _abandon_stale_sessions_for_chat(
             continue
         if sess.conversation_id != new_conversation_id:
             continue
-        if sess.status in {"completed", "failed"}:
+        if sess.status in {"completed", "failed"} and not alias_to_session_key:
             continue
         if sess.delivery_kind == "notice":
             continue
@@ -6912,6 +6934,15 @@ async def _abandon_stale_sessions_for_chat(
         sess = sessions.get(key)
         if sess is None:
             continue
+        already_terminal = sess.status in {"completed", "failed"}
+        if alias_to_session_key:
+            app[SESSION_ALIASES_KEY][key] = alias_to_session_key
+            app[REDIRECT_SESSION_ALIASES_KEY][key] = alias_to_session_key
+            for alias_key, canonical_key in tuple(app[SESSION_ALIASES_KEY].items()):
+                if canonical_key == key:
+                    app[SESSION_ALIASES_KEY][alias_key] = alias_to_session_key
+        if already_terminal:
+            continue
         sess.timeline.complete()
         sess.status = "completed"
         sess.updated_at = time.time()
@@ -6921,8 +6952,6 @@ async def _abandon_stale_sessions_for_chat(
         sess.refresh_display_status_source(
             StatusConfig.from_mapping(card_config.get("status"))
         )
-        if alias_to_session_key:
-            app[SESSION_ALIASES_KEY][key] = alias_to_session_key
         logger.info(
             "Abandoning stale session %s (chat_hash=%s, ans=%d chars) "
             "— new session %s is taking over",

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -884,6 +884,53 @@ async def test_serial_and_concurrent_conflict_reject_before_session_mutation(cli
     assert len(feishu_client.sent) == 1
 
 
+async def test_redirect_followup_aliases_interrupted_card_to_new_card(client):
+    test_client, feishu_client = client
+    old_started = event_payload(
+        "message.started",
+        0,
+        {"reply_to_message_id": "om_user_original"},
+        conversation_id="omt_topic",
+        message_id="om_old_turn",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    redirect_started = event_payload(
+        "message.started",
+        0,
+        {
+            "reply_to_message_id": "om_redirect_prompt",
+            "redirect_followup": True,
+        },
+        conversation_id="omt_topic",
+        message_id="om_redirect_turn",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    late_original_delta = event_payload(
+        "answer.delta",
+        1,
+        {"text": "redirected answer"},
+        conversation_id="omt_topic",
+        message_id="om_old_turn",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+
+    first = await test_client.post("/events", json=old_started)
+    second = await test_client.post("/events", json=redirect_started)
+    late = await test_client.post("/events", json=late_original_delta)
+
+    assert first.status == second.status == late.status == 200
+    assert test_client.app[SESSION_ALIASES_KEY]["om_old_turn"] == "om_redirect_turn"
+    old_session = test_client.app[SESSIONS_KEY]["om_old_turn"]
+    new_session = test_client.app[SESSIONS_KEY]["om_redirect_turn"]
+    assert old_session.status == "completed"
+    assert old_session.answer_text == ""
+    assert "redirected answer" in new_session.answer_text
+    assert len(feishu_client.sent) == 2
+
+
 async def test_error_response_is_replayed_without_retrying_delivery(tmp_path):
     feishu_client = FakeFeishuClient()
     feishu_client.fail_send = True

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1050,6 +1050,62 @@ async def test_redirect_followup_recovers_turn_terminalized_before_redirect(clie
     assert new_session.answer_text == "final redirected answer"
 
 
+async def test_redirect_followup_receives_legacy_completion_on_original_anchor(client):
+    test_client, _feishu_client = client
+    old_started = event_payload(
+        "message.started",
+        0,
+        {"reply_to_message_id": "om_original_question"},
+        conversation_id="omt_topic",
+        message_id="om_original_question",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    interrupted_terminal = event_payload(
+        "message.completed",
+        1,
+        {"answer": "partial answer"},
+        conversation_id="omt_topic",
+        message_id="om_original_question",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    redirect_started = event_payload(
+        "message.started",
+        0,
+        {
+            "reply_to_message_id": "om_original_question",
+            "redirect_followup": True,
+        },
+        conversation_id="omt_topic",
+        message_id="om_redirect_user",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    late_final = event_payload(
+        "message.completed",
+        2,
+        {"answer": "final redirected answer"},
+        conversation_id="omt_topic",
+        message_id="om_original_question",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+
+    first = await test_client.post("/events", json=old_started)
+    terminal = await test_client.post("/events", json=interrupted_terminal)
+    redirect = await test_client.post("/events", json=redirect_started)
+    late = await test_client.post("/events", json=late_final)
+
+    assert first.status == terminal.status == redirect.status == late.status == 200
+    assert test_client.app[SESSION_ALIASES_KEY]["om_original_question"] == "om_redirect_user"
+    old_session = test_client.app[SESSIONS_KEY]["om_original_question"]
+    new_session = test_client.app[SESSIONS_KEY]["om_redirect_user"]
+    assert old_session.status == "completed"
+    assert old_session.answer_text == "partial answer"
+    assert new_session.answer_text == "final redirected answer"
+
+
 async def test_error_response_is_replayed_without_retrying_delivery(tmp_path):
     feishu_client = FakeFeishuClient()
     feishu_client.fail_send = True

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1106,6 +1106,51 @@ async def test_redirect_followup_receives_legacy_completion_on_original_anchor(c
     assert new_session.answer_text == "final redirected answer"
 
 
+async def test_redirect_followup_hook_payload_aliases_terminalized_card(client):
+    test_client, _feishu_client = client
+    old_started = event_payload(
+        "message.started",
+        0,
+        {"reply_to_message_id": "om_original_question", "profile_id": "default"},
+        conversation_id="omt_topic",
+        message_id="om_original_question",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    interrupted_terminal = event_payload(
+        "message.completed",
+        1,
+        {"answer": "partial answer", "profile_id": "default"},
+        conversation_id="omt_topic",
+        message_id="om_original_question",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    redirect_started = hook_runtime.build_event(
+        "message.started",
+        {
+            "source": SimpleNamespace(
+                platform="feishu",
+                chat_id="oc_topic",
+                thread_id="omt_topic",
+            ),
+            "chat_id": "oc_topic",
+            "message_id": "om_redirect_user",
+            "reply_to_message_id": "om_original_question",
+            "redirect_followup": True,
+        },
+    )
+    assert redirect_started is not None
+
+    first = await test_client.post("/events", json=old_started)
+    terminal = await test_client.post("/events", json=interrupted_terminal)
+    redirect = await test_client.post("/events", json=redirect_started)
+
+    assert first.status == terminal.status == redirect.status == 200
+    assert test_client.app[SESSION_ALIASES_KEY]["default:om_original_question"] == "default:om_redirect_user"
+    assert test_client.app[REDIRECT_SESSION_ALIASES_KEY]["default:om_original_question"] == "default:om_redirect_user"
+
+
 async def test_error_response_is_replayed_without_retrying_delivery(tmp_path):
     feishu_client = FakeFeishuClient()
     feishu_client.fail_send = True

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -67,6 +67,7 @@ from hermes_feishu_card.server import (
     NATIVE_HANDOFF_STORE_KEY,
     RUNTIME_CLEANUP_INTERVAL_SECONDS,
     SESSION_ALIASES_KEY,
+    REDIRECT_SESSION_ALIASES_KEY,
     SESSION_CARD_CONFIGS_KEY,
     SESSIONS_KEY,
     create_app as _create_app,
@@ -929,6 +930,124 @@ async def test_redirect_followup_aliases_interrupted_card_to_new_card(client):
     assert old_session.answer_text == ""
     assert "redirected answer" in new_session.answer_text
     assert len(feishu_client.sent) == 2
+
+
+async def test_redirect_followup_aliases_interrupted_turn_id_stream_to_new_card(client):
+    test_client, _feishu_client = client
+    old_started = event_payload(
+        "message.started",
+        0,
+        {"reply_to_message_id": "om_user_original"},
+        conversation_id="omt_topic",
+        message_id="om_old_turn",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+        turn_id="turn-old-runtime",
+    )
+    redirect_started = event_payload(
+        "message.started",
+        0,
+        {
+            "reply_to_message_id": "om_redirect_prompt",
+            "redirect_followup": True,
+        },
+        conversation_id="omt_topic",
+        message_id="om_redirect_turn",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    late_original_delta = event_payload(
+        "answer.delta",
+        1,
+        {"text": "redirected answer"},
+        conversation_id="omt_topic",
+        message_id="om_old_turn",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+        turn_id="turn-old-runtime",
+    )
+
+    first = await test_client.post("/events", json=old_started)
+    second = await test_client.post("/events", json=redirect_started)
+    late = await test_client.post("/events", json=late_original_delta)
+
+    assert first.status == second.status == late.status == 200
+    assert (
+        test_client.app[SESSION_ALIASES_KEY]["turn-old-runtime"]
+        == "om_redirect_turn"
+    )
+    assert (
+        test_client.app[REDIRECT_SESSION_ALIASES_KEY]["turn-old-runtime"]
+        == "om_redirect_turn"
+    )
+    old_session = test_client.app[SESSIONS_KEY]["turn-old-runtime"]
+    new_session = test_client.app[SESSIONS_KEY]["om_redirect_turn"]
+    assert old_session.status == "completed"
+    assert old_session.answer_text == ""
+    assert "redirected answer" in new_session.answer_text
+
+
+async def test_redirect_followup_recovers_turn_terminalized_before_redirect(client):
+    test_client, _feishu_client = client
+    old_started = event_payload(
+        "message.started",
+        0,
+        {"reply_to_message_id": "om_original_question"},
+        conversation_id="omt_topic",
+        message_id="om_deep_search_user",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+        turn_id="turn-old-runtime",
+    )
+    interrupted_terminal = event_payload(
+        "message.completed",
+        1,
+        {"answer": "partial answer", "reply_to_message_id": "om_original_question"},
+        conversation_id="omt_topic",
+        message_id="om_deep_search_user",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+        turn_id="turn-old-runtime",
+    )
+    redirect_started = event_payload(
+        "message.started",
+        0,
+        {
+            "reply_to_message_id": "om_deep_search_user",
+            "redirect_followup": True,
+        },
+        conversation_id="omt_topic",
+        message_id="om_redirect_user",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+    )
+    late_final = event_payload(
+        "message.completed",
+        2,
+        {"answer": "final redirected answer", "reply_to_message_id": "om_original_question"},
+        conversation_id="omt_topic",
+        message_id="om_deep_search_user",
+        chat_id="oc_topic",
+        thread_id="omt_topic",
+        turn_id="turn-old-runtime",
+    )
+
+    first = await test_client.post("/events", json=old_started)
+    terminal = await test_client.post("/events", json=interrupted_terminal)
+    redirect = await test_client.post("/events", json=redirect_started)
+    late = await test_client.post("/events", json=late_final)
+
+    assert first.status == terminal.status == redirect.status == late.status == 200
+    assert (
+        test_client.app[REDIRECT_SESSION_ALIASES_KEY]["turn-old-runtime"]
+        == "om_redirect_user"
+    )
+    assert test_client.app[SESSION_ALIASES_KEY]["om_original_question"] == "om_redirect_user"
+    old_session = test_client.app[SESSIONS_KEY]["turn-old-runtime"]
+    new_session = test_client.app[SESSIONS_KEY]["om_redirect_user"]
+    assert old_session.status == "completed"
+    assert old_session.answer_text == "partial answer"
+    assert new_session.answer_text == "final redirected answer"
 
 
 async def test_error_response_is_replayed_without_retrying_delivery(tmp_path):
@@ -8647,6 +8766,53 @@ async def test_topic_system_notice_with_reply_anchor_updates_existing_card(clien
     assert message_id == "feishu-message-1"
     assert "上下文窗口提示" in str(card)
     assert len(feishu_client.sent) == 1
+
+
+async def test_turn_system_notice_with_user_message_id_updates_existing_card(client):
+    test_client, feishu_client = client
+
+    started = await test_client.post(
+        "/events",
+        json=event_payload(
+            "message.started",
+            0,
+            {"reply_to_message_id": "om_topic_quote"},
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+            turn_id="turn-runtime-1",
+        ),
+    )
+    notice = await test_client.post(
+        "/events",
+        json=event_payload(
+            "system.notice",
+            1,
+            {
+                "reply_to_message_id": "om_topic_user",
+                "title": "运行中",
+                "content": "⏳ Working — 3 min — iteration 7/300, terminal",
+                "level": "info",
+                "notice_kind": "heartbeat",
+                "notice_id": "heartbeat",
+                "notice_scope": "session",
+                "notice_terminal": False,
+            },
+            conversation_id="omt_topic",
+            message_id="om_topic_user",
+            thread_id="omt_topic",
+        ),
+    )
+
+    assert started.status == notice.status == 200
+    assert await notice.json() == {
+        "ok": True,
+        "applied": True,
+        "delivery": {"outcome": "accepted"},
+    }
+    assert len(feishu_client.sent) == 1
+    _message_id, card = await wait_for_card_update(feishu_client, "Working — 3 min")
+    assert "运行中" in str(card)
 
 
 async def test_existing_session_notice_update_failure_is_observable():

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -7606,6 +7606,27 @@ def test_build_cron_event_from_feishu_job_origin():
     ]["attachments"]
 
 
+def test_build_cron_event_uses_origin_message_as_topic_reply_anchor():
+    payload = hook_runtime.build_cron_event(
+        {
+            "job": {
+                "id": "job-topic",
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_cron",
+                    "thread_id": "omt_topic",
+                    "message_id": "om_create",
+                },
+            },
+            "delivery_content": "定时结果",
+        }
+    )
+
+    assert payload["conversation_id"] == "omt_topic"
+    assert payload["thread_id"] == "omt_topic"
+    assert payload["data"]["reply_to_message_id"] == "om_create"
+
+
 def test_build_cron_event_extracts_chat_id_from_deliver_string():
     payload = hook_runtime.build_cron_event(
         {

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -9317,6 +9317,26 @@ async def test_adapter_metadata_reply_anchor_preserves_topic_thread_placement():
     ]
 
 
+def test_build_started_event_preserves_redirect_followup_marker():
+    payload = hook_runtime.build_event(
+        "message.started",
+        {
+            "source": SimpleNamespace(
+                platform="feishu",
+                chat_id="oc_topic",
+                thread_id="omt_topic",
+            ),
+            "chat_id": "oc_topic",
+            "message_id": "om_redirect",
+            "reply_to_message_id": "om_original",
+            "redirect_followup": True,
+        },
+    )
+
+    assert payload is not None
+    assert payload["data"]["redirect_followup"] is True
+
+
 def _install_native_ack_context(
     adapter,
     content,

--- a/tests/unit/test_hook_runtime.py
+++ b/tests/unit/test_hook_runtime.py
@@ -9273,6 +9273,29 @@ async def test_adapter_thread_create_without_reply_anchor_falls_back_to_chat_cre
     assert adapter.raw_calls[-1][2] == "thread"
 
 
+@pytest.mark.asyncio
+async def test_adapter_metadata_reply_anchor_preserves_topic_thread_placement():
+    adapter = _NativeAckAdapter()
+    runner = SimpleNamespace(adapters={"feishu": adapter})
+    assert hook_runtime.install_feishu_command_card_adapter_methods(runner)
+
+    result = await adapter.send(
+        "oc_native",
+        "queued reply",
+        metadata={
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_parent",
+        },
+    )
+
+    assert result.success is True
+    assert adapter.raw_calls == [
+        ("{\"text\": \"queue\"}", "text", "thread", "random-reply"),
+        ("{\"text\": \"d rep\"}", "text", "thread", "random-reply"),
+        ("{\"text\": \"ly\"}", "text", "thread", "random-reply"),
+    ]
+
+
 def _install_native_ack_context(
     adapter,
     content,

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -2016,6 +2016,121 @@ def test_queued_complete_patch_tolerates_interleaved_stream_confirmation():
     ast.parse(patched)
 
 
+def test_queued_complete_patch_supports_current_finalized_result_shape():
+    """Hermes 0.20.6 uses the finalized delivery result and an ``elif`` branch."""
+    content = (
+        "async def _run_agent(self):\n"
+        "    result = {'final_response': 'old answer'}\n"
+        "    response = {'final_response': 'old answer'}\n"
+        "    _delivery_result = response if isinstance(response, dict) else (result or {})\n"
+        "    _previewed = bool(_delivery_result.get('response_previewed'))\n"
+        "    first_response = _delivery_result.get('final_response', '')\n"
+        "    _already_streamed = _stream_confirmed_final_delivery(\n"
+        "        _sc,\n"
+        "        first_response,\n"
+        "        previewed=_previewed,\n"
+        "    )\n"
+        "    _intentional_silence = False\n"
+        "    if _intentional_silence:\n"
+        "        pass\n"
+        "    elif first_response:\n"
+        "        await self._deliver_queued_first_response(\n"
+        "            first_response,\n"
+        "            source=source,\n"
+        "            adapter=adapter,\n"
+        "            metadata=_status_thread_metadata,\n"
+        "            event_message_id=event_message_id,\n"
+        "            text_already_delivered=_already_streamed,\n"
+        "            deliver_media=not _delivery_result.get('failed'),\n"
+        "            stream_consumer=_sc,\n"
+        "        )\n"
+    )
+
+    patched = patcher._apply_queued_complete_patch(content)
+
+    assert patcher.QUEUED_COMPLETE_PATCH_BEGIN in patched
+    assert "_hfc_card_delivered = await _hfc_emit_async" in patched
+    assert patched.index(patcher.QUEUED_COMPLETE_PATCH_BEGIN) < patched.index(
+        "if _intentional_silence:"
+    )
+    ast.parse(patched)
+
+
+def test_queued_followup_patch_starts_and_completes_a_new_card():
+    """A pending follow-up must not reuse the parent turn's card identity."""
+    content = (
+        "async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "    response = await self._run_agent(event, source)\n"
+        "    await self.hooks.emit('agent:end', {'response': response})\n"
+        "    return response\n"
+        "\n"
+        "async def _run_agent(self):\n"
+        "    result = {'interrupted': False, 'messages': history}\n"
+        "    was_interrupted = result.get('interrupted')\n"
+        "    updated_history = result.get('messages', history)\n"
+        "    next_source = source\n"
+        "    next_message = pending\n"
+        "    next_message_id = None\n"
+        "    next_channel_prompt = None\n"
+        "    next_session_key = session_key\n"
+        "    next_message_type = None\n"
+        "    if pending_event is not None:\n"
+        "        next_source = getattr(pending_event, 'source', None) or source\n"
+        "        next_message_id = self._reply_anchor_for_event(pending_event)\n"
+        "    followup_result = await self._run_agent(\n"
+        "        message=next_message,\n"
+        "        context_prompt=context_prompt,\n"
+        "        history=updated_history,\n"
+        "        source=next_source,\n"
+        "        session_id=session_id,\n"
+        "        session_key=next_session_key,\n"
+        "        run_generation=run_generation,\n"
+        "        _interrupt_depth=_interrupt_depth + 1,\n"
+        "        event_message_id=next_message_id,\n"
+        "        channel_prompt=next_channel_prompt,\n"
+        "        message_type=next_message_type,\n"
+        "    )\n"
+        "    return _preserve_queued_followup_history_offset(result, followup_result)\n"
+    )
+
+    patched = patcher.apply_patch(content, strategy="gateway_run_013_plus")
+
+    assert "# HERMES_FEISHU_CARD_QUEUED_FOLLOWUP_PATCH_BEGIN" in patched
+    assert 'event_name="message.started"' in patched
+    assert 'event_name="message.completed"' in patched
+    assert 'event_name="message.failed"' in patched
+    ast.parse(patched)
+
+
+def test_redirect_patch_starts_a_new_card_for_active_turn_redirect():
+    """A successful active-turn redirect moves subsequent updates to a new card."""
+    content = (
+        "async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):\n"
+        "    response = await self._run_agent(event, source)\n"
+        "    await self.hooks.emit('agent:end', {'response': response})\n"
+        "    return response\n"
+        "\n"
+        "async def _handle_busy_message(self, event):\n"
+        "    running_agent = self._session_state(session_key).turn.agent\n"
+        "    redirected = False\n"
+        "    if running_agent and hasattr(running_agent, 'redirect'):\n"
+        "        try:\n"
+        "            redirected = bool(running_agent.redirect((event.text or '').strip()))\n"
+        "        except Exception:\n"
+        "            redirected = False\n"
+        "    if not redirected:\n"
+        "        self._queue_or_replace_pending_event(session_key, event)\n"
+        "    return True\n"
+    )
+
+    patched = patcher.apply_patch(content, strategy="gateway_run_013_plus")
+
+    assert "# HERMES_FEISHU_CARD_REDIRECT_PATCH_BEGIN" in patched
+    assert 'event_name="message.started"' in patched
+    assert "reply_to_message_id" in patched
+    ast.parse(patched)
+
+
 def test_hfc_command_patch_enforces_maintenance_admission_before_commands():
     block = "".join(patcher._render_hfc_command_hook_block("    ", "\n"))
 


### PR DESCRIPTION
1|## Summary
2|
3|- Preserve `metadata.reply_to_message_id` through the native-handoff raw-send wrapper so anchored Feishu topic replies use the reply endpoint instead of falling back to a top-level create.
4|- Restore the queued-completion patch for Hermes 0.20.6's finalized-result shape, so the parent turn completes on its own card before a queued follow-up starts.
5|- Start a fresh card for queued/interrupted follow-ups and active-turn redirects; interrupted sessions alias to the new card without rewriting the previous card.
6|- Keep redirected streams alive when the old runtime turn terminalizes before the redirect card is created: late `turn_id` events and original reply/message anchors are remapped to the new card.
7|- Register the triggering Feishu message ID as an alias for turn-owned cards, so session-scoped `system.notice` heartbeats (for example `Working — ...`) update the active card instead of falling back to a separate notice card.
8|- Keep the unanchored topic fallback on the parent chat; `omt_*`/`om_*` thread IDs are not used as create-API receivers.

- Carry an origin Feishu `message_id` into cron card events as `reply_to_message_id`, so `deliver=origin` results reply inside the original topic instead of opening a new top-level topic when the caller provides the anchor.
9|
10|## Reproduction
11|
12|Reproduced on Hermes 0.20.6 with Feishu topic groups:
13|
14|- A queued final response with `metadata.thread_id` + `metadata.reply_to_message_id` lost the thread route and created a new top-level topic.
15|- A `/queue` follow-up completed inside the parent handler and overwrote the previous card instead of creating a new card below it.
16|- A successful active-turn redirect continued updating the previous card, then (after the first alias fix) could leave the new card without stream/final updates when the old turn terminalized first.
17|- A session-scoped Working heartbeat could not resolve the turn-owned card from the triggering user message ID and became a separate notice card.
18|
19|## Tests
20|
21|- `python -m pytest tests/unit/test_hook_runtime.py tests/integration/test_server.py -q` — 858 passed
22|23|- `python -m pytest tests/unit/test_patcher.py -k 'not fixed_tag_real_sources_render_detect_compile_and_restore_exactly' -q` — 149 passed, 1 deselected
24|- Gateway patch in-memory compile and backup apply/remove roundtrip passed
25|- `git diff --check` passed
26|
27|The deselected patcher test requires the maintainer fixture at `/private/tmp/hermes-agent-v2026.8.3-v430-audit`, which is not present on this machine.
28|