### PR TITLE
fix(install): support Hermes 0.21.1 split delivery ledger

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -314,8 +314,15 @@ def apply_base_patch(
     no_text_renderer = (_render_decomposed_base_no_text_hook_block
                         if _has_decomposed_base(tree) else _render_exact_base_no_text_hook_block)
     no_text_hook = no_text_renderer(no_text_indent, newline)
-    final_renderer = (_render_decomposed_base_final_hook_block
-                      if _has_decomposed_base(tree) else _render_exact_base_final_delivery_hook_block)
+    final_renderer = (
+        _render_decomposed_split_base_final_hook_block
+        if _has_split_exact_base(tree) and _has_decomposed_base(tree)
+        else _render_split_base_final_delivery_hook_block
+        if _has_split_exact_base(tree)
+        else _render_decomposed_base_final_hook_block
+        if _has_decomposed_base(tree)
+        else _render_exact_base_final_delivery_hook_block
+    )
     final_hook = final_renderer(final_indent, newline)
 
     # Insert bottom-up so the earlier location is not shifted by the later
@@ -1981,6 +1988,10 @@ def _parse_exact_base_content(content: str):
 
 def _find_exact_base_patch_locations(tree, lines):
     """Return the two insertion locations after validating Hermes' pipeline."""
+    if _has_split_exact_base(tree):
+        if _has_decomposed_base(tree):
+            return _find_split_decomposed_base_patch_locations(tree, lines)
+        return _find_split_exact_base_patch_locations(tree, lines)
     if _has_decomposed_base(tree):
         return _find_decomposed_base_patch_locations(tree, lines)
     method = _find_exact_base_process_method(tree)
@@ -2201,6 +2212,232 @@ def _find_exact_base_patch_locations(tree, lines):
     return (
         (no_text_index, _line_indent(lines, no_text_index)),
         (send_index, _line_indent(lines, send_index)),
+    )
+
+
+def _find_split_exact_base_patch_locations(tree, lines):
+    """Support Hermes' extracted ``send_final_ledgered`` delivery helper.
+
+    Hermes' carried 0.21.1 integration moves the ledger bracket out of
+    ``_process_message_background`` without changing its semantics.  Keep the
+    same strict extraction checks for the no-text seam, then validate the new
+    helper's record → send → finalize order before placing the final hook.
+    """
+    classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BasePlatformAdapter"
+    ]
+    if len(classes) != 1:
+        raise ValueError("could not find safe BasePlatformAdapter contract")
+    process_methods = [
+        node
+        for node in classes[0].body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "_process_message_background"
+    ]
+    ledger_methods = [
+        node
+        for node in classes[0].body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "send_final_ledgered"
+    ]
+    if len(process_methods) != 1 or len(ledger_methods) != 1:
+        raise ValueError("could not find safe BasePlatformAdapter contract")
+    process = process_methods[0]
+    ledger = ledger_methods[0]
+    process_nodes = list(ast.walk(process))
+    ordered = [
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_exact_assignment_call(
+                node,
+                targets=("media_files", "response"),
+                owner="self",
+                function="extract_media",
+                args=("response",),
+            ),
+        ),
+        _unique_exact_base_node(process_nodes, _is_exact_media_filter_assignment),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_exact_assignment_call(
+                node,
+                targets=("images", "text_content"),
+                owner="self",
+                function="extract_images",
+                args=("response",),
+            ),
+        ),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_strip_assignment(
+                node, target="text_content", source="text_content"
+            ),
+        ),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_exact_assignment_call(
+                node,
+                targets=("local_files", "text_content"),
+                owner="self",
+                function="extract_local_files",
+                args=("text_content",),
+            ),
+        ),
+        _unique_exact_base_node(process_nodes, _is_exact_local_filter_assignment),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_strip_assignment(
+                node, target="_recovered", source="response"
+            ),
+        ),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_exact_name_assignment(
+                node, target="text_content", value="_recovered"
+            ),
+        ),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_exact_assignment_call(
+                node,
+                targets=("_final_thread_metadata",),
+                owner=None,
+                function="_mark_notify_metadata",
+                args=("_thread_metadata",),
+            ),
+        ),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: _is_exact_constant_assignment(
+                node, target="_tts_caption_delivered", value=False
+            ),
+        ),
+        _unique_exact_base_node(
+            process_nodes,
+            lambda node: isinstance(node, ast.If)
+            and _same_expression(
+                node.test, "text_content and not _tts_caption_delivered"
+            ),
+        ),
+    ]
+    line_numbers = [node.lineno for node in ordered]
+    if line_numbers != sorted(line_numbers) or len(set(line_numbers)) != len(line_numbers):
+        raise ValueError("could not find safe BasePlatformAdapter contract")
+
+    ledger_args = ledger.args
+    positional = tuple(
+        arg.arg for arg in (*ledger_args.posonlyargs, *ledger_args.args)
+    )
+    keyword_only = tuple(arg.arg for arg in ledger_args.kwonlyargs)
+    if positional != ("self", "event", "session_key", "text_content", "metadata"):
+        raise ValueError("could not find safe BasePlatformAdapter contract")
+    if keyword_only != ("reply_to", "is_ephemeral_response"):
+        raise ValueError("could not find safe BasePlatformAdapter contract")
+    ledger_nodes = list(ast.walk(ledger))
+    record = _unique_exact_base_node(
+        ledger_nodes,
+        lambda node: _is_split_record_obligation_call(node),
+    )
+    send = _unique_exact_base_node(ledger_nodes, _is_split_final_send_assignment)
+    finalize = _unique_exact_base_node(
+        ledger_nodes,
+        lambda node: _is_split_finalize_obligation_call(node),
+    )
+    if not (record.lineno < send.lineno < finalize.lineno):
+        raise ValueError("could not find safe BasePlatformAdapter contract")
+    return (
+        (ordered[-1].lineno - 1, _line_indent(lines, ordered[-1].lineno - 1)),
+        (send.lineno - 1, _line_indent(lines, send.lineno - 1)),
+    )
+
+
+def _is_split_record_obligation_call(node) -> bool:
+    if not isinstance(node, ast.Assign):
+        return False
+    if _assignment_target_names(node) != ("obligation_id",):
+        return False
+    value = _assignment_value(node)
+    if not isinstance(value, ast.Await) or not isinstance(value.value, ast.Call):
+        return False
+    call = value.value
+    owner, function = _call_function(call)
+    return (
+        owner == "self"
+        and function == "_record_delivery_obligation"
+        and not call.keywords
+        and len(call.args) == 5
+        and all(
+            _same_expression(actual, expected)
+            for actual, expected in zip(
+                call.args,
+                (
+                    "event",
+                    "session_key",
+                    "text_content",
+                    "delivery_adapter",
+                    "is_ephemeral_response",
+                ),
+            )
+        )
+    )
+
+
+def _has_split_exact_base(tree) -> bool:
+    classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BasePlatformAdapter"
+    ]
+    return len(classes) == 1 and sum(
+        isinstance(node, ast.AsyncFunctionDef) and node.name == "send_final_ledgered"
+        for node in classes[0].body
+    ) == 1
+
+
+def _is_split_final_send_assignment(node) -> bool:
+    if _assignment_target_names(node) != ("result",):
+        return False
+    value = _assignment_value(node)
+    if not isinstance(value, ast.Await) or not isinstance(value.value, ast.Call):
+        return False
+    call = value.value
+    if not (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "_send_with_retry"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "delivery_adapter"
+        and not call.args
+    ):
+        return False
+    expected = {
+        "chat_id": "event.source.chat_id",
+        "content": "text_content",
+        "reply_to": "reply_to",
+        "metadata": "metadata",
+    }
+    keywords = {keyword.arg: keyword.value for keyword in call.keywords if keyword.arg}
+    return set(keywords) == set(expected) and all(
+        _same_expression(keywords[name], expression)
+        for name, expression in expected.items()
+    )
+
+
+def _is_split_finalize_obligation_call(node) -> bool:
+    if not isinstance(node, ast.Await) or not isinstance(node.value, ast.Call):
+        return False
+    call = node.value
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "_finalize_delivery_obligation"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "self"
+        and len(call.args) == 4
+        and _same_expression(call.args[0], "obligation_id")
+        and _same_expression(call.args[1], "result")
+        and _same_expression(call.args[2], "event")
+        and _same_expression(call.args[3], "delivery_adapter")
     )
 
 
