### PR TITLE
fix(install): accept record_delivery on the exact base delivery anchor

### DIFF
--- a/hermes_feishu_card/install/patcher.py
+++ b/hermes_feishu_card/install/patcher.py
@@ -4289,6 +4289,21 @@ def _find_decomposed_base_patch_locations(tree, lines):
     def exact(scope, source):
         expected = ast.parse(source).body[0]
         return _unique_exact_base_node(ast.walk(scope), lambda n: ast.dump(n) == ast.dump(expected))
+    def exact_any(scope, sources):
+        """Accept any known-good spelling of one anchored statement.
+
+        Hermes may add orthogonal keyword arguments to a call we anchor on — e.g.
+        ``record_delivery=_record_delivery`` on ``_deliver_attachments``. A drift like
+        that is compatible, so accept either spelling instead of failing the install.
+        """
+        for source in sources:
+            expected = ast.parse(source).body[0]
+            matches = [n for n in ast.walk(scope) if ast.dump(n) == ast.dump(expected)]
+            if len(matches) == 1:
+                return matches[0]
+        raise ValueError(error)
+
+
     def ordered(nodes):
         if any(a.lineno >= b.lineno for a, b in zip(nodes, nodes[1:])):
             raise ValueError(error)
@@ -4300,7 +4315,10 @@ def _find_decomposed_base_patch_locations(tree, lines):
     delegated = exact(guard, 'await self._send_final_text(event, session_key, text_content, _final_thread_metadata, is_ephemeral_response, _ephemeral_ttl, _record_delivery)')
     if guard.body != [delegated]:
         raise ValueError(error)
-    attachments = exact(process, 'await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)')
+    attachments = exact_any(process, (
+        'await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)',
+        'await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered, record_delivery=_record_delivery)',
+    ))
     ordered([extracted, assigned, metadata, tts_default, guard, attachments])
     # All three stages must be siblings in the response branch.
     branches = [n for n in ast.walk(process) if isinstance(n, ast.If)
@@ -4417,6 +4435,22 @@ def _find_split_decomposed_base_patch_locations(tree, lines):
             ast.walk(scope), lambda node: ast.dump(node) == ast.dump(expected)
         )
 
+    def exact_any(scope, sources):
+        """Accept any known-good spelling of one anchored statement.
+
+        Hermes may add orthogonal keyword arguments to a call we anchor on — e.g.
+        ``record_delivery=_record_delivery`` on ``_deliver_attachments``. A drift like
+        that is compatible, so accept either spelling instead of failing the install.
+        """
+        for source in sources:
+            expected = ast.parse(source).body[0]
+            matches = [n for n in ast.walk(scope) if ast.dump(n) == ast.dump(expected)]
+            if len(matches) == 1:
+                return matches[0]
+        raise ValueError(error)
+
+
+
     def ordered(nodes):
         if any(a.lineno >= b.lineno for a, b in zip(nodes, nodes[1:])):
             raise ValueError(error)
@@ -4445,9 +4479,12 @@ def _find_split_decomposed_base_patch_locations(tree, lines):
     )
     if guard.body != [delegated]:
         raise ValueError(error)
