### PR TITLE
fix(install): accept Hermes 0.21.1 _deliver_attachments with record_delivery= kwarg

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -4300,7 +4300,7 @@ def _find_decomposed_base_patch_locations(tree, lines):
     delegated = exact(guard, 'await self._send_final_text(event, session_key, text_content, _final_thread_metadata, is_ephemeral_response, _ephemeral_ttl, _record_delivery)')
     if guard.body != [delegated]:
         raise ValueError(error)
-    attachments = exact(process, 'await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)')
+    attachments = _exact_deliver_attachments(process, exact)
     ordered([extracted, assigned, metadata, tts_default, guard, attachments])
     # All three stages must be siblings in the response branch.
     branches = [n for n in ast.walk(process) if isinstance(n, ast.If)
@@ -4338,6 +4338,25 @@ def _find_decomposed_base_patch_locations(tree, lines):
     exact(finish, 'await asyncio.to_thread(mark_failed, obligation_id, error)')
     return ((guard.lineno - 1, _line_indent(lines, guard.lineno - 1)),
             (final_send.lineno - 1, _line_indent(lines, final_send.lineno - 1)))
+
+
+_DELIVER_ATTACHMENTS_PATTERNS = (
+    # Hermes 0.21.1+: _deliver_attachments gained record_delivery= kwarg
+    "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered, record_delivery=_record_delivery)",
+    # Hermes <= 0.21.0: no record_delivery kwarg
+    "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)",
+)
+
+
+def _exact_deliver_attachments(process, exact):
+    """Match the _deliver_attachments call site, accepting both pre- and
+    post-0.21.1 signatures (with/without ``record_delivery=`` kwarg)."""
+    for pattern in _DELIVER_ATTACHMENTS_PATTERNS:
+        try:
+            return exact(process, pattern)
+        except ValueError:
+            continue
+    raise ValueError("could not find safe BasePlatformAdapter contract")
 
 
 def _find_split_decomposed_base_patch_locations(tree, lines):
@@ -4445,9 +4464,9 @@ def _find_split_decomposed_base_patch_locations(tree, lines):
     )
     if guard.body != [delegated]:
         raise ValueError(error)
-    attachments = exact(
+    attachments = _exact_deliver_attachments(
         process,
-        "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)",
+        exact,
     )
     ordered([extracted, assigned, metadata, tts_default, guard, attachments])
     branches = [


### PR DESCRIPTION
**Problem**

Hermes 0.21.1 commit \`78de23053f\` added a \`record_delivery=_record_delivery\` keyword argument to the \`_deliver_attachments\` call in \`gateway/platforms/base.py\`. The HFC installer uses byte-exact AST statement matching for this call site and fails with:

\`\`\`
ValueError: gateway/platforms/base.py exact delivery anchors are unsupported
\`\`\`

This blocks installation on Hermes 0.21.1 (reported in #288).

**Fix**

Introduce \`_exact_deliver_attachments()\` helper that tries the new signature first and falls back to the old one. Both \`_find_decomposed_base_patch_locations\` and \`_find_split_decomposed_base_patch_locations\` are updated.

**Verification**

- Tested on Hermes 0.21.1 (git \`67764dc086\`) — \`hermes-feishu-card install\` succeeds and all decomposed gateway hooks are written.
- Backward-compatible: Hermes ≤ 0.21.0 still matches the old signature.

Fixes #288