@@ -2666,7 +2903,9 @@ def _find_owned_exact_base_blocks(content: str, *, strict: bool):
             raise ValueError("corrupt exact base patch markers")
         if lines[final[0] : final[1] + 1] not in (
             _render_exact_base_final_delivery_hook_block(final_indent, final_newline),
+            _render_split_base_final_delivery_hook_block(final_indent, final_newline),
             _render_decomposed_base_final_hook_block(final_indent, final_newline),
+            _render_decomposed_split_base_final_hook_block(final_indent, final_newline),
         ):
             raise ValueError("corrupt exact base patch markers")
     return no_text, final
@@ -2783,6 +3022,34 @@ def _render_exact_base_final_delivery_hook_block(indent: str, newline: str):
         f"{inner_indent}    \"obligation_id\": _obligation_id,{newline}",
         f"{inner_indent}    \"reply_to\": _reply_anchor,{newline}",
         f"{inner_indent}    \"metadata\": _final_thread_metadata,{newline}",
+        f"{inner_indent}}}){newline}",
+        *_render_hook_exception_handler(indent, newline),
+        f"{indent}{EXACT_BASE_FINAL_DELIVERY_PATCH_END}{newline}",
+    ]
+
+
+def _render_split_base_final_delivery_hook_block(indent: str, newline: str):
+    """Render the final hook at Hermes' extracted ledger helper seam."""
+    inner_indent = _child_indent(indent)
+    return [
+        f"{indent}{EXACT_BASE_FINAL_DELIVERY_PATCH_BEGIN}{newline}",
+        f"{indent}try:{newline}",
+        (
+            f"{inner_indent}from hermes_feishu_card.hook_runtime "
+            f"import prepare_exact_base_final_delivery as "
+            f"_hfc_prepare_exact_base_final_delivery{newline}"
+        ),
+        (
+            f"{inner_indent}delivery_adapter, text_content, reply_to, metadata "
+            f"= await _hfc_prepare_exact_base_final_delivery({{{newline}"
+        ),
+        f"{inner_indent}    **locals(),{newline}",
+        f"{inner_indent}    \"source\": event.source,{newline}",
+        f"{inner_indent}    \"delivery_adapter\": delivery_adapter,{newline}",
+        f"{inner_indent}    \"content\": text_content,{newline}",
+        f"{inner_indent}    \"obligation_id\": obligation_id,{newline}",
+        f"{inner_indent}    \"reply_to\": reply_to,{newline}",
+        f"{inner_indent}    \"metadata\": metadata,{newline}",
         f"{inner_indent}}}){newline}",
         *_render_hook_exception_handler(indent, newline),
         f"{indent}{EXACT_BASE_FINAL_DELIVERY_PATCH_END}{newline}",
@@ -4173,12 +4440,229 @@ def _find_decomposed_base_patch_locations(tree, lines):
             (final_send.lineno - 1, _line_indent(lines, final_send.lineno - 1)))
 
 
