### PR TITLE
feat(install): support Hermes 2026-09 facade decomposition (8-file ownership)

### DIFF
--- a/docs/wiki/hermes-decomposed-patcher.md
+++ b/docs/wiki/hermes-decomposed-patcher.md
@@ -1,0 +1,74 @@
+# Hermes facade 拆分适配（fork）
+
+本页记录针对 Hermes `79445a496c` 源码布局的 Legacy patcher 适配。
+源码拆分本身不构成 native hook 能力证明；`MIN_SUPPORTED_VERSION`、固定 tag
+的 Hybrid/V3 安装入口与既有 native-hooks/hybrid/legacy-patch 选择规则保持不变。
+
+## 锚点与目标文件
+
+| 文件 | Hook |
+| --- | --- |
+| `gateway/run_turn.py` | message.started、completion、调用方耗时传递；校验 post-turn `agent:end` 调用 |
+| `gateway/run_turn_runner.py` | stable tool lifecycle、answer/thinking delta、status、clarify、approval |
+| `gateway/run_inbound.py` | command adapter 与 `_quick_key` 前的 HFC command |
+| `gateway/run_busy.py` | slash confirm |
+| `gateway/run_startup.py` | startup adapter 与 ledger redelivery |
+| `gateway/run_notifications.py` | platform notice |
+| `cron/scheduler_delivery.py` | 媒体提取和过滤之后的 cron completion |
+| `gateway/platforms/base.py` | exact final delivery 与无独立正文的 terminal |
+
+`gateway/run.py` 和 `cron/scheduler.py` facade 也参与 ownership 证据。
+检测只把实际可注入的定义视为 hook 锚点；cron 定义仍在 `scheduler.py` 时路由到
+该文件，重复定义拒绝安装。doctor 的 `anchor_locations` 显示实际命中文件。
+`status_callback` 仍是 optional，缺失时支持安装并显示 partial。
+
+TurnRunner 的 `stream_delta_cb` / `interim_assistant_cb` 使用 `ctx` 传递本轮 source、
+message ID、Gateway loop 和 session；approval 保留空选择时的原生回退。
+completion 从调用方复制 `_turn_seconds`，不修改原始 `agent_result` 对象。
+
+## Exact Base 边界
+
+必须同时验证 `_process_message_background`、`_extract_response_content`、
+`_send_final_text`、`_record_delivery_obligation` 与 `_finalize_delivery_obligation`
+的调用参数、提取/过滤顺序和 ledger 契约。不能仅按函数名接受新的上游实现。
+
+提取后的 images/local_files/media_files 通过 task-local completion stage 传给
+final-send helper；ledger 仍由 Hermes 在 terminal hook 前记录并标记 attempting。
+sidecar 明确接受后才用成功代理抑制原生正文，原生 ledger finalize 和附件路径继续执行。
+带附件和纯媒体 terminal 不授予 text-only native ACK。缺少提取证据时清理 stage，
+回退原生发送；不猜测附件为空。
+
+## Ownership 与恢复
+
+拆分布局使用 `manifest_version=4`、`layout=gateway-decomposed-v1`，每个受管源码文件
+独立记录原始/注入 SHA-256 与同目录 backup。安装前先完成整个集合的内存渲染、编译和
+逐字可逆检查，再复用 recovery 的目录绑定、原子替换与失败回滚事务。
+源码集合、backup、manifest、版本文件和 Git HEAD/packed refs 证据参与 fingerprint。
+
+重复安装不改源码。restore/uninstall 验证全部 ownership 后逐字还原源码并清理
+backup/manifest；恢复锁文件遵循原有 recovery 行为保留。任意受管文件的用户编辑、
+损坏 marker、缺失 backup、路径越界或 symlink 均拒绝覆盖。
+已知原始文件替换了 owned hook 时可 repair，`--no-repair` 阻止自动修复。
+兼容的无 marker 源码更新需要显式 `--accept-hermes-upgrade`。
+
+V4 不伪造 V1/V2 或固定 tag V3 ownership，也不自动迁移这些旧 manifest。
+`integrity.mode=safe` 的 Git provenance 自动修复仍要求原有严格证据；当前 V4 没有
+这份 provenance，必须拒绝自动升级修复，不能把普通多文件 fingerprint 当成授权。
+跨布局或未来 HFC renderer 变化时，先用原 installer 验证/还原旧 ownership，再安装新版本。
+
+## 验证与后续维护
+
+`tests/fixtures/hermes_decomposed/` 包含 8 个注入目标和两个 facade，无凭据、无运行环境。
+`tests/unit/test_decomposed_patcher.py` 验证 CLI install/uninstall、重复安装、LF/CRLF
+及无末尾换行的逐字往返、事务回滚、拒绝漂移、版本复核与生成 hook 的实际执行。
+这些测试不代替真实 Feishu/Lark smoke；模拟 CLI 测试仅替换 runtime package/SDK provisioning。
+
+```bash
+python -m pytest tests/unit/test_patcher.py tests/unit/test_decomposed_patcher.py tests/unit/test_installer_detection.py tests/integration/test_cli_install.py -q
+python -m pytest -q
+git diff --check
+```
+
+本适配尚属 fork 未发布改动。未来上游 HFC release 覆盖此布局时，应比较锚点、
+renderer 和 manifest 迁移行为后移除重复实现；`ac45e40` 的 20-year timeout 改动
+独立保留，不随此兼容补丁或上游版本切换而隐式重置。

--- a/docs/wiki/maintenance-guide.md
+++ b/docs/wiki/maintenance-guide.md
@@ -93,6 +93,7 @@
 - 新 hook block 必须有 patcher 单测和 remove/restore 覆盖。
 - Hermes 0.20 将同步 delivery-ledger 写入包装为 `await asyncio.to_thread(...)`；只可在已验证的 ledger anchor 内解包这一精确结构，未 `await`、其他 wrapper 或全局 call 解包必须继续拒绝。
 - `_status_callback_sync` 是 optional `status_callback` capability；缺失时保持其他安装路径可用并由 doctor 报 partial compatibility。
+- Hermes `79445a496c` facade 拆分的路由、Base helper 契约与 V4 ownership 边界见 [拆分适配说明](hermes-decomposed-patcher.md)。源码布局不得被用作 native hook 能力证明。
 
 ### `hermes_feishu_card/install/recovery.py` and operations execution
 

--- a/hermes_feishu_card/cli.py
+++ b/hermes_feishu_card/cli.py
@@ -1495,6 +1495,7 @@ def _doctor_hermes_report(detection: HermesDetection) -> dict[str, Any]:
         "cron_hook_strategy": detection.cron_hook_strategy,
         "compatibility": detection.compatibility,
         "anchors": dict(detection.capabilities),
+        "anchor_locations": dict(detection.capability_locations),
         "reason": detection.reason,
         "suggested_root": (
             str(detection.suggested_root)
@@ -2060,6 +2061,14 @@ def _summarize_process_output(result: subprocess.CompletedProcess[str]) -> str:
 
 
 def _diagnose_install_state(detection: HermesDetection) -> dict[str, Any]:
+    from .install import decomposed
+    if detection.decomposed or decomposed.is_managed(detection.root):
+        plan = decomposed.plan(detection)
+        return {"checked": True, "status": plan.state,
+                "manifest_exists": (detection.root / MANIFEST_NAME).exists(),
+                "manual_action_required": plan.state == "refused",
+                "automatic_repair_available": plan.executable,
+                "message": "Decomposed ownership: " + plan.state}
     run_py = detection.run_py
     backup_path = _backup_path(run_py)
     manifest_path = _manifest_path(detection.root)
@@ -2444,7 +2453,8 @@ def _format_hermes_detection(detection: HermesDetection) -> str:
     ]
     for capability, found in detection.capabilities.items():
         anchor_status = "found" if found else "missing"
-        lines.append(f"  {capability}: {anchor_status}")
+        locations = ", ".join(detection.capability_locations.get(capability, ()))
+        lines.append(f"  {capability}: {anchor_status}" + (f" ({locations})" if locations else ""))
     lines.append(f"reason: {detection.reason}")
     return "\n".join(lines)
 
@@ -3628,6 +3638,20 @@ def _run_install(args: argparse.Namespace) -> int:
     if fixed_tag_result is not None:
         return fixed_tag_result
 