-    attachments = exact(
+    attachments = exact_any(
         process,
-        "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)",
+        (
+            "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)",
+            "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered, record_delivery=_record_delivery)",
+        ),
     )
     ordered([extracted, assigned, metadata, tts_default, guard, attachments])
     branches = [

--- a/tests/unit/test_decomposed_patcher.py
+++ b/tests/unit/test_decomposed_patcher.py
@@ -82,6 +82,29 @@ def test_decomposed_contract_drift_fails_closed(hermes, target, old, new):
     assert not detect_hermes(hermes).supported
 
 
+def test_decomposed_accepts_record_delivery_kwarg_end_to_end(hermes):
+    """A build that passes ``record_delivery=...`` to ``_deliver_attachments`` stays installable.
+
+    Hermes adds that keyword to the exact final-delivery pipeline; it is orthogonal
+    to the delivery contract, so detection must stay supported and the patched tree
+    must round-trip byte-exact.
+    """
+    path = hermes / "gateway/platforms/base.py"
+    old = "anything_sent=delivery_attempted or _tts_caption_delivered)"
+    new = ("anything_sent=delivery_attempted or _tts_caption_delivered, "
+           "record_delivery=_record_delivery)")
+    content = path.read_text()
+    assert content.count(old) == 1
+    path.write_text(content.replace(old, new))
+    detection = detect_hermes(hermes)
+    assert detection.supported, detection.reason
+    before = sources(hermes)
+    decomposed.install(detection)
+    assert sources(hermes) != before
+    decomposed.restore(detect_hermes(hermes))
+    assert sources(hermes) == before
+
+
 @pytest.mark.parametrize("target", patcher.DECOMPOSED_TARGETS)
 def test_each_owned_file_is_required_for_restore(hermes, target):
     detection = detect_hermes(hermes)

--- a/tests/unit/test_split_ledger_patcher.py
+++ b/tests/unit/test_split_ledger_patcher.py
@@ -30,6 +30,41 @@ def test_split_ledger_contract_rejects_the_old_inline_ledger_shape() -> None:
         patcher.apply_base_patch(broken)
 
 
+ATTACHMENT_KWARG_TAIL = "anything_sent=delivery_attempted or _tts_caption_delivered)"
+ATTACHMENT_KWARG_TAIL_EXTENDED = (
+    "anything_sent=delivery_attempted or _tts_caption_delivered, "
+    "record_delivery=_record_delivery)"
+)
+
+
+def test_split_ledger_accepts_record_delivery_kwarg_on_attachment_anchor() -> None:
+    """Hermes passes ``record_delivery=...`` to ``_deliver_attachments``.
+
+    That keyword is orthogonal to the exact-delivery contract, so the anchor must
+    still bind and stay reversible instead of failing the whole install.
+    """
+    original = FIXTURE.read_text(encoding="utf-8")
+    assert original.count(ATTACHMENT_KWARG_TAIL) == 1
+    extended = original.replace(ATTACHMENT_KWARG_TAIL, ATTACHMENT_KWARG_TAIL_EXTENDED)
+    installed = patcher.apply_base_patch(extended)
+    assert patcher.apply_base_patch(installed) == installed
+    assert patcher.EXACT_BASE_FINAL_DELIVERY_PATCH_BEGIN in installed
+    compile(installed, str(FIXTURE), "exec")
+    assert patcher.remove_base_patch(installed) == extended
+
+
+def test_split_ledger_still_rejects_unknown_attachment_kwarg() -> None:
+    """Only known spellings are tolerated; a renamed keyword is still drift."""
+    original = FIXTURE.read_text(encoding="utf-8")
+    assert ATTACHMENT_KWARG_TAIL in original
+    drifted = original.replace(
+        ATTACHMENT_KWARG_TAIL,
+        ATTACHMENT_KWARG_TAIL.replace("anything_sent=", "anything_sent_renamed="),
+    )
+    with pytest.raises(ValueError, match="safe BasePlatformAdapter contract"):
+        patcher.apply_base_patch(drifted)
+
+
 @pytest.mark.parametrize(('before', 'after'), [
     ('metadata=metadata)', 'metadata=metadata, **extra)'),
     ('obligation_id, result, event, delivery_adapter)', 'obligation_id, result, event, delivery_adapter, extra=True)'),

--- a/tools/relax_base_anchor.py
+++ b/tools/relax_base_anchor.py
@@ -1,0 +1,93 @@
+"""给 HFC 的 patcher 加锚点容忍：允许 Hermes 给 _deliver_attachments 增加正交关键字参数。
+
+改两处 _find_*_decomposed_base_patch_locations 里的 attachments 锚点比对，
+让它们接受“有无 record_delivery=...”两种形态。幂等：已打过就跳过。
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+PATH = pathlib.Path("hermes_feishu_card/install/patcher.py")
+
+HELPER = '''    def exact_any(scope, sources):
+        """Accept any known-good spelling of one anchored statement.
+
+        Hermes may add orthogonal keyword arguments to a call we anchor on — e.g.
+        ``record_delivery=_record_delivery`` on ``_deliver_attachments``. A drift like
+        that is compatible, so accept either spelling instead of failing the install.
+        """
+        for source in sources:
+            expected = ast.parse(source).body[0]
+            matches = [n for n in ast.walk(scope) if ast.dump(n) == ast.dump(expected)]
+            if len(matches) == 1:
+                return matches[0]
+        raise ValueError(error)
+
+
+'''
+
+# 每个函数里 `def exact(...)` 的原文（两处格式不同，各自唯一）
+EXACT_A = """    def exact(scope, source):
+        expected = ast.parse(source).body[0]
+        return _unique_exact_base_node(ast.walk(scope), lambda n: ast.dump(n) == ast.dump(expected))
+"""
+
+EXACT_B = """    def exact(scope, source):
+        expected = ast.parse(source).body[0]
+        return _unique_exact_base_node(
+            ast.walk(scope), lambda node: ast.dump(node) == ast.dump(expected)
+        )
+"""
+
+OLD_ATTACH = "await self._deliver_attachments(event, extracted, _final_thread_metadata, anything_sent=delivery_attempted or _tts_caption_delivered)"
+NEW_ATTACH = OLD_ATTACH[:-1] + ", record_delivery=_record_delivery)"
+
+CALL_A_OLD = f"""    attachments = exact(process, '{OLD_ATTACH}')
+"""
+CALL_A_NEW = f"""    attachments = exact_any(process, (
+        '{OLD_ATTACH}',
+        '{NEW_ATTACH}',
+    ))
+"""
+
+CALL_B_OLD = f"""    attachments = exact(
+        process,
+        "{OLD_ATTACH}",
+    )
+"""
+CALL_B_NEW = f"""    attachments = exact_any(
+        process,
+        (
+            "{OLD_ATTACH}",
+            "{NEW_ATTACH}",
+        ),
+    )
+"""
+
+
+def apply(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n == 0 and text.count(new) > 0:
+        print(f"  [skip] {label}: 已打过")
+        return text
+    if n != 1:
+        sys.exit(f"  [FAIL] {label}: 找到 {n} 处（期望 1）")
+    print(f"  [ok]   {label}")
+    return text.replace(old, new, 1)
+
+
+def main() -> None:
+    text = PATH.read_text(encoding="utf-8")
+    print("打补丁：")
+    text = apply(text, EXACT_A, EXACT_A + HELPER, "函数A 插入 exact_any")
+    text = apply(text, EXACT_B, EXACT_B + "\n" + HELPER, "函数B 插入 exact_any")
+    text = apply(text, CALL_A_OLD, CALL_A_NEW, "函数A attachments 锚点放宽")
+    text = apply(text, CALL_B_OLD, CALL_B_NEW, "函数B attachments 锚点放宽")
+    PATH.write_text(text, encoding="utf-8")
+    print("已写入", PATH)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 问题

在 Hermes 0.21.1 上 `doctor` 判定 `unsupported`，`install` / `setup` 直接拒绝执行（release 版与当前 main 均复现）：

```
- Hermes: unsupported (0.21.1, compatibility full)
- Exact delivery contract: missing_or_unsupported
- reason: gateway/platforms/base.py exact delivery anchors are unsupported
- anchors: 19 项中 18 项 found，仅 exact_base_delivery 为 false
```

根因是 `BasePlatformAdapter._process_message_background` 里这条语句的形态变了：

```python
# patcher 期望
await self._deliver_attachments(event, extracted, _final_thread_metadata,
                                anything_sent=delivery_attempted or _tts_caption_delivered)

# Hermes 0.21.1 实际（gateway/platforms/base.py）
self._deliver_attachments(
    event, extracted, _final_thread_metadata,
    anything_sent=delivery_attempted or _tts_caption_delivered,
    record_delivery=_record_delivery)
```

多了一个 `record_delivery=_record_delivery`。同一交付管线里的 `_send_final_text(...)` 签名检查**已经**包含
`record_delivery`（见 `signatures` 元组），所以这是对同一改造的适配不完整，不是新概念。

## 改动

- 在两个 decomposed base locator（`_find_decomposed_base_patch_locations` /
  `_find_split_decomposed_base_patch_locations`）中加入 `exact_any(scope, sources)`：
  一条语句的多个已知形态都可接受，仍要求**唯一**命中；都不命中时照旧 `raise ValueError(error)`，
  fail-closed 语义不变。
- `_deliver_attachments` 锚点同时接受带 / 不带 `record_delivery` 两种写法。

## 测试

- `test_split_ledger_accepts_record_delivery_kwarg_on_attachment_anchor`：
  新形态可 patch、幂等、可编译、`remove_base_patch` 逐字节回到原文
- `test_split_ledger_still_rejects_unknown_attachment_kwarg`：
  把关键字改名（非已知形态）仍然拒绝 —— 契约漂移依旧 fail-closed
- `test_decomposed_accepts_record_delivery_kwarg_end_to_end`：
  `detect_hermes` 判定 supported，install / restore 字节级还原
- 两个 fixture 变体都从现有 fixture 文本推导，不引入快照式断言

本地：`pytest tests/unit/test_split_ledger_patcher.py tests/unit/test_decomposed_patcher.py -q` → **88 passed**

## 真机验证

本机 Hermes 0.21.1（HEAD `3868ee9a`）：`setup` 安装成功，**19/19 锚点 found**，sidecar `/health`
`readiness: ready`、`runtime_seen: true`，发卡与卡片更新成功，`fail / reject / refused / unknown /
mismatch / timeout` 计数全为 0。

未验证的部分（如实说明）：我没有跑完整的真实飞书验收矩阵（`docs/wiki/feishu-acceptance.md`），
只在本机单实例上确认了卡片链路可用。