+def _find_split_decomposed_base_patch_locations(tree, lines):
+    """Verify decomposed Hermes after its ledger helper was extracted."""
+    error = "could not find safe BasePlatformAdapter contract"
+    process = _find_exact_base_process_method(tree)
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BasePlatformAdapter"
+    )
+
+    def method(name):
+        matches = [
+            node
+            for node in cls.body
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == name
+        ]
+        if len(matches) != 1:
+            raise ValueError(error)
+        return matches[0]
+
+    extract, send, ledger, record, finish = (
+        method(name)
+        for name in (
+            "_extract_response_content",
+            "_send_final_text",
+            "send_final_ledgered",
+            "_record_delivery_obligation",
+            "_finalize_delivery_obligation",
+        )
+    )
+    signatures = (
+        (process, ("self", "event", "session_key"), ()),
+        (
+            extract,
+            ("self", "response", "event", "session_key"),
+            ("is_ephemeral_response",),
+        ),
+        (
+            send,
+            ("self", "event", "session_key", "text_content", "metadata",
+             "is_ephemeral_response", "ephemeral_ttl", "record_delivery"),
+            (),
+        ),
+        (
+            ledger,
+            ("self", "event", "session_key", "text_content", "metadata"),
+            ("reply_to", "is_ephemeral_response"),
+        ),
+        (
+            record,
+            ("self", "event", "session_key", "text_content", "delivery_adapter",
+             "is_ephemeral_response"),
+            (),
+        ),
+        (
+            finish,
+            ("self", "obligation_id", "result", "event", "delivery_adapter"),
+            (),
+        ),
+    )
+    for node, positional, keyword_only in signatures:
+        args = node.args
+        if (
+            tuple(arg.arg for arg in (*args.posonlyargs, *args.args)) != positional
+            or tuple(arg.arg for arg in args.kwonlyargs) != keyword_only
+            or args.vararg is not None
+            or args.kwarg is not None
+        ):
+            raise ValueError(error)
+
+    def exact(scope, source):
+        expected = ast.parse(source).body[0]
+        return _unique_exact_base_node(
+            ast.walk(scope), lambda node: ast.dump(node) == ast.dump(expected)
+        )
+
+    def ordered(nodes):
+        if any(a.lineno >= b.lineno for a, b in zip(nodes, nodes[1:])):
+            raise ValueError(error)
+
+    extracted = exact(
+        process,
+        "extracted = await self._extract_response_content(response, event, session_key, is_ephemeral_response=is_ephemeral_response)",
+    )
+    assigned = exact(
+        process,
+        "text_content, media_files = extracted.text_content, extracted.media_files",
+    )
+    metadata = exact(
+        process,
+        "_final_thread_metadata = _mark_notify_metadata(_thread_metadata)",
+    )
+    tts_default = exact(process, "_tts_caption_delivered = False")
+    guard = _unique_exact_base_node(
+        ast.walk(process),
+        lambda node: isinstance(node, ast.If)
+        and _same_expression(node.test, "text_content and not _tts_caption_delivered"),
+    )
+    delegated = exact(
+        guard,
+        "await self._send_final_text(event, session_key, text_content, _final_thread_metadata, is_ephemeral_response, _ephemeral_ttl, _record_delivery)",
+    )
+    if guard.body != [delegated]:
+        raise ValueError(error)
+    attachments = exact(
+        process,
+        "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)",
+    )
+    ordered([extracted, assigned, metadata, tts_default, guard, attachments])
+    branches = [
+        node
+        for node in ast.walk(process)
+        if isinstance(node, ast.If)
+        and all(
+            part in node.orelse
+            for part in (extracted, assigned, metadata, tts_default, guard, attachments)
+        )
+    ]
+    if len(branches) != 1 or not _same_expression(branches[0].test, "not response"):
+        raise ValueError(error)
+
+    em = exact(extract, "media_files, response = self.extract_media(response)")
+    fm = _unique_exact_base_node(ast.walk(extract), _is_exact_media_filter_assignment)
+    ei = exact(extract, "images, text_content = self.extract_images(response)")
+    strip = exact(extract, "text_content = _strip_media_directives(text_content).strip()")
+    el = exact(extract, "local_files, text_content = self.extract_local_files(text_content)")
+    fl = _unique_exact_base_node(ast.walk(extract), _is_exact_local_filter_assignment)
+    recovered = exact(extract, "_recovered = _strip_media_directives(response).strip()")
+    restored = exact(extract, "text_content = _recovered")
+    result = exact(
+        extract,
+        "return _ExtractedResponse(text_content=text_content, images=images, media_files=media_files, local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)",
+    )
+    ordered([em, fm, ei, strip, el, fl, recovered, restored, result])
+
+    delegated_call = exact(
+        send,
+        "result, delivery_adapter = await self.send_final_ledgered(event, session_key, text_content, metadata, reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)",
+    )
+    delivered = exact(send, "record_delivery(result)")
+    if delegated_call.lineno >= delivered.lineno:
+        raise ValueError(error)
+    record_source = exact(record, "source = event.source")
+    ledger_id = exact(
+        record, "_ledger_id = getattr(event, \"ledger_message_id\", None)"
+    )
+    ledger_fallback = exact(
+        record,
+        "if _ledger_id is None:\n    _ledger_id = getattr(event, \"message_id\", \"\")",
+    )
+    computed = _unique_exact_base_node(
+        ast.walk(record),
+        lambda node: _is_split_compute_obligation_assignment(node),
+    )
+    recorded = exact(
+        record,
+        "await asyncio.to_thread(record_obligation, obligation_id=obligation_id, session_key=session_key, platform=str(getattr(source.platform, \"value\", source.platform)), chat_id=source.chat_id, thread_id=getattr(source, \"thread_id\", None), content=text_content, adapter_profile=getattr(delivery_adapter, \"_owner_profile\", None))",
+    )
+    attempting = exact(record, "await asyncio.to_thread(mark_attempting, obligation_id)")
+    returned = exact(record, "return obligation_id")
+    ordered([record_source, ledger_id, ledger_fallback, computed, recorded, attempting, returned])
+    tries = [
+        node
+        for node in record.body
+        if isinstance(node, ast.Try)
+        and all(x in node.body for x in (record_source, ledger_id, ledger_fallback,
+                                          computed, recorded, attempting, returned))
+    ]
+    if len(tries) != 1:
+        raise ValueError(error)
+
+    ledger_nodes = list(ast.walk(method("send_final_ledgered")))
+    ledger_record = _unique_exact_base_node(ledger_nodes, _is_split_record_obligation_call)
+    final_send = _unique_exact_base_node(ledger_nodes, _is_split_final_send_assignment)
+    finalized = _unique_exact_base_node(ledger_nodes, _is_split_finalize_obligation_call)
+    ledger_return = exact(
+        method("send_final_ledgered"), "return result, delivery_adapter"
+    )
+    ordered([ledger_record, final_send, finalized, ledger_return])
+    return (
+        (guard.lineno - 1, _line_indent(lines, guard.lineno - 1)),
+        (final_send.lineno - 1, _line_indent(lines, final_send.lineno - 1)),
+    )
+
+
+def _is_split_compute_obligation_assignment(node) -> bool:
+    if _assignment_target_names(node) != ("obligation_id",):
+        return False
+    call = _assignment_value(node)
+    if not isinstance(call, ast.Call):
+        return False
+    owner, function = _call_function(call)
+    return (
+        owner is None
+        and function == "compute_obligation_id"
+        and not call.keywords
+        and len(call.args) == 3
+        and _same_expression(call.args[0], "session_key")
+        and (
+            _same_expression(call.args[1], "str(_ledger_id or \"\")")
+            or _same_expression(call.args[1], "_ledger_id")
+        )
+        and _same_expression(call.args[2], "text_content")
+    )
+
+
 def _render_decomposed_base_final_hook_block(indent, newline):
     block = _render_exact_base_final_delivery_hook_block(indent, newline)
     block = [line.replace("prepare_exact_base_final_delivery as", "prepare_decomposed_base_final_delivery as")
              .replace("_final_thread_metadata", "metadata") for line in block]
     block.insert(2, f'{_child_indent(indent)}_reply_anchor = _reply_anchor_for_event(event){newline}')
     return block