+    if detection.decomposed:
+        from .install.decomposed import install as install_decomposed
+        try:
+            changed = install_decomposed(
+                detection, no_repair=bool(getattr(args, "no_repair", False)),
+                accept_hermes_upgrade=bool(getattr(args, "accept_hermes_upgrade", False)))
+        except (OSError, UnicodeError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        print("install ok" if changed else "install ok (already installed)")
+        if changed:
+            print("gateway.restart_required: hermes gateway start")
+        return 0
+
     accept_hermes_upgrade = bool(
         getattr(args, "accept_hermes_upgrade", False)
     )
@@ -4193,6 +4217,11 @@ def _repair_action_message(action: str) -> str:
 
 
 def _restore(hermes_root: Path) -> None:
+    from .install import decomposed
+    detection = detect_hermes(hermes_root)
+    if detection.decomposed or decomposed.is_managed(hermes_root):
+        decomposed.restore(detection)
+        return
     run_py = hermes_root / "gateway" / "run.py"
     cron_py = hermes_root / "cron" / "scheduler.py"
     base_py = hermes_root / "gateway" / "platforms" / "base.py"

--- a/hermes_feishu_card/diagnostics.py
+++ b/hermes_feishu_card/diagnostics.py
@@ -317,6 +317,7 @@ def build_diagnostic_report(
         "cron_hook_strategy": detection.cron_hook_strategy,
         "compatibility": detection.compatibility,
         "anchors": dict(detection.capabilities),
+        "anchor_locations": dict(detection.capability_locations),
         "reason": detection.reason,
         "suggested_root": str(detection.suggested_root or ""),
         "suggestion_reason": detection.suggestion_reason,
@@ -563,6 +564,11 @@ def format_diagnostic_text(report: DiagnosticReport, explain: bool) -> str:
         exact_contract = hermes.get("exact_delivery_contract")
         if exact_contract:
             lines.append(f"- Exact delivery contract: {exact_contract}")
+        locations = _mapping(hermes.get("anchor_locations"))
+        for name, found in _mapping(hermes.get("anchors")).items():
+            paths = locations.get(name) or ()
+            suffix = " (" + ", ".join(paths) + ")" if paths else ""
+            lines.append(f"- Anchor {name}: {'found' if found else 'missing'}{suffix}")
     else:
         lines.append(f"- Hermes: {hermes_status}")
 

--- a/hermes_feishu_card/hook_runtime.py
+++ b/hermes_feishu_card/hook_runtime.py
@@ -2016,10 +2016,14 @@ def _exact_base_delivery_hook_available() -> bool:
         method = getattr(BasePlatformAdapter, "_process_message_background", None)
         code = getattr(method, "__code__", None)
         names = set(getattr(code, "co_names", ()) or ())
-        return {
-            "prepare_exact_base_final_delivery",
-            "finalize_exact_base_no_text",
-        }.issubset(names)
+        if {"prepare_exact_base_final_delivery", "finalize_exact_base_no_text"}.issubset(names):
+            return True
+        send = getattr(BasePlatformAdapter, "_send_final_text", None)
+        send_names = set(getattr(getattr(send, "__code__", None), "co_names", ()))
+        return {"capture_decomposed_base_context", "finalize_exact_base_no_text", "_send_final_text"}.issubset(names) and {
+            "prepare_decomposed_base_final_delivery", "_record_delivery_obligation",
+            "_send_with_retry", "_finalize_delivery_obligation",
+        }.issubset(send_names)
     except Exception:
         return False
 
@@ -2490,6 +2494,31 @@ async def _recover_exact_terminal_native_handoff(
         )
         return True
     return False
+
+
+def capture_decomposed_base_context(local_vars: dict[str, Any]) -> None:
+    """Carry extracted attachments across Base's helper call in this exact turn."""
+    stage = _exact_completion_stage_for_current_task()
+    if stage is not None:
+        stage["base_context"] = {
+            key: local_vars[key] for key in ("images", "local_files", "media_files")
+        }
+
+
+async def prepare_decomposed_base_final_delivery(
+    local_vars: dict[str, Any],
+) -> tuple[Any, str, Any, Any]:
+    stage = _exact_completion_stage_for_current_task()
+    if stage is not None:
+        context = stage.pop("base_context", None)
+        if not isinstance(context, dict):
+            # Missing extraction evidence must never grant a text-only ACK.
+            _HFC_EXACT_COMPLETION_STAGE.set(None)
+            _HFC_NATIVE_HANDOFF_CONTEXT.set(None)
+            return (local_vars.get("delivery_adapter"), str(local_vars.get("content") or ""),
+                    local_vars.get("reply_to"), local_vars.get("metadata"))
+        local_vars = {**local_vars, **context}
+    return await prepare_exact_base_final_delivery(local_vars)
 
 
 async def prepare_exact_base_final_delivery(

--- a/hermes_feishu_card/install/decomposed.py
+++ b/hermes_feishu_card/install/decomposed.py
@@ -1,0 +1,228 @@
+"""Legacy-patch ownership for Hermes' September facade decomposition.
+
+Mode selection stays in the CLI. This module owns only a verified source set;
+all filesystem mutations reuse recovery's bound, rollback-capable transaction.
+"""
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from pathlib import Path
+import stat
+
+from . import patcher
+
+MANIFEST_VERSION = 4
+MANIFEST_NAME = ".hermes_feishu_card_manifest"
+BACKUP_SUFFIX = ".hermes_feishu_card.bak"
+SOURCE_TARGETS = ("gateway/run.py", *patcher.DECOMPOSED_GATEWAY_TARGETS,
+                  "cron/scheduler.py", "cron/scheduler_delivery.py", "gateway/platforms/base.py")
+VERSION_TARGETS = ("VERSION", "hermes_cli/__init__.py", ".git/HEAD", ".git/packed-refs")
+
+
+def is_managed(root: Path) -> bool:
+    try:
+        value = json.loads((root / MANIFEST_NAME).read_bytes())
+        return isinstance(value, dict) and value.get("manifest_version") == MANIFEST_VERSION
+    except (OSError, ValueError):
+        return False
+
+
+def validate_manifest(manifest):
+    from .manifest import ManifestStructureError
+    if (not isinstance(manifest, dict)
+            or type(manifest.get("manifest_version")) is not int
+            or manifest.get("manifest_version") != MANIFEST_VERSION
+            or manifest.get("layout") != "gateway-decomposed-v1"
+            or manifest.get("integration_mode") != "legacy-patch"
+            or not isinstance(manifest.get("targets"), dict)
+            or not manifest["targets"]
+            or not set(manifest["targets"]).issubset(SOURCE_TARGETS)
+            or "gateway/run.py" not in manifest["targets"]):
+        raise ManifestStructureError("invalid decomposed ownership manifest")
+    for target, row in manifest["targets"].items():
+        if (not isinstance(row, dict) or set(row) != {"path", "backup", "original_sha256", "patched_sha256"}
+                or row["path"] != target or row["backup"] != target + BACKUP_SUFFIX
+                or any(not isinstance(row[k], str) or len(row[k]) != 64
+                       or any(c not in "0123456789abcdef" for c in row[k])
+                       for k in ("original_sha256", "patched_sha256"))):
+            raise ManifestStructureError("invalid decomposed target ownership")
+
+
+def _snapshot(root):
+    """Bind every candidate, including absence, so a new file invalidates a plan."""
+    result = {}
+    for name in (*SOURCE_TARGETS, *(n + BACKUP_SUFFIX for n in SOURCE_TARGETS),
+                 MANIFEST_NAME, *VERSION_TARGETS):
+        path = root / name
+        for parent in (path, *path.parents):
+            if parent.is_symlink():
+                raise ValueError("decomposed source ancestry must not contain symlinks")
+            if parent == root:
+                break
+        try:
+            metadata = path.lstat()
+        except (FileNotFoundError, NotADirectoryError):
+            result[name] = None
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("decomposed ownership evidence must be a regular file")
+        result[name] = path.read_bytes()
+    return result
+
+
+def _fingerprint(snapshot):
+    evidence = [(key, None if value is None else sha256(value).hexdigest())
+                for key, value in sorted(snapshot.items())]
+    return sha256(json.dumps(evidence).encode()).hexdigest()
+
+
+def render(sources, strategy="gateway_run_013_plus"):
+    rendered = {}
+    for target, raw in sources.items():
+        text = raw.decode("utf-8")
+        if target == "gateway/platforms/base.py":
+            patched = patcher.apply_base_patch(text)
+            restored = patcher.remove_base_patch(patched)
+        elif target.startswith("cron/"):
+            patched = patcher.apply_cron_patch(text)
+            restored = patcher.remove_cron_patch(patched)
+        else:
+            patched = patcher.apply_gateway_fragment(text, target, strategy=strategy)
+            restored = patcher.remove_patch(patched)
+        compile(patched, target, "exec")
+        if restored != text:
+            raise ValueError(f"{target}: patch is not reversible")
+        rendered[target] = patched.encode("utf-8")
+    from .detect import _LAYOUT_MARKERS
+    all_bytes = b"\n".join(rendered.values())
+    for name, marker in _LAYOUT_MARKERS.items():
+        count = all_bytes.count(marker.encode())
+        if count != 1 and not (name == "status_callback" and count == 0):
+            raise ValueError(f"decomposed patch group missing or ambiguous: {name}")
+    for marker in (patcher.CRON_PATCH_BEGIN, patcher.EXACT_BASE_NO_TEXT_PATCH_BEGIN,
+                   patcher.EXACT_BASE_FINAL_DELIVERY_PATCH_BEGIN):
+        if all_bytes.count(marker.encode()) != 1:
+            raise ValueError("decomposed delivery patch group missing or ambiguous")
+    return rendered
+
+
+def _inspect(root):
+    snapshot = _snapshot(root)
+    sources = {name: snapshot[name] for name in SOURCE_TARGETS if snapshot[name] is not None}
+    raw_manifest = snapshot[MANIFEST_NAME]
+    if raw_manifest is None:
+        if any(snapshot[name + BACKUP_SUFFIX] is not None for name in SOURCE_TARGETS):
+            raise ValueError("decomposed backup has no manifest; refusing mutation")
+        if any(b"HERMES_FEISHU_CARD_" in raw for raw in sources.values()):
+            raise ValueError("decomposed hooks have no manifest; refusing mutation")
+        return snapshot, sources, None, "clean"
+    manifest = json.loads(raw_manifest)
+    validate_manifest(manifest)
+    if set(manifest["targets"]) != set(sources):
+        raise ValueError("decomposed source target set changed")
+    originals = {}
+    for target, row in manifest["targets"].items():
+        backup = snapshot[target + BACKUP_SUFFIX]
+        if backup is None or sha256(backup).hexdigest() != row["original_sha256"]:
+            raise ValueError(f"{target}: backup missing or changed")
+        originals[target] = backup
+    if any(snapshot[name + BACKUP_SUFFIX] is not None for name in SOURCE_TARGETS if name not in originals):
+        raise ValueError("unowned decomposed backup exists")
+    rendered = render(originals)
+    clean_targets = []
+    replacements = {}
+    for target, raw in sources.items():
+        row = manifest["targets"][target]
+        if sha256(rendered[target]).hexdigest() != row["patched_sha256"]:
+            raise ValueError(f"{target}: patch implementation differs from owned manifest")
+        if raw == rendered[target]:
+            continue
+        if raw == originals[target]:
+            clean_targets.append(target)
+        elif b"HERMES_FEISHU_CARD_" not in raw:
+            replacements[target] = raw
+        else:
+            raise ValueError(f"{target}: source drift; refusing mutation")
+    if replacements:
+        originals = {**originals, **replacements}
+        rendered = render(originals)
+        return snapshot, originals, rendered, "stale_unpatched"
+    return snapshot, originals, rendered, "owned_incomplete" if clean_targets else "installed"
+
+
+def plan(detection, *, accept_hermes_upgrade=False):
+    from .recovery import RecoveryFinding, RecoveryPlan
+    try:
+        snapshot, _, _, state = _inspect(detection.root)
+        fingerprint = _fingerprint(snapshot)
+        executable = state == "owned_incomplete" or (state == "stale_unpatched" and accept_hermes_upgrade and detection.supported)
+        actions = ("restore_owned_hooks",) if state == "owned_incomplete" else ("accept_hermes_upgrade",) if state == "stale_unpatched" else ()
+        return RecoveryPlan(detection.root, state, executable, fingerprint, actions, ())
+    except (OSError, ValueError, UnicodeError):
+        try:
+            fingerprint = _fingerprint(_snapshot(detection.root))
+        except (OSError, ValueError):
+            fingerprint = sha256(b"unsafe decomposed evidence").hexdigest()
+        return RecoveryPlan(detection.root, "refused", False, fingerprint, (),
+                            (RecoveryFinding("user_modified", "error", "Decomposed ownership cannot be verified."),))
+
+
+def install(detection, *, no_repair=False, expected_fingerprint=None, accept_hermes_upgrade=False):
+    from .detect import detect_hermes
+    from .recovery import _root_lock, _commit_recovery_changes, _require_secure_dirfd_transactions
+    _require_secure_dirfd_transactions()
+    with _root_lock(detection.root):
+        snapshot, originals, rendered, state = _inspect(detection.root)
+        if expected_fingerprint and _fingerprint(snapshot) != expected_fingerprint:
+            raise ValueError("recovery evidence changed; rerun diagnosis")
+        detection = detect_hermes(detection.root)
+        if not detection.supported:
+            raise ValueError("unsupported decomposed Hermes: " + detection.reason)
+        if state == "installed":
+            return False
+        if state in {"owned_incomplete", "stale_unpatched"} and no_repair:
+            raise ValueError("decomposed ownership needs repair; --no-repair set")
+        if state == "stale_unpatched" and not (accept_hermes_upgrade and detection.supported):
+            raise ValueError("decomposed source upgrade requires --accept-hermes-upgrade")
+        fresh = plan(detection, accept_hermes_upgrade=accept_hermes_upgrade)
+        if fresh.fingerprint != _fingerprint(snapshot):
+            raise ValueError("decomposed evidence changed before install")
+        rendered = rendered or render(originals, detection.hook_strategy)
+        manifest = {
+            "manifest_version": MANIFEST_VERSION, "layout": "gateway-decomposed-v1",
+            "integration_mode": "legacy-patch",
+            "targets": {name: {"path": name, "backup": name + BACKUP_SUFFIX,
+                                "original_sha256": sha256(raw).hexdigest(),
+                                "patched_sha256": sha256(rendered[name]).hexdigest()}
+                        for name, raw in originals.items()},
+        }
+        validate_manifest(manifest)
+        changes = [(detection.root / name, raw.decode("utf-8")) for name, raw in rendered.items()
+                   if snapshot[name] != raw]
+        if state in {"clean", "stale_unpatched"}:
+            changes = [(detection.root / (name + BACKUP_SUFFIX), raw.decode("utf-8"))
+                       for name, raw in originals.items()] + changes
+            changes.append((detection.root / MANIFEST_NAME, json.dumps(manifest, indent=2) + "\n"))
+        _commit_recovery_changes(detection, fresh, changes, accept_hermes_upgrade=accept_hermes_upgrade)
+        _inspect(detection.root)
+        return True
+
+
+def restore(detection):
+    from .recovery import _root_lock, _commit_recovery_changes, _require_secure_dirfd_transactions
+    _require_secure_dirfd_transactions()
+    with _root_lock(detection.root):
+        snapshot, originals, _, state = _inspect(detection.root)
+        if state == "clean":
+            return
+        if state == "stale_unpatched":
+            raise ValueError("decomposed source drift; refusing restore until upgrade is accepted")
+        fresh = plan(detection)
+        if fresh.fingerprint != _fingerprint(snapshot):
+            raise ValueError("decomposed evidence changed before restore")
+        changes = [(detection.root / name, raw.decode("utf-8")) for name, raw in originals.items()
+                   if snapshot[name] != raw]
+        changes.extend((detection.root / (name + BACKUP_SUFFIX), None) for name in originals)
+        changes.append((detection.root / MANIFEST_NAME, None))
+        _commit_recovery_changes(detection, fresh, changes)

--- a/hermes_feishu_card/install/detect.py
+++ b/hermes_feishu_card/install/detect.py
@@ -57,6 +57,9 @@ class HermesDetection:
     base_required: bool = False
     compatibility: str = "unsupported"
     capabilities: dict[str, bool] = field(default_factory=dict)
+    capability_locations: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    gateway_files: tuple[str, ...] = ()
+    decomposed: bool = False
     suggested_root: Path | None = None
     suggestion_reason: str = ""
 
@@ -109,6 +112,10 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     run_py = hermes_root / "gateway" / "run.py"
     cron_py = hermes_root / "cron" / "scheduler.py"
     base_py = hermes_root / "gateway" / "platforms" / "base.py"
+    gateway_sources = {}
+    capability_locations = {}
+    decomposed = any((hermes_root / name).exists() for name in patcher.DECOMPOSED_GATEWAY_TARGETS)
+    cron_sources = {}
     version, version_error, version_source = _read_version(hermes_root / "VERSION")
     if version == "unknown" and version_error is None:
         package_version = _read_static_package_version(
@@ -154,6 +161,9 @@ def detect_hermes(root: str | Path) -> HermesDetection:
             base_required=base_required,
             compatibility=compatibility,
             capabilities=capabilities or {},
+            capability_locations=capability_locations,
+            gateway_files=tuple(gateway_sources),
+            decomposed=decomposed,
             suggested_root=suggested_root,
             suggestion_reason=suggestion_reason,
         )
@@ -182,16 +192,35 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     if run_py_error is not None:
         return result(False, run_py_error)
 
+    gateway_sources["gateway/run.py"] = contents
+    for name in patcher.DECOMPOSED_GATEWAY_TARGETS:
+        path = hermes_root / name
+        if path.is_symlink():
+            return result(False, f"{name} must not be a symlink")
+        if path.exists():
+            source, error = _read_text(path, name)
+            if error:
+                return result(False, error)
+            gateway_sources[name] = source
+
     cron_contents = ""
     cron_error = None
-    if cron_py.exists():
-        if cron_py.is_symlink():
-            cron_error = "cron/scheduler.py must not be a symlink"
-        else:
-            cron_contents, cron_error = _read_text(cron_py, "cron/scheduler.py")
-
-    if cron_error is not None:
-        return result(False, cron_error)
+    for name in ("cron/scheduler.py", "cron/scheduler_delivery.py"):
+        path = hermes_root / name
+        if path.is_symlink():
+            return result(False, f"{name} must not be a symlink")
+        if path.exists():
+            source, cron_error = _read_text(path, name)
+            if cron_error is not None:
+                return result(False, cron_error)
+            cron_sources[name] = source
+    cron_anchors = [name for name, source in cron_sources.items()
+                    if _find_deliver_result_in_contents(source)]
+    if len(cron_anchors) > 1:
+        return result(False, "ambiguous cron delivery anchors: " + ", ".join(cron_anchors))
+    if cron_anchors:
+        cron_py = hermes_root / cron_anchors[0]
+    cron_contents = cron_sources.get(cron_py.relative_to(hermes_root).as_posix(), "")
 
     parsed_version = _parse_version(version)
     version_requires_base = bool(
@@ -211,7 +240,7 @@ def detect_hermes(root: str | Path) -> HermesDetection:
                 base_py, "gateway/platforms/base.py"
             )
     verified_ledger_signals = _has_exact_delivery_ledger_signals(base_contents)
-    base_required = version_requires_base or verified_ledger_signals
+    base_required = decomposed or version_requires_base or verified_ledger_signals
     exact_base_delivery = False
     exact_base_error = ""
     if base_contents and base_error is None:
@@ -223,7 +252,12 @@ def detect_hermes(root: str | Path) -> HermesDetection:
     elif base_required:
         exact_base_error = "gateway/platforms/base.py missing for exact delivery contract"
 
-    capabilities, capability_error = _detect_capabilities(contents, cron_contents)
+    if decomposed:
+        capabilities, capability_locations, capability_error = _detect_layout_capabilities(gateway_sources, cron_contents, cron_py.relative_to(hermes_root).as_posix())
+    else:
+        capabilities, capability_error = _detect_capabilities(contents, cron_contents)
+        capability_locations = {key: ((cron_py.relative_to(hermes_root).as_posix(),) if key == "cron_delivery" and _find_deliver_result_in_contents(cron_contents) else ("gateway/run.py",)) for key, found in capabilities.items() if found}
+    capability_locations["exact_base_delivery"] = ("gateway/platforms/base.py",) if exact_base_delivery else ()
     capabilities["exact_base_delivery"] = exact_base_delivery
     core_ok = all(capabilities.get(name, False) for name in CORE_CAPABILITIES)
     optional_ok = all(capabilities.get(name, False) for name in OPTIONAL_CAPABILITIES)
@@ -848,3 +882,66 @@ def _is_hooks_emit(func: ast.expr) -> bool:
         and isinstance(receiver.value, ast.Name)
         and receiver.value.id == "self"
     )
+
+
+_LAYOUT_MARKERS = {
+    "message_handler": patcher.PATCH_BEGIN,
+    "completion_return": patcher.COMPLETE_PATCH_BEGIN,
+    "tool_callback": patcher.STABLE_TOOL_PATCH_BEGIN,
+    "answer_delta_callback": patcher.ANSWER_DELTA_PATCH_BEGIN,
+    "thinking_delta_callback": patcher.THINKING_DELTA_PATCH_BEGIN,
+    "status_callback": patcher.STATUS_PATCH_BEGIN,
+    "clarify_callback": patcher.CLARIFY_PATCH_BEGIN,
+    "approval_callback": patcher.APPROVAL_PATCH_BEGIN,
+    "command_card": patcher.COMMAND_CARD_PATCH_BEGIN,
+    "hfc_command": patcher.HFC_COMMAND_PATCH_BEGIN,
+    "slash_confirm": patcher.SLASH_CONFIRM_PATCH_BEGIN,
+    "startup": patcher.COMMAND_CARD_STARTUP_PATCH_BEGIN,
+    "redelivery": patcher.NATIVE_REDELIVERY_PATCH_BEGIN,
+    "platform_notice": patcher.PLATFORM_NOTICE_PATCH_BEGIN,
+}
+
+
+def _detect_layout_capabilities(sources, cron_contents, cron_target):
+    locations = {name: [] for name in (*_LAYOUT_MARKERS, "run_agent", "reply_context", "attachment_delivery", "cron_delivery")}
+    errors = []
+    for target, content in sources.items():
+        try:
+            clean = patcher.remove_patch(content)
+            tree = ast.parse(clean)
+            rendered = patcher.apply_gateway_fragment(clean, target)
+            for name, marker in _LAYOUT_MARKERS.items():
+                if marker in rendered:
+                    locations[name].append(target)
+            if _find_run_agent(tree) is not None:
+                locations["run_agent"].append(target)
+            if any(isinstance(node, ast.Attribute) and node.attr in {
+                "reply_to_message_id", "_reply_anchor_for_event"
+            } for node in ast.walk(tree)):
+                locations["reply_context"].append(target)
+            if any(isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                   and node.func.attr in {"extract_media", "_deliver_media_from_response"}
+                   for node in ast.walk(tree)):
+                locations["attachment_delivery"].append(target)
+            handler = patcher._find_handler_node(tree)
+            if handler is not None and patcher._find_decomposed_completion_node(tree) is None:
+                errors.append(f"{target}: decomposed completion/agent:end contract missing")
+        except (ValueError, SyntaxError) as exc:
+            errors.append(f"{target}: unsafe anchors or ownership ({exc})")
+    try:
+        if patcher.CRON_PATCH_BEGIN in patcher.apply_cron_patch(cron_contents):
+            locations["cron_delivery"].append(cron_target)
+        else:
+            errors.append(f"{cron_target}: missing cron delivery anchor")
+    except ValueError:
+        errors.append(f"{cron_target}: unsafe cron anchors")
+    for name in _LAYOUT_MARKERS:
+        if len(locations[name]) > 1:
+            errors.append(f"{name}: ambiguous anchors in {', '.join(locations[name])}")
+    capabilities = {key: bool(value) for key, value in locations.items()}
+    # Status remains optional exactly as on the legacy layout. All other
+    # decomposed delivery/interaction seams are required to preserve features.
+    missing = [key for key in _LAYOUT_MARKERS if key != "status_callback" and not capabilities[key]]
+    if missing:
+        errors.append("missing decomposed anchors: " + ", ".join(missing))
+    return capabilities, {key: tuple(value) for key, value in locations.items()}, "; ".join(errors) or "supported"

--- a/hermes_feishu_card/install/manifest.py
+++ b/hermes_feishu_card/install/manifest.py
@@ -60,6 +60,12 @@ def validate_install_manifest_version(manifest: Mapping[str, object]) -> int:
     if "manifest_version" not in manifest:
         return 1
     version = manifest.get("manifest_version")
+    # V4 describes one explicit Legacy layout, not arbitrary future ownership.
+    # A bare version number must retain the existing fail-closed behavior.
+    if (type(version) is int and version == 4
+            and manifest.get("layout") == "gateway-decomposed-v1"
+            and manifest.get("integration_mode") == "legacy-patch"):
+        return version
     if type(version) is int and version in {
         *LEGACY_INSTALL_MANIFEST_VERSIONS,
         CURRENT_INSTALL_MANIFEST_VERSION,
@@ -70,6 +76,10 @@ def validate_install_manifest_version(manifest: Mapping[str, object]) -> int:
 
 def validate_install_manifest(manifest: Mapping[str, object]) -> int:
     version = validate_install_manifest_version(manifest)
+    if version == 4:
+        from .decomposed import validate_manifest
+        validate_manifest(manifest)
+        return version
     if version == 3:
         _validate_v3_manifest(manifest)
         return version

--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -16,6 +16,8 @@ from .patch_descriptors import (
 )
 
 
+TURN_TIMING_PATCH_BEGIN = "# HERMES_FEISHU_CARD_TURN_TIMING_PATCH_BEGIN"
+TURN_TIMING_PATCH_END = "# HERMES_FEISHU_CARD_TURN_TIMING_PATCH_END"
 PATCH_BEGIN = "# HERMES_FEISHU_CARD_PATCH_BEGIN"
 PATCH_END = "# HERMES_FEISHU_CARD_PATCH_END"
 COMPLETE_PATCH_BEGIN = "# HERMES_FEISHU_CARD_COMPLETE_PATCH_BEGIN"
@@ -157,6 +159,10 @@ def apply_patch(
         content = _apply_hfc_command_patch(content)
         content = _apply_platform_notice_patch(content)
         content = _apply_slash_confirm_patch(content)
+    return _apply_turn_callbacks(content, strategy=strategy)
+
+
+def _apply_turn_callbacks(content: str, *, strategy: str) -> str:
     content = _apply_stable_tool_lifecycle_patch(content)
     content = _apply_callback_patch(
         content,
@@ -295,13 +301,17 @@ def apply_base_patch(
     newline = _detect_newline(content)
     no_text_index, no_text_indent = no_text_location
     final_index, final_indent = final_location
-    no_text_hook = _render_exact_base_no_text_hook_block(no_text_indent, newline)
-    final_hook = _render_exact_base_final_delivery_hook_block(final_indent, newline)
+    no_text_renderer = (_render_decomposed_base_no_text_hook_block
+                        if _has_decomposed_base(tree) else _render_exact_base_no_text_hook_block)
+    no_text_hook = no_text_renderer(no_text_indent, newline)
+    final_renderer = (_render_decomposed_base_final_hook_block
+                      if _has_decomposed_base(tree) else _render_exact_base_final_delivery_hook_block)
+    final_hook = final_renderer(final_indent, newline)
 
     # Insert bottom-up so the earlier location is not shifted by the later
     # block. Both anchors are guaranteed to belong to the same exact pipeline.
-    lines = lines[:final_index] + final_hook + lines[final_index:]
-    lines = lines[:no_text_index] + no_text_hook + lines[no_text_index:]
+    for index, hook in sorted(((final_index, final_hook), (no_text_index, no_text_hook)), reverse=True):
+        lines[index:index] = hook
     return "".join(lines)
 
 
@@ -359,7 +369,9 @@ def _apply_start_patch(content: str, *, strategy: str) -> str:
 
 def _apply_complete_patch(content: str, *, strategy: str = "legacy_gateway_run") -> str:
     renderer = (
-        _render_complete_hook_block_with_reply_anchor
+        _render_decomposed_complete_hook_block
+        if _find_decomposed_completion_node(_parse_content(content)) is not None
+        else _render_complete_hook_block_with_reply_anchor
         if strategy == "gateway_run_013_plus"
         else _render_complete_hook_block
     )
@@ -494,7 +506,7 @@ def _apply_command_card_adapter_patch(content: str) -> str:
     if end is None:
         end = len(lines)
     for index in range(start, min(end, len(lines))):
-        if _strip_line_ending(lines[index]).strip() != "source = event.source":
+        if _strip_line_ending(lines[index]).strip() not in {"source = event.source", "event, source, is_internal = _admitted"}:
             continue
         indent = _leading_whitespace(_strip_line_ending(lines[index]))
         newline = _line_ending(lines[index]) or _detect_newline(content)
@@ -522,10 +534,12 @@ def _apply_command_card_startup_patch(content: str) -> str:
             return _apply_command_card_startup_patch(stripped)
 
     tree = _parse_content(content)
-    func = _find_gateway_runner_method(tree, "start")
+    func = (_find_gateway_runner_method(tree, "_start_finish_wiring")
+            or _find_gateway_runner_method(tree, "start"))
     if func is None:
         return content
-    anchor = _find_redelivery_startup_call(func) or _find_recovered_watcher_drain(func)
+    anchor = (_find_startup_boot_send(func) or _find_redelivery_startup_call(func)
+              or _find_recovered_watcher_drain(func))
     if anchor is None or anchor.lineno is None:
         return content
 
@@ -555,7 +569,8 @@ def _apply_native_redelivery_patch(content: str) -> str:
         return "".join(lines[:begin_index] + expected + lines[end_index + 1 :])
 
     tree = _parse_content(content)
-    func = _find_gateway_runner_method(tree, "_redeliver_pending_obligations")
+    func = (_find_gateway_runner_method(tree, "_redeliver_claimed_obligations")
+            or _find_gateway_runner_method(tree, "_redeliver_pending_obligations"))
     if func is None:
         return content
     send = _find_redelivery_adapter_send(func)
@@ -640,6 +655,9 @@ def _apply_hfc_command_patch(content: str) -> str:
 
 def remove_patch(content: str) -> str:
     """Remove the owned Feishu card hook block from patched Hermes content."""
+    content = _remove_simple_owned_patch(
+        content, TURN_TIMING_PATCH_BEGIN, TURN_TIMING_PATCH_END,
+        _render_turn_timing_hook_block, "turn timing patch markers")
     content = _remove_cron_patch(content)
     content = _remove_simple_owned_patch(
         content,
@@ -774,6 +792,7 @@ def remove_patch_lenient(content: str) -> str:
         content = "".join(lines[:begin_index] + lines[end_index + 1 :])
 
     for begin_marker, end_marker in (
+        (TURN_TIMING_PATCH_BEGIN, TURN_TIMING_PATCH_END),
         (STABLE_TOOL_PATCH_BEGIN, STABLE_TOOL_PATCH_END),
         (TOOL_PATCH_BEGIN, TOOL_PATCH_END),
         (ANSWER_DELTA_PATCH_BEGIN, ANSWER_DELTA_PATCH_END),
@@ -1018,6 +1037,9 @@ def _find_completion_return_location(tree, lines):
     if handler is None:
         return None
 
+    decomposed = _find_decomposed_completion_node(tree)
+    if decomposed is not None:
+        handler = decomposed
     already_sent_location = _find_already_sent_early_return_location(handler, lines)
     if already_sent_location is not None:
         return already_sent_location
@@ -1198,14 +1220,20 @@ def _find_turn_runner_callback_body_location(
     if turn_runner is None:
         return None
 
-    if callback_name == "_status_callback_sync":
+    direct_context = any(isinstance(n, ast.FunctionDef) and n.name == callback_name
+                         and _binds_turn_context(n) for n in turn_runner.body)
+    if direct_context:
         candidates = [
             node
             for node in turn_runner.body
             if isinstance(node, ast.FunctionDef) and node.name == callback_name
         ]
     else:
-        run_sync = _find_direct_class_function_node(turn_runner, "run_sync")
+        run_sync = _find_direct_class_function_node(turn_runner, "_setup_stream_consumer")
+        if run_sync is not None:
+            callback_name = {"_stream_delta_cb": "stream_delta_cb", "_interim_assistant_cb": "interim_assistant_cb"}.get(callback_name, callback_name)
+        else:
+            run_sync = _find_direct_class_function_node(turn_runner, "run_sync")
         if run_sync is None or not _binds_turn_context(run_sync):
             return None
         candidates = [
@@ -1219,7 +1247,7 @@ def _find_turn_runner_callback_body_location(
         for node in candidates
         if set(required_callback_args).issubset(_function_argument_names(node))
     ]
-    if callback_name == "_status_callback_sync":
+    if direct_context:
         candidates = [node for node in candidates if _binds_turn_context(node)]
     if required_callback_calls:
         preferred = [
@@ -1231,9 +1259,9 @@ def _find_turn_runner_callback_body_location(
             candidates = preferred
         elif len(candidates) != 1:
             return None
-    if not candidates:
+    if len(candidates) != 1:
         return None
-    if callback_name == "_status_callback_sync":
+    if direct_context:
         return _turn_context_binding_location(candidates[0], lines)
     return _body_location(candidates[0], lines)
 
@@ -1259,7 +1287,8 @@ def _find_turn_runner_stable_tool_lifecycle_location(tree, lines):
     turn_runner = _find_turn_runner_node(tree)
     if turn_runner is None:
         return None
-    run_sync = _find_direct_class_function_node(turn_runner, "run_sync")
+    run_sync = (_find_direct_class_function_node(turn_runner, "_wire_turn_agent_callbacks")
+                or _find_direct_class_function_node(turn_runner, "run_sync"))
     if run_sync is None or not _binds_turn_context(run_sync):
         return None
     if "agent" not in _function_scope_names(run_sync):
@@ -1590,6 +1619,7 @@ def _find_owned_complete_block(content: str):
     )
     actual = lines[begin_index : end_index + 1]
     if actual not in (
+        _render_decomposed_complete_hook_block(indent, newline),
         expected_with_anchor,
         expected,
         v400,
@@ -1750,7 +1780,7 @@ def _find_async_function(tree, name: str):
 
 def _find_gateway_runner_method(tree, name: str):
     for node in tree.body:
-        if not isinstance(node, ast.ClassDef) or node.name != "GatewayRunner":
+        if not isinstance(node, ast.ClassDef) or node.name not in {"GatewayRunner", "GatewayStartupMixin"}:
             continue
         for child in node.body:
             if isinstance(child, ast.AsyncFunctionDef) and child.name == name:
@@ -1768,6 +1798,8 @@ def _parse_exact_base_content(content: str):
 
 def _find_exact_base_patch_locations(tree, lines):
     """Return the two insertion locations after validating Hermes' pipeline."""
+    if _has_decomposed_base(tree):
+        return _find_decomposed_base_patch_locations(tree, lines)
     method = _find_exact_base_process_method(tree)
     method_nodes = list(ast.walk(method))
 
@@ -2373,6 +2405,10 @@ def _find_simple_owned_patch(
     newline = _line_ending(lines[begin_index]) or _detect_newline(content)
     expected = renderer(indent, newline)
     expected_blocks = [expected]
+    if renderer is _render_approval_hook_block:
+        previous_context = _render_turn_context_hook_block(renderer, indent, newline)
+        expected_blocks.append([line for line in previous_context
+                                if not line.strip().startswith('_approval_session_key = ctx.session_key')])
     if renderer is _render_command_card_adapter_hook_block:
         expected_blocks.append(_render_legacy_command_card_adapter_hook_block(indent, newline))
     if renderer in (
@@ -2432,8 +2468,6 @@ def _find_owned_exact_base_blocks(content: str, *, strict: bool):
     if no_text is None or final is None:
         raise ValueError("corrupt exact base patch markers")
 
-    if no_text[1] >= final[0]:
-        raise ValueError("corrupt exact base patch markers")
     if strict:
         lines = content.splitlines(keepends=True)
         no_text_indent = _leading_whitespace(
@@ -2442,14 +2476,14 @@ def _find_owned_exact_base_blocks(content: str, *, strict: bool):
         no_text_newline = _line_ending(lines[no_text[0]]) or _detect_newline(content)
         final_indent = _leading_whitespace(_strip_line_ending(lines[final[0]]))
         final_newline = _line_ending(lines[final[0]]) or _detect_newline(content)
-        if lines[no_text[0] : no_text[1] + 1] != _render_exact_base_no_text_hook_block(
-            no_text_indent,
-            no_text_newline,
+        if lines[no_text[0] : no_text[1] + 1] not in (
+            _render_exact_base_no_text_hook_block(no_text_indent, no_text_newline),
+            _render_decomposed_base_no_text_hook_block(no_text_indent, no_text_newline),
         ):
             raise ValueError("corrupt exact base patch markers")
-        if lines[final[0] : final[1] + 1] != _render_exact_base_final_delivery_hook_block(
-            final_indent,
-            final_newline,
+        if lines[final[0] : final[1] + 1] not in (
+            _render_exact_base_final_delivery_hook_block(final_indent, final_newline),
+            _render_decomposed_base_final_hook_block(final_indent, final_newline),
         ):
             raise ValueError("corrupt exact base patch markers")
     return no_text, final
@@ -3045,6 +3079,8 @@ def _render_turn_context_hook_block(renderer, indent: str, newline: str):
             line = line.replace(old, new)
         adapted.append(line)
     adapted.insert(1, f"{indent}_hfc_turn_ctx = ctx{newline}")
+    if renderer is _render_approval_hook_block:
+        adapted.insert(2, f"{indent}_approval_session_key = ctx.session_key or \"\"{newline}")
     return adapted
 
 
@@ -3673,3 +3709,218 @@ HYBRID_PATCH_REGISTRY = PatchDescriptorRegistry(
     descriptors=HYBRID_PATCH_DESCRIPTORS,
     required_groups=HYBRID_PATCH_GROUPS,
 )
+
+
+# September 2026 facade layout. Keep this separate from the fixed-tag Hybrid
+# descriptor registry: source layout is not evidence of native hook support.
+DECOMPOSED_GATEWAY_TARGETS = (
+    "gateway/run_turn.py", "gateway/run_turn_runner.py", "gateway/run_inbound.py",
+    "gateway/run_busy.py", "gateway/run_startup.py", "gateway/run_notifications.py",
+)
+DECOMPOSED_TARGETS = (*DECOMPOSED_GATEWAY_TARGETS,
+                      "cron/scheduler_delivery.py", "gateway/platforms/base.py")
+
+
+def apply_gateway_fragment(content: str, target: str, *, strategy="gateway_run_013_plus") -> str:
+    """Render one routed legacy fragment; never infer an integration mode."""
+    if target not in ("gateway/run.py", *DECOMPOSED_GATEWAY_TARGETS):
+        raise ValueError("unknown Gateway patch target")
+    tree = _parse_content(content)
+    if _find_handler_node(tree) is not None:
+        content = _apply_start_patch(content, strategy=strategy)
+        content = _apply_complete_patch(content, strategy=strategy)
+        content = _apply_turn_timing_patch(content)
+    content = _apply_queued_complete_patch(content)
+    for apply in (_apply_command_card_adapter_patch, _apply_hfc_command_patch,
+                  _apply_slash_confirm_patch, _apply_command_card_startup_patch,
+                  _apply_native_redelivery_patch, _apply_platform_notice_patch):
+        content = apply(content)
+    return _apply_turn_callbacks(content, strategy=strategy)
+
+
+def _find_startup_boot_send(func):
+    if func.name != "_start_finish_wiring":
+        return None
+    return next((node for node in func.body if isinstance(node, ast.Expr)
+                 and isinstance(node.value, ast.Await)
+                 and isinstance(node.value.value, ast.Call)
+                 and _same_expression(node.value.value.func, "self._await_startup_boot_sends")), None)
+
+
+def _find_decomposed_completion_node(tree):
+    handler = _find_handler_node(tree)
+    owners = [node for node in tree.body if isinstance(node, ast.ClassDef)
+              and handler in node.body]
+    if handler is None or len(owners) != 1:
+        return None
+    methods = []
+    for name, parameters in (
+        ("_hmwa_deliver_turn_response", ("self", "event", "source", "session_entry", "session_key",
+                                        "run_generation", "agent_result", "agent_messages", "response",
+                                        "_footer_line", "_intentional_silence")),
+        ("_hmwa_post_turn_hooks", ("self", "hook_ctx", "agent_result", "response")),
+    ):
+        candidates = [node for node in owners[0].body
+                      if isinstance(node, ast.AsyncFunctionDef) and node.name == name]
+        if len(candidates) != 1:
+            return None
+        args = candidates[0].args
+        if (tuple(arg.arg for arg in (*args.posonlyargs, *args.args)) != parameters
+                or args.kwonlyargs or args.vararg is not None or args.kwarg is not None):
+            return None
+        methods.append(candidates[0])
+    delivery, post = methods
+    # Both seams must actually be called by the handler, with the same result
+    # and response; a facade import or a similarly named dead method is not enough.
+    expected_return = ast.parse('return await self._hmwa_deliver_turn_response(event, source, session_entry, session_key, run_generation, agent_result, agent_messages, response, _footer_line, _intentional_silence)').body[0]
+    expected_post = ast.parse('await self._hmwa_post_turn_hooks(hook_ctx, agent_result, response)').body[0]
+    same = lambda a, b: ast.dump(a) == ast.dump(b)
+    returns = [n for n in ast.walk(handler) if same(n, expected_return)]
+    posts = [n for n in ast.walk(handler) if same(n, expected_post)]
+    emits = [n for n in ast.walk(post) if isinstance(n, ast.Await)
+             and isinstance(n.value, ast.Call)
+             and _same_expression(n.value.func, 'self.hooks.emit')
+             and n.value.args and _same_expression(n.value.args[0], '"agent:end"')]
+    if len(returns) != 1 or len(posts) != 1 or len(emits) != 1 or posts[0].lineno >= returns[0].lineno:
+        return None
+    return delivery
+
+
+def _render_decomposed_complete_hook_block(indent, newline):
+    # Timing is copied from the caller without mutating its original result.
+    return [line.replace('"duration": _response_time,', '"duration": agent_result.get("_hfc_turn_seconds"),')
+            for line in _render_complete_hook_block_with_reply_anchor(indent, newline)]
+
+
+def _has_decomposed_base(tree):
+    return any(isinstance(c, ast.ClassDef) and c.name == "BasePlatformAdapter"
+               and any(isinstance(n, ast.AsyncFunctionDef) and n.name == "_send_final_text" for n in c.body)
+               for c in tree.body)
+
+
+def _find_decomposed_base_patch_locations(tree, lines):
+    """Verify the extracted methods AND their exact call/argument boundaries."""
+    error = "could not find safe BasePlatformAdapter contract"
+    process = _find_exact_base_process_method(tree)
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "BasePlatformAdapter")
+    def method(name):
+        matches = [n for n in cls.body if isinstance(n, ast.AsyncFunctionDef) and n.name == name]
+        if len(matches) != 1:
+            raise ValueError(error)
+        return matches[0]
+    extract, send, record, finish = (method(n) for n in (
+        "_extract_response_content", "_send_final_text", "_record_delivery_obligation", "_finalize_delivery_obligation"))
+    # Positional calls are only safe when the callee binds the same values.
+    # Matching names somewhere in the body does not prove that boundary.
+    for node, positional, keyword_only in (
+        (process, ("self", "event", "session_key"), ()),
+        (extract, ("self", "response", "event", "session_key"), ("is_ephemeral_response",)),
+        (send, ("self", "event", "session_key", "text_content", "metadata",
+                "is_ephemeral_response", "ephemeral_ttl", "record_delivery"), ()),
+        (record, ("self", "event", "session_key", "text_content", "delivery_adapter",
+                  "is_ephemeral_response"), ()),
+        (finish, ("self", "obligation_id", "result", "event", "delivery_adapter"), ()),
+    ):
+        args = node.args
+        if (tuple(a.arg for a in (*args.posonlyargs, *args.args)) != positional
+                or tuple(a.arg for a in args.kwonlyargs) != keyword_only
+                or args.vararg is not None or args.kwarg is not None):
+            raise ValueError(error)
+    def exact(scope, source):
+        expected = ast.parse(source).body[0]
+        return _unique_exact_base_node(ast.walk(scope), lambda n: ast.dump(n) == ast.dump(expected))
+    def ordered(nodes):
+        if any(a.lineno >= b.lineno for a, b in zip(nodes, nodes[1:])):
+            raise ValueError(error)
+    extracted = exact(process, 'extracted = await self._extract_response_content(response, event, session_key, is_ephemeral_response=is_ephemeral_response)')
+    assigned = exact(process, 'text_content, media_files = extracted.text_content, extracted.media_files')
+    metadata = exact(process, '_final_thread_metadata = _mark_notify_metadata(_thread_metadata)')
+    tts_default = exact(process, '_tts_caption_delivered = False')
+    guard = _unique_exact_base_node(ast.walk(process), lambda n: isinstance(n, ast.If) and _same_expression(n.test, 'text_content and not _tts_caption_delivered'))
+    delegated = exact(guard, 'await self._send_final_text(event, session_key, text_content, _final_thread_metadata, is_ephemeral_response, _ephemeral_ttl, _record_delivery)')
+    if guard.body != [delegated]:
+        raise ValueError(error)
+    attachments = exact(process, 'await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)')
+    ordered([extracted, assigned, metadata, tts_default, guard, attachments])
+    # All three stages must be siblings in the response branch.
+    branches = [n for n in ast.walk(process) if isinstance(n, ast.If)
+                and all(part in n.orelse for part in (extracted, assigned, metadata, tts_default, guard, attachments))]
+    if len(branches) != 1 or not _same_expression(branches[0].test, 'not response'):
+        raise ValueError(error)
+    em = exact(extract, 'media_files, response = self.extract_media(response)')
+    fm = _unique_exact_base_node(ast.walk(extract), _is_exact_media_filter_assignment)
+    ei = exact(extract, 'images, text_content = self.extract_images(response)')
+    strip = exact(extract, 'text_content = _strip_media_directives(text_content).strip()')
+    el = exact(extract, 'local_files, text_content = self.extract_local_files(text_content)')
+    fl = _unique_exact_base_node(ast.walk(extract), _is_exact_local_filter_assignment)
+    recovered = exact(extract, '_recovered = _strip_media_directives(response).strip()')
+    restored = exact(extract, 'text_content = _recovered')
+    result = exact(extract, 'return _ExtractedResponse(text_content=text_content, images=images, media_files=media_files, local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)')
+    ordered([em, fm, ei, strip, el, fl, recovered, restored, result])
+    adapter = exact(send, 'delivery_adapter = self._final_delivery_adapter(event.source)')
+    ledger = exact(send, '_obligation_id = await self._record_delivery_obligation(event, session_key, text_content, delivery_adapter, is_ephemeral_response)')
+    final_send = exact(send, 'result = await delivery_adapter._send_with_retry(chat_id=event.source.chat_id, content=text_content, reply_to=_reply_anchor_for_event(event), metadata=metadata)')
+    delivered = exact(send, 'record_delivery(result)')
+    finalized = exact(send, 'if _obligation_id is not None:\n    await self._finalize_delivery_obligation(_obligation_id, result, event, delivery_adapter)')
+    if not all(n in send.body for n in (adapter, ledger, final_send, delivered, finalized)):
+        raise ValueError(error)
+    ordered([adapter, ledger, final_send, delivered, finalized])
+    source = exact(record, 'source = event.source')
+    computed = exact(record, 'obligation_id = compute_obligation_id(session_key, str(getattr(event, "message_id", "") or ""), text_content)')
+    recorded = exact(record, 'await asyncio.to_thread(record_obligation, obligation_id=obligation_id, session_key=session_key, platform=str(getattr(source.platform, "value", source.platform)), chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None), content=text_content, adapter_profile=getattr(delivery_adapter, "_owner_profile", None))')
+    attempting = exact(record, 'await asyncio.to_thread(mark_attempting, obligation_id)')
+    returned = exact(record, 'return obligation_id')
+    ordered([source, computed, recorded, attempting, returned])
+    tries = [n for n in record.body if isinstance(n, ast.Try) and all(x in n.body for x in (source, computed, recorded, attempting, returned))]
+    if len(tries) != 1:
+        raise ValueError(error)
+    exact(finish, 'if getattr(result, "success", False):\n    await asyncio.to_thread(mark_delivered, obligation_id)\n    return')
+    exact(finish, 'await asyncio.to_thread(mark_failed, obligation_id, error)')
+    return ((guard.lineno - 1, _line_indent(lines, guard.lineno - 1)),
+            (final_send.lineno - 1, _line_indent(lines, final_send.lineno - 1)))
+
+
+def _render_decomposed_base_final_hook_block(indent, newline):
+    block = _render_exact_base_final_delivery_hook_block(indent, newline)
+    block = [line.replace("prepare_exact_base_final_delivery as", "prepare_decomposed_base_final_delivery as")
+             .replace("_final_thread_metadata", "metadata") for line in block]
+    block.insert(2, f'{_child_indent(indent)}_reply_anchor = _reply_anchor_for_event(event){newline}')
+    return block
+
+
+def _render_decomposed_base_no_text_hook_block(indent, newline):
+    block = _render_exact_base_no_text_hook_block(indent, newline)
+    inner = _child_indent(indent)
+    block[2:2] = [
+        f'{inner}from hermes_feishu_card.hook_runtime import capture_decomposed_base_context as _hfc_capture_base{newline}',
+        f'{inner}images, local_files = extracted.images, extracted.local_files{newline}',
+        f'{inner}_hfc_capture_base(locals()){newline}',
+    ]
+    return block
+
+
+
+def _render_turn_timing_hook_block(indent, newline):
+    return [f"{indent}{TURN_TIMING_PATCH_BEGIN}{newline}",
+            f"{indent}try:{newline}",
+            f'{_child_indent(indent)}agent_result = {{**agent_result, "_hfc_turn_seconds": _turn_seconds}}{newline}',
+            *_render_hook_exception_handler(indent, newline),
+            f"{indent}{TURN_TIMING_PATCH_END}{newline}"]
+
+
+def _apply_turn_timing_patch(content):
+    content = _remove_simple_owned_patch(content, TURN_TIMING_PATCH_BEGIN, TURN_TIMING_PATCH_END,
+                                         _render_turn_timing_hook_block, "turn timing patch markers")
+    tree = _parse_content(content)
+    if _find_decomposed_completion_node(tree) is None:
+        return content
+    handler = _find_handler_node(tree)
+    if "_turn_seconds" not in _function_scope_names(handler):
+        raise ValueError("decomposed completion timing missing")
+    target = next(n for n in ast.walk(handler) if isinstance(n, ast.Return)
+                  and isinstance(n.value, ast.Await) and isinstance(n.value.value, ast.Call)
+                  and _same_expression(n.value.value.func, "self._hmwa_deliver_turn_response"))
+    lines = content.splitlines(keepends=True)
+    index = target.lineno - 1
+    lines[index:index] = _render_turn_timing_hook_block(_line_indent(lines, index), _detect_newline(content))
+    return "".join(lines)

--- a/hermes_feishu_card/install/recovery.py
+++ b/hermes_feishu_card/install/recovery.py
@@ -276,6 +276,16 @@ def execute_recovery(
     accept_hermes_upgrade: bool = False,
 ) -> RecoveryResult:
     _require_secure_dirfd_transactions()
+    from . import decomposed
+    if detection.decomposed or decomposed.is_managed(detection.root):
+        fresh = decomposed.plan(detection, accept_hermes_upgrade=accept_hermes_upgrade)
+        if expected_fingerprint and fresh.fingerprint != expected_fingerprint:
+            raise RecoveryRefused("recovery evidence changed; rerun diagnosis")
+        if not fresh.executable:
+            raise RecoveryRefused("decomposed recovery is not executable")
+        decomposed.install(detection, expected_fingerprint=fresh.fingerprint,
+                           accept_hermes_upgrade=accept_hermes_upgrade)
+        return RecoveryResult("repaired", fresh, fresh.actions, None, "Owned hooks restored; Gateway restart required.")
     with _root_lock(detection.root):
         manifest = _read_manifest_evidence(detection.root / MANIFEST_NAME)
         if manifest is not None and manifest.get(_MANIFEST_ERROR) == "unsupported_version":
@@ -1873,6 +1883,9 @@ def plan_recovery(
     *,
     accept_hermes_upgrade: bool = False,
 ) -> RecoveryPlan:
+    from . import decomposed
+    if detection.decomposed or decomposed.is_managed(detection.root):
+        return decomposed.plan(detection, accept_hermes_upgrade=accept_hermes_upgrade)
     return _plan_from_evidence(
         detection,
         _read_evidence(detection),

--- a/tests/fixtures/hermes_decomposed/cron/scheduler.py
+++ b/tests/fixtures/hermes_decomposed/cron/scheduler.py
@@ -1,0 +1,2 @@
+# Scheduler facade only.
+from cron.scheduler_delivery import _deliver_result

--- a/tests/fixtures/hermes_decomposed/cron/scheduler_delivery.py
+++ b/tests/fixtures/hermes_decomposed/cron/scheduler_delivery.py
@@ -1,0 +1,5 @@
+def _deliver_result(job, content, adapters=None, loop=None):
+    delivery_content = content
+    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    return cleaned_delivery_content, media_files

--- a/tests/fixtures/hermes_decomposed/gateway/platforms/base.py
+++ b/tests/fixtures/hermes_decomposed/gateway/platforms/base.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+# Contract excerpts from Hermes 79445a496c; no runtime installation needed.
+class BasePlatformAdapter:
+
+    async def _record_delivery_obligation(
+        self, event: MessageEvent, session_key: str, text_content: str,
+        delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool) -> Optional[str]:
+        """Ledger the final response BEFORE the send so a crash before platform ACK redelivers on
+        next boot; best-effort, skips slash-command and ephemeral replies. Returns the obligation id
+        or None."""
+        if is_ephemeral_response or str(event.text or "").lstrip().startswith(
+            ("/", self.typed_command_prefix or "!")):
+            return None
+        try:
+            from gateway.delivery_ledger import (
+                compute_obligation_id, ledger_enabled, mark_attempting, record_obligation)
+            if not await asyncio.to_thread(ledger_enabled):
+                return None
+            source = event.source
+            obligation_id = compute_obligation_id(
+                session_key, str(getattr(event, "message_id", "") or ""), text_content)
+            await asyncio.to_thread(
+                record_obligation, obligation_id=obligation_id, session_key=session_key,
+                platform=str(getattr(source.platform, "value", source.platform)),
+                chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
+                content=text_content,
+                adapter_profile=getattr(delivery_adapter, "_owner_profile", None))
+            await asyncio.to_thread(mark_attempting, obligation_id)
+            return obligation_id
+        except Exception:
+            logger.debug("delivery ledger record failed", exc_info=True)
+            return None
+
+    async def _finalize_delivery_obligation(
+        self, obligation_id: str, result: Any, event: MessageEvent,
+        delivery_adapter: "BasePlatformAdapter") -> None:
+        """Mark the ledger row delivered/failed (best-effort). On ``send_path_degraded`` with a
+        replacement adapter live, trigger another redelivery sweep (the watcher's may have run
+        before this failure landed; atomic claiming keeps it idempotent)."""
+        try:
+            from gateway.delivery_ledger import mark_delivered, mark_failed
+            if getattr(result, "success", False):
+                await asyncio.to_thread(mark_delivered, obligation_id)
+                return
+            error = str(getattr(result, "error", "") or "")
+            await asyncio.to_thread(mark_failed, obligation_id, error)
+            if error == "send_path_degraded":
+                redeliver = getattr(
+                    self.gateway_runner, "_redeliver_failed_obligations_for_platform", None)
+                live = self._final_delivery_adapter(event.source)
+                if live is not delivery_adapter and callable(redeliver):
+                    await redeliver(event.source.platform,
+                                    profile=getattr(delivery_adapter, "_owner_profile", None))
+        except Exception:
+            logger.debug("delivery ledger update failed", exc_info=True)
+
+    async def _send_final_text(
+        self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
+        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
+        """Send the final text on the CURRENT transport (a reconnect may have replaced
+        this adapter), ledger-bracketed; the message-id owner owns the ephemeral delete."""
+        delivery_adapter = self._final_delivery_adapter(event.source)
+        logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
+                    len(text_content), event.source.chat_id)
+        _obligation_id = await self._record_delivery_obligation(
+            event, session_key, text_content, delivery_adapter, is_ephemeral_response)
+        result = await delivery_adapter._send_with_retry(
+            chat_id=event.source.chat_id, content=text_content,
+            reply_to=_reply_anchor_for_event(event), metadata=metadata)
+        record_delivery(result)
+        if _obligation_id is not None:
+            await self._finalize_delivery_obligation(_obligation_id, result, event, delivery_adapter)
+        if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
+            delivery_adapter._schedule_ephemeral_delete(
+                event.source.chat_id, result.message_id, ephemeral_ttl)
+
+    async def _extract_response_content(self, response: str, event: MessageEvent, session_key: str,
+                                        *, is_ephemeral_response: bool) -> "_ExtractedResponse":
+        """Split a handler response into deliverable text + attachments. Order matters: MEDIA tags →
+        image URLs → residual directives → bare local paths (skipped for ephemeral notices so config
+        paths stay text; unknown-extension MEDIA tags survive for the bare-path detector). History
+        dedup is bare-path only, off-loop, fail-open. An emptied non-empty response is recovered."""
+        # Captured before extract_media strips it: images then go via send_document (no recompression).
+        force_document = "[[as_document]]" in response
+        pre_extract = response
+        # Pre-extract snapshot for the #29346 recovery/invariant below.
+        media_files, response = self.extract_media(response)
+        media_files = self.filter_media_delivery_paths(media_files, session_key=session_key)
+        images, text_content = self.extract_images(response)
+        # Strip any remaining internal directives from message body (fixes #1561). _strip_media_directives
+        # shares MEDIA_TAG_CLEANUP_RE, so a MEDIA: tag with an unknown extension is intentionally left in
+        # the body for extract_local_files below to pick up rather than silently dropped (#34517).
+        text_content = _strip_media_directives(text_content).strip()
+        if images:
+            logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
+        local_files = []
+        if not is_ephemeral_response:
+            local_files, text_content = self.extract_local_files(text_content)
+            local_files = self.filter_local_delivery_paths(local_files, session_key=session_key)
+            history = (await self._bounded_history_media_paths_for_session(session_key)
+                       if local_files else None)
+            if history:
+                suppressed = [p for p in local_files if p in history]
+                if suppressed:
+                    logger.info("[%s] Suppressing %d bare local file path(s) already delivered in "
+                                "this session: %s", self.name, len(suppressed), suppressed)
+                    local_files = [p for p in local_files if p not in history]
+            if local_files:
+                logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
+        # A2 (#29346): extraction can reduce a non-empty response to empty text with no attachment, and the
+        # `if text_content` guard below then drops it silently. Recover on every platform (#33842 was
+        # Discord-only); the guard avoids duplicating an attachment.
+        if not (text_content or images or local_files or media_files):
+            _recovered = _strip_media_directives(response).strip()
+            if _recovered:
+                logger.warning("[%s] response_delivery_recovered: extract pipeline "
+                               "reduced a non-empty response (%d chars) to empty with "
+                               "no attachment; delivering recovered original to %s", self.name,
+                               len(pre_extract), event.source.chat_id)
+                text_content = _recovered
+        return _ExtractedResponse(
+            text_content=text_content, images=images, media_files=media_files,
+            local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)
+
+
+    async def _process_message_background(self, event, session_key):
+        _record_delivery = self.record_delivery
+        response = await self._message_handler(event)
+        is_ephemeral_response = False
+        _ephemeral_ttl = 0
+        _thread_metadata = {}
+        delivery_attempted = False
+        if not response:
+            pass
+        else:
+            extracted = await self._extract_response_content(
+                response, event, session_key, is_ephemeral_response=is_ephemeral_response)
+            text_content, media_files = extracted.text_content, extracted.media_files
+            _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+            _tts_caption_delivered = False
+            if text_content and not _tts_caption_delivered:
+                await self._send_final_text(
+                    event, session_key, text_content, _final_thread_metadata,
+                    is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+            await self._deliver_attachments(
+                event, extracted, _final_thread_metadata,
+                anything_sent=delivery_attempted or _tts_caption_delivered)

--- a/tests/fixtures/hermes_decomposed/gateway/run.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run.py
@@ -1,0 +1,6 @@
+# Minimal facade: no executable hook anchors live here.
+from gateway.run_turn import GatewayTurnMixin
+from gateway.run_inbound import GatewayInboundMixin
+from gateway.run_busy import GatewayBusyMixin
+from gateway.run_startup import GatewayStartupMixin
+from gateway.run_notifications import GatewayNotificationsMixin

--- a/tests/fixtures/hermes_decomposed/gateway/run_busy.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run_busy.py
@@ -1,0 +1,7 @@
+class GatewayBusyMixin:
+    async def _request_slash_confirm(self, event, command, handler):
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        confirm_id = "fixture-confirm"
+        _slash_confirm_mod.register(session_key, confirm_id, command, handler)
+        return "confirm"

--- a/tests/fixtures/hermes_decomposed/gateway/run_inbound.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run_inbound.py
@@ -1,0 +1,8 @@
+class GatewayInboundMixin:
+    async def _handle_message(self, event):
+        _admitted = await self._hm_admit_event(event)
+        if _admitted is None:
+            return None
+        event, source, is_internal = _admitted
+        _quick_key = self._session_key_for_source(source)
+        return await self._handle_message_with_agent(event, source, _quick_key, 1)

--- a/tests/fixtures/hermes_decomposed/gateway/run_notifications.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run_notifications.py
@@ -1,0 +1,4 @@
+class GatewayNotificationsMixin:
+    async def _deliver_platform_notice(self, source, content):
+        adapter = self._adapter_for_source(source)
+        return await adapter.send(chat_id=source.chat_id, content=content)

--- a/tests/fixtures/hermes_decomposed/gateway/run_startup.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run_startup.py
@@ -1,0 +1,12 @@
+class GatewayStartupMixin:
+    async def _start_finish_wiring(self, connected_count):
+        await self._start_post_connect_services(connected_count)
+        await self._await_startup_boot_sends(planned_restart_notification_pending=False)
+
+    async def _redeliver_claimed_obligations(self, claimed):
+        for row in claimed:
+            adapter = await self._obligation_adapter(row)
+            content = row["content"]
+            metadata = {"thread_id": row["thread_id"]} if row.get("thread_id") else None
+            result = await adapter.send(chat_id=row["chat_id"], content=content, metadata=metadata)
+        return result

--- a/tests/fixtures/hermes_decomposed/gateway/run_turn.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run_turn.py
@@ -1,0 +1,36 @@
+class GatewayTurnMixin:
+    async def _handle_message_with_agent(self, event, source, _quick_key, run_generation):
+        hook_ctx = {}
+        session_entry = None
+        session_key = _quick_key
+        agent_result = await self._run_agent(event, source)
+        _turn_seconds = 1.25
+        agent_messages = []
+        response = agent_result.get("response", "")
+        _footer_line = ""
+        _intentional_silence = False
+        await self._hmwa_post_turn_hooks(hook_ctx, agent_result, response)
+        return await self._hmwa_deliver_turn_response(
+            event, source, session_entry, session_key, run_generation,
+            agent_result, agent_messages, response, _footer_line, _intentional_silence,
+        )
+
+    async def _hmwa_post_turn_hooks(self, hook_ctx, agent_result, response):
+        await self.hooks.emit("agent:end", {**hook_ctx, "response": response})
+
+    async def _hmwa_deliver_turn_response(
+        self, event, source, session_entry, session_key, run_generation,
+        agent_result, agent_messages, response, _footer_line, _intentional_silence,
+    ):
+        if _intentional_silence:
+            response = ""
+        if agent_result.get("already_sent") and not agent_result.get("failed"):
+            await self._deliver_media_from_response(response, event, None)
+            return None
+        return response
+
+    async def _run_agent(self, event, source):
+        return {"response": "answer"}
+
+    def _reply_anchor_for_event(self, event):
+        return event.reply_to_message_id

--- a/tests/fixtures/hermes_decomposed/gateway/run_turn_runner.py
+++ b/tests/fixtures/hermes_decomposed/gateway/run_turn_runner.py
@@ -1,0 +1,41 @@
+class TurnRunner:
+    def __init__(self, runner, ctx):
+        self._runner, self._ctx = runner, ctx
+
+    def _status_callback_sync(self, event_type, message):
+        ctx = self._ctx
+        ctx.status_queue.put((event_type, message))
+
+    def _setup_stream_consumer(self, platform_key):
+        ctx = self._ctx
+        stream_consumer = self._runner.stream_consumer
+        delta_sinks = [stream_consumer]
+
+        def stream_delta_cb(text):
+            if ctx._run_still_current():
+                for sink in delta_sinks:
+                    sink.on_delta(text)
+
+        def interim_assistant_cb(text, *, already_streamed=False):
+            if not ctx._run_still_current():
+                return
+            stream_consumer.on_segment_break() if already_streamed else stream_consumer.on_commentary(text)
+
+        return stream_consumer, stream_delta_cb, interim_assistant_cb, True
+
+    def _wire_turn_agent_callbacks(self, agent, turn_route, reasoning_config,
+                                   stream_delta_cb, interim_assistant_cb, want_interim_messages):
+        ctx = self._ctx
+        agent.tool_progress_callback = ctx.progress_callback
+        agent.tool_start_callback = ctx.native_tool_start_callback
+        agent.tool_complete_callback = ctx.native_tool_complete_callback
+        agent.stream_delta_callback = stream_delta_cb
+        agent.interim_assistant_callback = interim_assistant_cb if want_interim_messages else None
+
+    def _clarify_callback_sync(self, question, choices, multi_select=False):
+        ctx = self._ctx
+        return ctx.wait_for_clarify(question, choices)
+
+    def _approval_notify_sync(self, approval_data):
+        ctx = self._ctx
+        ctx.send_approval(ctx.session_key or "", approval_data)

--- a/tests/unit/test_decomposed_patcher.py
+++ b/tests/unit/test_decomposed_patcher.py
@@ -1,0 +1,427 @@
+"""Executable contracts for the 79445a496c facade layout (fully offline)."""
+import asyncio
+import json
+import logging
+from pathlib import Path
+import shutil
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_feishu_card import cli, hook_runtime
+from hermes_feishu_card.install import decomposed, patcher, recovery
+from hermes_feishu_card.install.detect import detect_hermes
+
+FIXTURE = Path(__file__).parents[1] / "fixtures/hermes_decomposed"
+
+
+@pytest.fixture
+def hermes(tmp_path):
+    root = tmp_path / "hermes"
+    shutil.copytree(FIXTURE, root, ignore=shutil.ignore_patterns("__pycache__"))
+    (root / "VERSION").write_text("0.20.0\n")
+    return root
+
+
+def sources(root):
+    return {name: (root / name).read_bytes() for name in decomposed.SOURCE_TARGETS
+            if (root / name).exists()}
+
+
+def test_decomposed_cli_install_doctor_repeat_remove_roundtrip(hermes, monkeypatch):
+    # Runtime installation and SDK setup belong to deployment. This fixture
+    # has no venv or adapter SDK; all patch/ownership/doctor calls remain real.
+    monkeypatch.setattr(cli, "_ensure_hermes_runtime_package", lambda detection: None)
+    monkeypatch.setattr(cli, "_ensure_hermes_feishu_sdk", lambda detection: None)
+    before = sources(hermes)
+    detection = detect_hermes(hermes)
+    assert detection.supported and detection.compatibility == "full"
+    assert cli.main(["install", "--hermes-dir", str(hermes), "--yes"]) == 0
+    installed = sources(hermes)
+    assert {name for name in before if before[name] != installed[name]} == set(patcher.DECOMPOSED_TARGETS)
+    assert cli.main(["install", "--hermes-dir", str(hermes), "--yes"]) == 0
+    assert installed == sources(hermes)
+    detection = detect_hermes(hermes)
+    assert cli._doctor_hermes_report(detection)["compatibility"] == "full"
+    assert cli._diagnose_install_state(detection)["status"] == "installed"
+    assert detection.capability_locations["answer_delta_callback"] == ("gateway/run_turn_runner.py",)
+    assert detection.capability_locations["completion_return"] == ("gateway/run_turn.py",)
+    assert "status_callback: found (gateway/run_turn_runner.py)" in cli._format_hermes_detection(detection)
+    for name, raw in installed.items():
+        compile(raw, name, "exec")
+    assert cli.main(["uninstall", "--hermes-dir", str(hermes), "--yes"]) == 0
+    assert sources(hermes) == before
+    assert not list(hermes.rglob("*.hermes_feishu_card.bak"))
+    assert not (hermes / decomposed.MANIFEST_NAME).exists()
+    assert recovery.plan_recovery(detect_hermes(hermes)).state == "clean"
+
+
+@pytest.mark.parametrize("target,old,new", [
+    ("gateway/run_turn.py", 'await self.hooks.emit("agent:end",', 'await self.hooks.emit("agent:other",'),
+    ("gateway/run_turn.py", 'agent_result, agent_messages, response, _footer_line, _intentional_silence,\n        )', 'agent_result, agent_messages, "wrong", _footer_line, _intentional_silence,\n        )'),
+    ("gateway/run_turn.py", "async def _hmwa_post_turn_hooks(self, hook_ctx, agent_result, response):", "async def _hmwa_post_turn_hooks(self, hook_ctx, response, agent_result):"),
+    ("gateway/run_turn.py", "agent_result, agent_messages, response, _footer_line, _intentional_silence,\n    ):", "response, agent_messages, agent_result, _footer_line, _intentional_silence,\n    ):"),
+    ("gateway/run_turn_runner.py", "ctx = self._ctx", "ctx = self._other"),
+    ("gateway/run_turn_runner.py", "def stream_delta_cb(text):", "def stream_delta_cb(wrong):"),
+    ("gateway/run_busy.py", "_slash_confirm_mod.register(session_key, confirm_id, command, handler)", "_slash_confirm_mod.register(session_key, confirm_id, command, wrong)"),
+    ("gateway/platforms/base.py", "session_key=session_key)", "session_key=wrong)"),
+    ("gateway/platforms/base.py", "await asyncio.to_thread(mark_attempting, obligation_id)", "asyncio.to_thread(mark_attempting, obligation_id)"),
+    ("gateway/platforms/base.py", "record_delivery(result)", "record_delivery(wrong)"),
+    ("gateway/platforms/base.py", "reply_to=_reply_anchor_for_event(event)", "reply_to=None"),
+    ("gateway/platforms/base.py", "self, event: MessageEvent, session_key: str, text_content: str, metadata:", "self, event: MessageEvent, text_content: str, session_key: str, metadata:"),
+    ("gateway/platforms/base.py", "source = event.source", "source = self.other_source"),
+    ("gateway/platforms/base.py", "_final_thread_metadata = _mark_notify_metadata(_thread_metadata)", "_final_thread_metadata = {}"),
+])
+def test_decomposed_contract_drift_fails_closed(hermes, target, old, new):
+    path = hermes / target
+    content = path.read_text()
+    assert old in content
+    path.write_text(content.replace(old, new))
+    assert not detect_hermes(hermes).supported
+
+
+@pytest.mark.parametrize("target", patcher.DECOMPOSED_TARGETS)
+def test_each_owned_file_is_required_for_restore(hermes, target):
+    detection = detect_hermes(hermes)
+    decomposed.install(detection)
+    path = hermes / target
+    path.write_bytes(path.read_bytes() + b"\n# user edit\n")
+    edited = sources(hermes)
+    assert recovery.plan_recovery(detection).state == "refused"
+    with pytest.raises(ValueError, match="source drift"):
+        decomposed.restore(detection)
+    assert sources(hermes) == edited
+
+
+def test_multifile_transaction_rolls_back_on_late_write_failure(hermes, monkeypatch):
+    before = sources(hermes)
+    replace = recovery._atomic_replace
+    count = 0
+    def fail_once(staged, target):
+        nonlocal count
+        count += 1
+        if count == 5:
+            raise OSError("injected write failure")
+        return replace(staged, target)
+    monkeypatch.setattr(recovery, "_atomic_replace", fail_once)
+    with pytest.raises(OSError, match="injected"):
+        decomposed.install(detect_hermes(hermes))
+    assert sources(hermes) == before
+    assert not list(hermes.rglob("*.hermes_feishu_card.bak"))
+    assert not (hermes / decomposed.MANIFEST_NAME).exists()
+
+
+def test_owned_missing_hooks_repair_and_no_repair(hermes):
+    detection = detect_hermes(hermes)
+    decomposed.install(detection)
+    target = "gateway/run_turn_runner.py"
+    installed = (hermes / target).read_bytes()
+    (hermes / target).write_bytes((hermes / (target + decomposed.BACKUP_SUFFIX)).read_bytes())
+    plan = recovery.plan_recovery(detection)
+    assert plan.state == "owned_incomplete" and plan.executable
+    with pytest.raises(ValueError, match="no-repair"):
+        decomposed.install(detection, no_repair=True)
+    recovery.execute_recovery(detection, expected_fingerprint=plan.fingerprint)
+    assert (hermes / target).read_bytes() == installed
+
+
+def test_manifest_path_escape_and_symlink_refused(hermes, tmp_path):
+    detection = detect_hermes(hermes)
+    decomposed.install(detection)
+    manifest_path = hermes / decomposed.MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text())
+    manifest["targets"]["gateway/run.py"]["backup"] = "../outside"
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="ownership"):
+        decomposed.restore(detection)
+    target = hermes / "gateway/run_busy.py"
+    target.unlink()
+    target.symlink_to(tmp_path / "outside")
+    assert not detect_hermes(hermes).supported
+
+
+def test_optional_status_stays_partial(hermes):
+    path = hermes / "gateway/run_turn_runner.py"
+    path.write_text(path.read_text().replace("def _status_callback_sync(", "def other_status("))
+    detection = detect_hermes(hermes)
+    assert detection.supported and detection.compatibility == "partial"
+    assert not detection.capabilities["status_callback"]
+
+
+def test_decomposed_callbacks_execute_with_real_context_mapping(monkeypatch):
+    source = (FIXTURE / "gateway/run_turn_runner.py").read_text()
+    namespace = {}
+    exec(patcher.apply_gateway_fragment(source, "gateway/run_turn_runner.py"), namespace)
+    emitted, native = [], []
+    def emit(payload, *, event_name):
+        emitted.append((event_name, payload))
+        return True
+    monkeypatch.setattr(hook_runtime, "emit_from_hermes_locals_threadsafe", emit)
+    monkeypatch.setattr(hook_runtime, "request_clarify_response_from_hermes_locals", lambda *a, **kw: "chosen")
+    monkeypatch.setattr(hook_runtime, "request_approval_choice_from_hermes_locals", lambda *a, **kw: "")
+    ctx = SimpleNamespace(source=SimpleNamespace(platform="feishu"), event_message_id="fixture-message",
+                          _loop_for_step=None, _run_still_current=lambda: True,
+                          _status_chat_id="fixture-chat", session_key="fixture-session",
+                          status_queue=SimpleNamespace(put=native.append),
+                          progress_callback=lambda *a, **kw: native.append(a),
+                          native_tool_start_callback=None, native_tool_complete_callback=None,
+                          wait_for_clarify=lambda *a: "native",
+                          send_approval=lambda *a: native.append(a))
+    consumer = SimpleNamespace(on_delta=lambda text: native.append(text),
+                               on_commentary=lambda text: native.append(text), on_segment_break=lambda: None)
+    runner = namespace["TurnRunner"](SimpleNamespace(stream_consumer=consumer), ctx)
+    _, answer, thinking, _ = runner._setup_stream_consumer("feishu")
+    answer("answer")
+    thinking("thinking")
+    runner._status_callback_sync("status", "Compacting context")
+    assert runner._clarify_callback_sync("question", ["a", "b"]) == "chosen"
+    runner._approval_notify_sync({"command": "echo fixture"})
+    agent = SimpleNamespace()
+    runner._wire_turn_agent_callbacks(agent, None, None, answer, thinking, True)
+    agent.tool_start_callback("fixture-call", "read_file", {})
+    agent.tool_complete_callback("fixture-call", "read_file", {}, "ok")
+    assert {name for name, _ in emitted} >= {"answer.delta", "thinking.delta", "tool.updated"}
+    for _, payload in emitted:
+        assert payload["source"] is ctx.source
+        assert payload["message_id"] == ctx.event_message_id
+    assert "answer" not in native and "thinking" not in native
+    assert ("fixture-session", {"command": "echo fixture"}) in native
+
+
+def test_facade_comments_are_not_capability_evidence(hermes):
+    facade = hermes / "gateway/run.py"
+    facade.write_text('# reply_to_message_id _reply_anchor_for_event extract_media _deliver_media_from_response\n')
+    detection = detect_hermes(hermes)
+    assert detection.supported
+    assert "gateway/run.py" not in detection.capability_locations["reply_context"]
+    assert "gateway/run.py" not in detection.capability_locations["attachment_delivery"]
+
+
+def test_cron_routing_uses_definition_not_facade_filename(hermes):
+    scheduler = hermes / "cron/scheduler.py"
+    delivery = hermes / "cron/scheduler_delivery.py"
+    scheduler.write_bytes(delivery.read_bytes())
+    delivery.write_text('from .scheduler import _deliver_result\n')
+    detection = detect_hermes(hermes)
+    assert detection.supported and detection.compatibility == "full"
+    assert detection.capability_locations["cron_delivery"] == ("cron/scheduler.py",)
+    assert detection.cron_py == scheduler
+    before = sources(hermes)
+    decomposed.install(detection)
+    assert patcher.CRON_PATCH_BEGIN in scheduler.read_text()
+    assert delivery.read_bytes() == before["cron/scheduler_delivery.py"]
+    decomposed.restore(detect_hermes(hermes))
+    assert sources(hermes) == before
+    scheduler.write_text("# facade without a delivery definition\n")
+    assert not detect_hermes(hermes).supported
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attachment", [None, "images", "local_files", "media_files", "media_only"])
+@pytest.mark.parametrize("outcome", ["applied", "native", "error"])
+async def test_generated_base_pipeline_preserves_ledger_media_and_fallback(monkeypatch, attachment, outcome):
+    events, posted = [], []
+    async def no_pending(_locals):
+        pass
+    async def policy(*args, **kwargs):
+        return hook_runtime._PolicyGateResult(True, None)
+    async def post(_url, payload, _timeout):
+        events.append("terminal")
+        posted.append(payload)
+        if outcome == "error":
+            raise OSError("offline simulated response loss")
+        return {"ok": True, "applied": outcome == "applied"}
+    async def absent(*args):
+        return {"ok": True, "found": False}
+    monkeypatch.setattr(hook_runtime, "_policy_gate_async", policy)
+    monkeypatch.setattr(hook_runtime, "_flush_pending_deltas_for_local_vars", no_pending)
+    monkeypatch.setattr(hook_runtime, "_post_json_ordered_response", post)
+    monkeypatch.setattr(hook_runtime, "_post_json_response", absent)
+    monkeypatch.setattr(hook_runtime, "_native_handoff_plan_fingerprint", lambda adapter: "f" * 64)
+    monkeypatch.setattr(hook_runtime, "_native_handoff_runtime_wrappers_ready", lambda adapter: True)
+    ledger = SimpleNamespace(
+        ledger_enabled=lambda: True,
+        compute_obligation_id=lambda *args: "fixture-obligation",
+        record_obligation=lambda **kwargs: events.append(("ledger", kwargs["content"])),
+        mark_attempting=lambda obligation: events.append("attempting"),
+        mark_delivered=lambda obligation: events.append("delivered"),
+        mark_failed=lambda *args: events.append("failed"),
+    )
+    monkeypatch.setitem(sys.modules, "gateway.delivery_ledger", ledger)
+    namespace = {"asyncio": asyncio, "logger": logging.getLogger(__name__),
+                 "_ExtractedResponse": SimpleNamespace,
+                 "_strip_media_directives": lambda text: text,
+                 "_mark_notify_metadata": lambda metadata: {**metadata, "notify": True},
+                 "_reply_anchor_for_event": lambda event: event.message_id}
+    original = (FIXTURE / "gateway/platforms/base.py").read_text()
+    exec(patcher.apply_base_patch(original), namespace)
+    adapter = namespace["BasePlatformAdapter"]()
+    adapter.name, adapter.typed_command_prefix = "feishu", "!"
+    media = [("/tmp/fixture-video.mp4", False)] if attachment in {"media_files", "media_only"} else []
+    images = [("https://example.invalid/fixture.png", "fixture")] if attachment == "images" else []
+    local = ["/tmp/fixture-document.pdf"] if attachment == "local_files" else []
+    text = "" if attachment == "media_only" else "exact text"
+    adapter.extract_media = lambda response: (media, text)
+    adapter.filter_media_delivery_paths = lambda paths, **kwargs: paths
+    adapter.extract_images = lambda response: (images, response)
+    adapter.extract_local_files = lambda response: (local, response)
+    adapter.filter_local_delivery_paths = lambda paths, **kwargs: paths
+    adapter._bounded_history_media_paths_for_session = no_pending
+    adapter._final_delivery_adapter = lambda source: adapter
+    adapter.record_delivery = lambda result: events.append(("record_delivery", result.success))
+    async def native_send(**kwargs):
+        events.append(("native", kwargs))
+        return SimpleNamespace(success=True, message_id="fixture-native")
+    async def attachments(event, extracted, metadata, **kwargs):
+        events.append(("attachments", extracted.images, extracted.local_files, extracted.media_files))
+    async def handler(event):
+        assert await hook_runtime.stage_message_completed_from_hermes_locals_async({
+            "platform": "feishu", "chat_id": "fixture-chat", "conversation_id": "fixture-session",
+            "message_id": "fixture-message", "answer": "raw answer", "created_at": 1777017600.0,
+        })
+        return "raw answer"
+    adapter._send_with_retry = native_send
+    adapter._deliver_attachments = attachments
+    adapter._message_handler = handler
+    event = SimpleNamespace(text="question", message_id="fixture-message",
+                            source=SimpleNamespace(platform="feishu", chat_id="fixture-chat"))
+    await adapter._process_message_background(event, "fixture-session")
+    assert len(posted) == 1
+    assert events[-1] == ("attachments", images, local, media)
+    assert hook_runtime._HFC_EXACT_COMPLETION_STAGE.get() is None
+    data = posted[0]["data"]
+    if attachment is not None:
+        assert data["native_delivery"] == "required"
+        assert "capabilities" not in data.get("native_handoff", {})
+        assert data["attachments"]
+    else:
+        assert "native-ack-v2" in data["native_handoff"]["capabilities"]
+    sends = [row for row in events if isinstance(row, tuple) and row[0] == "native"]
+    if text:
+        assert events[:3] == [("ledger", text), "attempting", "terminal"]
+        assert events[-3:-1] == [("record_delivery", True), "delivered"]
+        assert data["answer"] == text
+        assert len(sends) == (0 if outcome == "applied" else 1)
+        if sends:
+            assert sends[0][1] == {"chat_id": "fixture-chat", "content": text,
+                                   "reply_to": "fixture-message", "metadata": {"notify": True}}
+    else:
+        assert events == ["terminal", ("attachments", images, local, media)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("accepted", [True, False])
+async def test_generated_turn_completion_keeps_timing_and_native_fallback(monkeypatch, accepted):
+    events = []
+    async def post_turn(*args):
+        events.append("agent:end")
+    async def completed(payload, *, event_name):
+        events.append((event_name, payload["answer"], payload["duration"]))
+        return accepted
+    monkeypatch.setattr(hook_runtime, "emit_from_hermes_locals", lambda *args, **kwargs: False)
+    monkeypatch.setattr(hook_runtime, "can_stage_exact_base_completion", lambda payload: False)
+    monkeypatch.setattr(hook_runtime, "build_event", lambda *args, **kwargs: {"data": {}})
+    monkeypatch.setattr(hook_runtime, "emit_from_hermes_locals_async", completed)
+    namespace = {}
+    source = (FIXTURE / "gateway/run_turn.py").read_text()
+    exec(patcher.apply_gateway_fragment(source, "gateway/run_turn.py"), namespace)
+    runner = namespace["GatewayTurnMixin"]()
+    runner.hooks = SimpleNamespace(emit=post_turn)
+    source = SimpleNamespace(platform="feishu")
+    event = SimpleNamespace(source=source, message_id="fixture-message", reply_to_message_id="fixture-parent")
+    result = await runner._handle_message_with_agent(event, source, "fixture-session", 1)
+    assert result == (None if accepted else "answer")
+    assert events == ["agent:end", ("message.completed", "answer", 1.25)]
+
+
+@pytest.mark.parametrize("newline", [b"\r\n", b"\n"])
+def test_byte_exact_reinstall_after_uninstall(hermes, newline):
+    for name, raw in sources(hermes).items():
+        (hermes / name).write_bytes(raw.rstrip(b"\n").replace(b"\n", newline))
+    before = sources(hermes)
+    for _ in range(2):
+        detection = detect_hermes(hermes)
+        assert detection.supported
+        assert decomposed.install(detection)
+        installed = sources(hermes)
+        assert not decomposed.install(detect_hermes(hermes))
+        assert sources(hermes) == installed
+        decomposed.restore(detect_hermes(hermes))
+        assert sources(hermes) == before
+
+
+def test_upgrade_requires_explicit_acceptance_and_binds_all_evidence(hermes):
+    detection = detect_hermes(hermes)
+    decomposed.install(detection)
+    target = "gateway/run_turn_runner.py"
+    original = (hermes / (target + decomposed.BACKUP_SUFFIX)).read_bytes()
+    (hermes / target).write_bytes(original + b"\n# simulated source upgrade\n")
+    detection = detect_hermes(hermes)
+    plan = recovery.plan_recovery(detection)
+    assert plan.state == "stale_unpatched" and not plan.executable
+    with pytest.raises(ValueError, match="accept-hermes-upgrade"):
+        decomposed.install(detection)
+    approved = recovery.plan_recovery(detection, accept_hermes_upgrade=True)
+    assert approved.executable
+    # Even an otherwise unpatched facade participates in the fingerprint.
+    facade = hermes / "gateway/run.py"
+    facade.write_bytes(facade.read_bytes() + b"\n# concurrent edit\n")
+    with pytest.raises(ValueError, match="evidence changed"):
+        recovery.execute_recovery(detection, expected_fingerprint=approved.fingerprint,
+                                  accept_hermes_upgrade=True)
+    fresh = recovery.plan_recovery(detect_hermes(hermes), accept_hermes_upgrade=True)
+    recovery.execute_recovery(detect_hermes(hermes), expected_fingerprint=fresh.fingerprint,
+                              accept_hermes_upgrade=True)
+    assert recovery.plan_recovery(detect_hermes(hermes)).state == "installed"
+    decomposed.restore(detect_hermes(hermes))
+    assert (hermes / target).read_bytes() == original + b"\n# simulated source upgrade\n"
+    assert facade.read_bytes().endswith(b"# concurrent edit\n")
+
+
+@pytest.mark.parametrize("damage", ["missing_backup", "orphan_backup", "marker_body", "missing_source"])
+def test_incomplete_ownership_never_overwrites_sources(hermes, damage):
+    detection = detect_hermes(hermes)
+    decomposed.install(detection)
+    target = hermes / "gateway/run_turn_runner.py"
+    if damage == "missing_backup":
+        target.with_name(target.name + decomposed.BACKUP_SUFFIX).unlink()
+    elif damage == "orphan_backup":
+        (hermes / decomposed.MANIFEST_NAME).unlink()
+    elif damage == "marker_body":
+        target.write_text(target.read_text().replace("_hfc_turn_ctx = ctx", "_hfc_turn_ctx = None"))
+    else:
+        target.unlink()
+    before = sources(hermes)
+    assert recovery.plan_recovery(detection).state == "refused"
+    with pytest.raises(ValueError):
+        decomposed.install(detection)
+    with pytest.raises(ValueError):
+        decomposed.restore(detection)
+    assert sources(hermes) == before
+
+
+@pytest.mark.asyncio
+async def test_missing_base_context_falls_back_and_clears_terminal_stage():
+    token = hook_runtime._HFC_EXACT_COMPLETION_STAGE.set({"payload": {}, "task_id": id(asyncio.current_task())})
+    adapter = object()
+    try:
+        result = await hook_runtime.prepare_decomposed_base_final_delivery({
+            "delivery_adapter": adapter, "content": "native answer", "reply_to": "fixture-parent", "metadata": {},
+        })
+        assert result == (adapter, "native answer", "fixture-parent", {})
+        assert hook_runtime._HFC_EXACT_COMPLETION_STAGE.get() is None
+    finally:
+        hook_runtime._HFC_EXACT_COMPLETION_STAGE.reset(token)
+
+
+def test_install_rechecks_version_gate_and_recovery_binds_version(hermes):
+    detection = detect_hermes(hermes)
+    before = sources(hermes)
+    old_plan = recovery.plan_recovery(detection)
+    (hermes / "VERSION").write_text("0.1.0\n")
+    assert recovery.plan_recovery(detection).fingerprint != old_plan.fingerprint
+    with pytest.raises(ValueError, match="unsupported"):
+        decomposed.install(detection)
+    assert sources(hermes) == before
+    assert not (hermes / decomposed.MANIFEST_NAME).exists()


### PR DESCRIPTION
## 背景 / Background

Hermes (commit `79445a496c`, 2026-09-04) 将 gateway 按 topic 拆分为 facade + siblings：`_handle_message_with_agent` 及其管线锚点从 `gateway/run.py` 迁移到 8 个文件（`run_turn.py` / `run_turn_runner.py` / `run_inbound.py` / `run_busy.py` / `run_startup.py` / `run_notifications.py` / `cron/scheduler_delivery.py` / `platforms/base.py`），部分回调改名。当前 installer 硬编码扫描 `gateway/run.py`，导致 doctor 报 `missing async anchor function: _handle_message_with_agent`、install 拒绝，飞书退化为纯文本（无流式卡片）。

Hermes 官方 2026-09-14 将移除 compat 指针层（`COMPAT_MANIFEST.md` / `compat_manifest.json`），本适配不依赖任何 compat 层，直接按新布局注入。

## 改动 / Changes

- **`install/detect.py`**：capability 检测按锚点实际所在文件搜索（8 文件布局），doctor 输出每个 capability 的精确位置
- **`install/patcher.py` + 新增 `install/decomposed.py`**：多文件 ownership（V4 manifest）——patch groups 按锚点路由到各自文件；跨文件幂等 install；uninstall 从全部受管文件逐字还原
- **`install/recovery.py` / `manifest.py` / `cli.py`**：recovery 绑定新 manifest；`--accept-hermes-upgrade` 语义保持
- **`hook_runtime.py` / `diagnostics.py`**：decomposed base final-delivery 上下文适配（exact-base delivery 缺失时 fail-open 降级并清理 terminal stage）
- **测试**：新增 `tests/unit/test_decomposed_patcher.py`（56 个契约测试：8 文件注入、事务回滚、CRLF 逐字还原、漂移拒绝、幂等）+ `tests/fixtures/hermes_decomposed/` 模拟布局

## 验证 / Verification

- focused：`test_patcher` + `test_decomposed_patcher` 全绿（唯一失败为预存的 fixed-tag 源码目录缺失测试）
- 全量：**3325 passed / 61 failed / 5 skipped**，61 个失败 ID 与基线（v4.3.7 `ac45e40`）逐一相同——**零新增失败**，新增 56 个测试全部通过
- 真实 CLI 往返（无 mock）：临时 8 文件布局上 install → doctor=`full` → uninstall 逐字还原 → 重复 install 幂等
- 已部署验证：Hermes `79445a496c` 上 `hook.status: installed`，sidecar `healthy` / `delivery: live`，真实飞书 smoke card 投递成功

## 说明 / Notes

- 本 PR 只含拆分适配（v4.4.0 基座），不含任何本地 fork 私有改动（如超长按钮超时）
- 基准为上游 main（v4.4.0, `ea2cb11`），cherry-pick 自本地 fork 的 v4.3.7 适配提交，零冲突
- 兼容窗口：不依赖 Hermes compat 指针，2026-09-14 compat 移除后仍可用

Co-authored-by: Codex <codex@openai.com>