+
+
+def _render_decomposed_split_base_final_hook_block(indent, newline):
+    """Render the split ledger hook while preserving decomposed context."""
+    return [
+        line.replace(
+            "prepare_exact_base_final_delivery as",
+            "prepare_decomposed_base_final_delivery as",
+        )
+        for line in _render_split_base_final_delivery_hook_block(indent, newline)
+    ]
 
 
 def _render_decomposed_base_no_text_hook_block(indent, newline):

--- a/tests/fixtures/hermes_split_ledger_base.py
+++ b/tests/fixtures/hermes_split_ledger_base.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+class BasePlatformAdapter:
+
+    async def _record_delivery_obligation(
+
+            self, event: MessageEvent, session_key: str, text_content: str,
+
+            delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool) -> Optional[str]:
+
+            """Ledger the final response BEFORE the send so a crash before platform ACK redelivers on
+
+            next boot; best-effort, skips slash-command and ephemeral replies. Returns the obligation id
+
+            or None."""
+
+            if is_ephemeral_response or str(event.text or "").lstrip().startswith(
+
+                ("/", self.typed_command_prefix or "!")):
+
+                return None
+
+            try:
+
+                from gateway.delivery_ledger import (
+
+                    compute_obligation_id, ledger_enabled, mark_attempting, record_obligation)
+
+                if not await asyncio.to_thread(ledger_enabled):
+
+                    return None
+
+                source = event.source
+
+                # ``ledger_message_id`` wins when set: a queued chain's final answers the last message
+
+                # of the chain, not the event that opened it (see ``MessageEvent.ledger_message_id``).
+
+                _ledger_id = getattr(event, "ledger_message_id", None)
+
+                if _ledger_id is None:
+
+                    _ledger_id = getattr(event, "message_id", "")
+
+                obligation_id = compute_obligation_id(
+
+                    session_key, str(_ledger_id or ""), text_content)
+
+                await asyncio.to_thread(
+
+                    record_obligation, obligation_id=obligation_id, session_key=session_key,
+
+                    platform=str(getattr(source.platform, "value", source.platform)),
+
+                    chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
+
+                    content=text_content,
+
+                    adapter_profile=getattr(delivery_adapter, "_owner_profile", None))
+
+                await asyncio.to_thread(mark_attempting, obligation_id)
+
+                return obligation_id
+
+            except Exception:
+
+                logger.debug("delivery ledger record failed", exc_info=True)
+
+                return None
+
+    async def _finalize_delivery_obligation(
+
+            self, obligation_id: str, result: Any, event: MessageEvent,
+
+            delivery_adapter: "BasePlatformAdapter") -> None:
+
+            """Mark the ledger row delivered/failed (best-effort). On ``send_path_degraded`` with a
+
+            replacement adapter live, trigger another redelivery sweep (the watcher's may have run
+
+            before this failure landed; atomic claiming keeps it idempotent). On a flood-control refusal
+
+            arm the runner's timed redelivery, so the reply goes out once the penalty has passed instead
+
+            of waiting for the next restart."""
+
+            try:
+
+                from gateway.delivery_ledger import is_flood_error, mark_delivered, mark_failed
+
+                if getattr(result, "success", False):
+
+                    await asyncio.to_thread(mark_delivered, obligation_id)
+
+                    return
+
+                error = str(getattr(result, "error", "") or "")
+
+                await asyncio.to_thread(mark_failed, obligation_id, error)
+
+                if error == "send_path_degraded":
+
+                    redeliver = getattr(
+
+                        self.gateway_runner, "_redeliver_failed_obligations_for_platform", None)
+
+                    live = self._final_delivery_adapter(event.source)
+
+                    if live is not delivery_adapter and callable(redeliver):
+
+                        await redeliver(event.source.platform,
+
+                                        profile=getattr(delivery_adapter, "_owner_profile", None))
+
+                elif is_flood_error(error):
+
+                    schedule = getattr(self.gateway_runner, "_schedule_flood_redelivery", None)
+
+                    if callable(schedule):
+
+                        schedule(event.source.platform,
+
+                                 profile=getattr(delivery_adapter, "_owner_profile", None))
+
+            except Exception:
+
+                logger.debug("delivery ledger update failed", exc_info=True)
+
+    async def send_final_ledgered(
+
+            self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
+
+            reply_to: Optional[str], is_ephemeral_response: bool = False,
+
+        ) -> "tuple[SendResult, BasePlatformAdapter]":
+
+            """The delivery-ledger bracket every final text goes through, on the CURRENT transport
+
+            (a reconnect may have replaced this adapter): record the obligation before the send,
+
+            send with retry, finalize from the result — so a refused final (flood control, a dead
+
+            transport) leaves a ledger row the boot sweep / runtime redelivery can act on. ``event``
+
+            supplies the source and the ledger identity (``ledger_message_id`` or ``message_id``).
+
+            Returns the result with the adapter that sent it: that adapter owns ``result.message_id``
+
+            (an ephemeral delete must go to the same transport)."""
+
+            delivery_adapter = self._final_delivery_adapter(event.source)
+
+            logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
+
+                        len(text_content), event.source.chat_id)
+
+            obligation_id = await self._record_delivery_obligation(
+
+                event, session_key, text_content, delivery_adapter, is_ephemeral_response)
+
+            result = await delivery_adapter._send_with_retry(
+
+                chat_id=event.source.chat_id, content=text_content, reply_to=reply_to, metadata=metadata)
+
+            if obligation_id is not None:
+
+                await self._finalize_delivery_obligation(obligation_id, result, event, delivery_adapter)
+
+            return result, delivery_adapter
+
+    async def _send_final_text(
+
+            self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
+
+            is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
+
+            """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete."""
+
+            result, delivery_adapter = await self.send_final_ledgered(
+
+                event, session_key, text_content, metadata,
+
+                reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)
+
+            record_delivery(result)
+
+            if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
+
+                delivery_adapter._schedule_ephemeral_delete(event.source.chat_id, result.message_id, ephemeral_ttl)
+
+    async def _extract_response_content(self, response: str, event: MessageEvent, session_key: str,
+
+                                            *, is_ephemeral_response: bool) -> "_ExtractedResponse":
+
+            """Split a handler response into deliverable text + attachments. Order matters: MEDIA tags →
+
+            image URLs → residual directives → bare local paths (skipped for ephemeral notices so config
+
+            paths stay text; unknown-extension MEDIA tags survive for the bare-path detector). History
+
+            dedup is bare-path only, off-loop, fail-open. An emptied non-empty response is recovered."""
+
+            # Captured before extract_media strips it: images then go via send_document (no recompression).
+
+            force_document = "[[as_document]]" in response
+
+            pre_extract = response
+
+            # Pre-extract snapshot for the #29346 recovery/invariant below.
+
+            media_files, response = self.extract_media(response)
+
+            media_files = self.filter_media_delivery_paths(media_files, session_key=session_key)
+
+            images, text_content = self.extract_images(response)
+
+            # Strip any remaining internal directives from message body (fixes #1561). _strip_media_directives
+
+            # shares MEDIA_TAG_CLEANUP_RE, so a MEDIA: tag with an unknown extension is intentionally left in
+
+            # the body for extract_local_files below to pick up rather than silently dropped (#34517).
+
+            text_content = _strip_media_directives(text_content).strip()
+
+            if images:
+
+                logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
+
+            local_files = []
+
+            if not is_ephemeral_response:
+
+                local_files, text_content = self.extract_local_files(text_content)
+
+                local_files = self.filter_local_delivery_paths(local_files, session_key=session_key)
+
+                history = (await self._bounded_history_media_paths_for_session(session_key)
+
+                           if local_files else None)
+
+                if history:
+
+                    suppressed = [p for p in local_files if p in history]
+
+                    if suppressed:
+
+                        logger.info("[%s] Suppressing %d bare local file path(s) already delivered in "
+
+                                    "this session: %s", self.name, len(suppressed), suppressed)
+
+                        local_files = [p for p in local_files if p not in history]
+
+                if local_files:
+
+                    logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
+
+            # A2 (#29346): extraction can reduce a non-empty response to empty text with no attachment, and the
+
+            # `if text_content` guard below then drops it silently. Recover on every platform (#33842 was
+
+            # Discord-only); the guard avoids duplicating an attachment.
+
+            if not (text_content or images or local_files or media_files):
+
+                _recovered = _strip_media_directives(response).strip()
+
+                if _recovered:
+
+                    logger.warning("[%s] response_delivery_recovered: extract pipeline "
+
+                                   "reduced a non-empty response (%d chars) to empty with "
+
+                                   "no attachment; delivering recovered original to %s", self.name,
+
+                                   len(pre_extract), event.source.chat_id)
+
+                    text_content = _recovered
+
+            return _ExtractedResponse(
+
+                text_content=text_content, images=images, media_files=media_files,
+
+                local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)
+
+    async def _process_message_background(self, event, session_key):
+
+            _record_delivery = self.record_delivery
+
+            response = await self._message_handler(event)
+
+            is_ephemeral_response = False
+
+            _ephemeral_ttl = 0
+
+            _thread_metadata = {}
+
+            delivery_attempted = False
+
+            if not response:
+
+                pass
+
+            else:
+
+                extracted = await self._extract_response_content(
+
+                    response, event, session_key, is_ephemeral_response=is_ephemeral_response)
+
+                text_content, media_files = extracted.text_content, extracted.media_files
+
+                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+
+                _tts_caption_delivered = False
+
+                if text_content and not _tts_caption_delivered:
+
+                    await self._send_final_text(
+
+                        event, session_key, text_content, _final_thread_metadata,
+
+                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+
+                await self._deliver_attachments(
+
+                    event, extracted, _final_thread_metadata,
+
+                    anything_sent=delivery_attempted or _tts_caption_delivered)

--- a/tests/unit/test_split_ledger_patcher.py
+++ b/tests/unit/test_split_ledger_patcher.py
@@ -1,0 +1,30 @@
+"""Hermes 0.21.1 split-ledger patcher contracts."""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_feishu_card.install import patcher
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures/hermes_split_ledger_base.py"
+
+
+def test_split_ledger_install_is_idempotent_and_reversible() -> None:
+    original = FIXTURE.read_text(encoding="utf-8")
+    installed = patcher.apply_base_patch(original)
+    assert "send_final_ledgered" in installed
+    assert patcher.apply_base_patch(installed) == installed
+    assert patcher.EXACT_BASE_FINAL_DELIVERY_PATCH_BEGIN in installed
+    compile(installed, str(FIXTURE), "exec")
+    assert patcher.remove_base_patch(installed) == original
+
+
+def test_split_ledger_contract_rejects_the_old_inline_ledger_shape() -> None:
+    original = FIXTURE.read_text(encoding="utf-8")
+    broken = original.replace(
+        "async def send_final_ledgered(",
+        "async def send_final_ledgered_broken(",
+    )
+    with pytest.raises(ValueError, match="safe BasePlatformAdapter contract"):
+        patcher.apply_base_patch(broken)


### PR DESCRIPTION
## Summary

HFC 4.4.4 fail-closes on Hermes 0.21.1 because the delivery ledger bracket moved from `_send_final_text` into `send_final_ledgered`, and the ledger identity now uses `ledger_message_id` when present. This PR adds a strict patcher path for that layout.

## Changes

- Detect and validate the extracted `send_final_ledgered` seam and its exact signature.
- Validate the `record → send → finalize` ledger order across the extracted helper and `_send_final_text`.
- Accept Hermes 0.21.1 `_ledger_id` identity indirection while retaining the old 0.21.0/legacy paths.
- Render the HFC final-delivery hook inside `send_final_ledgered`, using the in-scope `obligation_id`.
- Add an offline fixture covering install, repeat install, compile, remove round-trip, and fail-closed drift.

## Non-goals

- No Hermes source changes.
- No Feishu business behavior changes.
- No changes to the legacy or existing decomposed patcher paths.

## Validation

- `uv run --extra test pytest tests/unit/test_split_ledger_patcher.py -q`: 2 passed.
- `uv run --extra test pytest tests/unit/test_split_ledger_patcher.py tests/unit/test_patcher.py -q -k "not fixed_tag_real_sources"`: 164 passed, 1 deselected.
- Real clean Hermes 0.21.1 source checkout: install, repeat install, doctor installed, uninstall round-trip passed.
- Full local suite: 3501 passed, 34 failed, 9 skipped; the failures are pre-existing environment-coupled tests (missing `/private/tmp/hermes-agent-v2026.8.3-v430-audit` fixture, detached process expectation, and a symlink error-message expectation). The new split-ledger tests pass.

Closes #281